### PR TITLE
docs: update install docs

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -21,12 +21,10 @@ test_task:
     - XMR_BINDIR: ${BIN_DIR}/monero
   setup_script:
     - apt-get update
-    - apt-get install -y wget python3-pip gnupg unzip automake libtool pkg-config
-    - pip install tox pytest
+    - apt-get install -y git python3-pip gnupg automake libtool pkg-config
+    - pip install tox pytest wheel
     - python3 setup.py install
-    - wget -O coincurve-basicswap.zip https://github.com/basicswap/coincurve/archive/refs/tags/basicswap_v0.2.zip
-    - unzip -d coincurve-basicswap coincurve-basicswap.zip
-    - mv ./coincurve-basicswap/*/{.,}* ./coincurve-basicswap || true
+    - git clone https://github.com/basicswap/coincurve.git -b basicswap_v0.2 coincurve-basicswap
     - cd coincurve-basicswap
     - pip install .
   bins_cache:

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,13 +5,10 @@ ENV LANG=C.UTF-8 \
     DATADIRS="/coindata"
 
 RUN apt-get update; \
-    apt-get install -y wget python3-pip gnupg unzip make g++ autoconf automake libtool pkg-config gosu tzdata;
+    apt-get install -y git python3-pip gnupg make g++ autoconf automake libtool pkg-config gosu tzdata;
 
 ARG COINCURVE_VERSION=v0.2
-RUN wget -O coincurve-basicswap.zip https://github.com/basicswap/coincurve/archive/refs/tags/basicswap_$COINCURVE_VERSION.zip && \
-    echo "c309deef22c929c9ab5b3adf7adbda940bffcea6c6ec7c66202d6c3d4e3ceb79 coincurve-basicswap.zip" | sha256sum -c && \
-    unzip coincurve-basicswap.zip && \
-    mv ./coincurve-basicswap_$COINCURVE_VERSION ./coincurve-basicswap && \
+RUN git clone https://github.com/basicswap/coincurve.git -b basicswap_$COINCURVE_VERSION coincurve-basicswap && \
     cd coincurve-basicswap && \
     pip install .
 

--- a/doc/install.md
+++ b/doc/install.md
@@ -54,7 +54,7 @@ Depending on your environment, the `docker-compose` command may not work. If tha
 
 Set xmrrestoreheight to the current xmr chain height.
 
-    CURRENT_XMR_HEIGHT=$(curl https://localmonero.co/blocks/api/get_stats | jq .height)
+    CURRENT_XMR_HEIGHT=$(curl -s http://node2.monerodevs.org:18089/get_info | jq .height)
 
 Adjust `--withcoins` and `--withoutcoins` as desired, eg: `--withcoins=monero,bitcoin`.  By default only Particl is loaded.
 
@@ -140,7 +140,7 @@ Continue from the [Run Using Docker](#run-using-docker) section.
 
 ### Ubuntu Setup:
 
-    apt-get install -y wget git python3-venv python3-pip gnupg unzip automake libtool pkg-config curl jq
+    apt-get install -y git python3-venv python3-pip gnupg automake libtool pkg-config curl jq
 
 ### OSX Setup:
 
@@ -150,21 +150,18 @@ Install Homebrew (See https://brew.sh/):
 
 Dependencies:
 
-    brew install wget unzip python git protobuf gnupg automake libtool pkg-config curl jq
+    brew install python git protobuf gnupg automake libtool pkg-config curl jq
 
 Close the terminal and open a new one to update the python symlinks.
 
 
 ### Basicswap:
 
-    export SWAP_DATADIR=/Users/$USER/coinswaps
-    mkdir -p "$SWAP_DATADIR/venv"
+    export SWAP_DATADIR=$HOME/coinswaps
     python3 -m venv "$SWAP_DATADIR/venv"
     . $SWAP_DATADIR/venv/bin/activate && python -V
     cd $SWAP_DATADIR
-    wget -O coincurve-basicswap.zip https://github.com/tecnovert/coincurve/archive/refs/tags/basicswap_v0.2.zip
-    unzip -d coincurve-basicswap coincurve-basicswap.zip
-    mv ./coincurve-basicswap/*/{.,}* ./coincurve-basicswap || true
+    git clone https://github.com/basicswap/coincurve.git -b basicswap_v0.2 coincurve-basicswap
     cd $SWAP_DATADIR/coincurve-basicswap
     pip3 install .
 
