### PR TITLE
firo: v0.14.14.0 hardfork 2024-09-16 (mandatory)

### DIFF
--- a/bin/basicswap_prepare.py
+++ b/bin/basicswap_prepare.py
@@ -65,7 +65,7 @@ PIVX_VERSION_TAG = os.getenv('PIVX_VERSION_TAG', '')
 DASH_VERSION = os.getenv('DASH_VERSION', '20.0.2')
 DASH_VERSION_TAG = os.getenv('DASH_VERSION_TAG', '')
 
-FIRO_VERSION = os.getenv('FIRO_VERSION', '0.14.13.3')
+FIRO_VERSION = os.getenv('FIRO_VERSION', '0.14.14.0')
 FIRO_VERSION_TAG = os.getenv('FIRO_VERSION_TAG', '')
 
 NAV_VERSION = os.getenv('NAV_VERSION', '7.0.3')


### PR DESCRIPTION
Firo has an upcoming hardfork on or around 2024-09-16. Updating is mandatory