### PR TITLE
wownero: only 3 confirmations required

### DIFF
--- a/basicswap/interface/wow.py
+++ b/basicswap/interface/wow.py
@@ -25,3 +25,7 @@ class WOWInterface(XMRInterface):
     @staticmethod
     def exp() -> int:
         return 11
+
+    @staticmethod
+    def depth_spendable() -> int:
+        return 3


### PR DESCRIPTION
quickfix:
Wownero has a 5 minute block time and only requires 3 confirmations (15min) to unlock the funds. Currently is using 10 confirmations (50min)