@@ -182,12 +179,13 @@ From https://pypi.org/project/certifi/
 
 Continue installing Basicswap
 
+    pip3 install wheel
     pip3 install .
 
 
 Prepare the datadir:
 
-    CURRENT_XMR_HEIGHT=$(curl https://localmonero.co/blocks/api/get_stats | jq .height)
+    CURRENT_XMR_HEIGHT=$(curl -s http://node2.monerodevs.org:18089/get_info | jq .height)
 
     basicswap-prepare --datadir=$SWAP_DATADIR --withcoins=monero --xmrrestoreheight=$CURRENT_XMR_HEIGHT
 

--- a/doc/notes.md
+++ b/doc/notes.md
@@ -11,33 +11,28 @@ In chainclients.monero:
 - connection_type - rpc
 - manage_daemon - false
 - manage_wallet_daemon - true
-- rpchost - ip of remote monero node (192.168.1.9)
-- rpcport - rpcport that monero is listening on remote node (18081)
+- rpchost - ip of remote monero node (example: 192.168.1.9)
+- rpcport - rpcport that monero is listening on remote node (18089)
 - rpcuser - test_user
 - rpcpassword - test_pwd
 
 
 Edit monerod.conf on the remote node:
 
-    data-dir=PATH_TO_MONERO_DATADIR
-    restricted-rpc=1
     rpc-login=test_user:test_pwd
-    rpc-bind-port=18081
-    rpc-bind-ip=192.168.1.9
-    prune-blockchain=1
+    rpc-restricted-bind-port=18089
+    rpc-restricted-bind-ip=0.0.0.0
 
-Start the remote monerod binary with `--confirm-external-bind`
-
-Remember to open port 18081 in the remote machine's firewall if necessary.
+Remember to open port 18089 in the remote machine's firewall if necessary.
 
 You can debug the connection using curl (from the local node)
 
-    curl http://192.168.1.9:18081/json_rpc -u test_user:test_pwd --digest -d '{"jsonrpc":"2.0","id":"0","method":"get_info"}' -H 'Content-Type: application/json'
+    curl http://node.ip.addr.here:18089/json_rpc -u test_user:test_pwd --digest -d '{"jsonrpc":"2.0","id":"0","method":"get_info"}' -H 'Content-Type: application/json'
 
 
 ## Monero remote private node with ssh tunneling
 
-Example connecting to a private remote monero node running at 192.168.1.9
+Example connecting to a private remote monero node over ssh:
 
 Set the following in basicswap.json:
 
@@ -46,13 +41,20 @@ In chainclients.monero:
 - manage_daemon - false
 - manage_wallet_daemon - true
 - rpchost - localhost
-- rpcport - rpcport that monero is listening on remote node (18081)
+- rpcport - rpcport that monero is listening on remote node (18089)
 
-On the remote machine open an ssh tunnel to port 18081:
+Edit monerod.conf on the remote node:
 
-    ssh -N -R 18081:localhost:18081 user@LOCAL_NODE_IP
+    rpc-restricted-bind-port=18089
 
-And start monerod
+On the remote machine open an ssh tunnel to BSX:
+
+    ssh -N -R 18089:localhost:18089 user@LOCAL_BSX_IP
+
+Or, on the BSX host machine create a tunnel to the node:
+
+    ssh -N -L 18089:localhost:18089 user@REMOTE_NODE_IP
+
 
 
 ## SSH Tunnel to Remote BasicSwap Node
@@ -92,8 +94,8 @@ Create and activate a venv
 
 Install coincurve
 
-    git clone https://github.com/basicswap/coincurve.git -b basicswap
-    cd coincurve/
+    git clone https://github.com/basicswap/coincurve.git -b basicswap_v0.2 coincurve-basicswap
+    cd coincurve-basicswap
     pip3 install .
 
 
@@ -101,6 +103,7 @@ Install basicswap
 
     git clone https://github.com/basicswap/basicswap.git
     cd basicswap
+    pip3 install wheel
     pip3 install .
 
 


### PR DESCRIPTION
- docs: git clone the basicswap_v0.2 tag
- dependencies: remove wget and unzip
- dependencies: install wheel before sqalchemy to get rid of errors
- install: edit node used for monero height
- notes: update monero example
- notes: use `coincurve-basicswap` folder instead of `coincurve` for windows

closes #116 