### PR TITLE
script: Add min_amount offer setting.

### DIFF
--- a/scripts/createoffers.py
+++ b/scripts/createoffers.py
@@ -16,7 +16,7 @@ Create offers
     "wallet_port_override": Used for testing.
     "offers": [
         {
-            "name": Offer tenplate name, eg "Offer 0", will be automatically renamed if not unique.
+            "name": Offer template name, eg "Offer 0", will be automatically renamed if not unique.
             "coin_from": Coin you send.
             "coin_to": Coin you receive.
             "amount": Amount to create the offer for.

--- a/scripts/createoffers.py
+++ b/scripts/createoffers.py
@@ -31,7 +31,7 @@ Create offers
             "enabled": Set to false to ignore offer template.
             "swap_type": Type of swap, defaults to "adaptor_sig"
             "min_swap_amount": Sets "amt_bid_min" on the offer, minimum valid bid when offer amount is variable.
-            "min_amount": If set offers will be created for amounts between "min_coin_from_amt" and "amount" in increments of "min_amount".
+            "amount_step": If set offers will be created for amount values between "amount" and "min_coin_from_amt" in decrements of "amount_step".
         },
         ...
     ],
@@ -168,7 +168,7 @@ def readConfig(args, known_coins):
             num_changes += 1
         offer_templates_map[offer_template['name']] = offer_template
 
-        min_offer_amount: float = float(offer_template.get('min_amount', offer_template['amount']))
+        min_offer_amount: float = float(offer_template.get('amount_step', offer_template['amount']))
         if float(offer_template.get('min_coin_from_amt', 0)) < min_offer_amount:
             print('Setting min_coin_from_amt for', offer_template['name'])
             offer_template['min_coin_from_amt'] = min_offer_amount
@@ -330,7 +330,7 @@ def main():
                     continue
 
                 max_offer_amount: float = offer_template['amount']
-                min_offer_amount: float = offer_template.get('min_amount', max_offer_amount)
+                min_offer_amount: float = offer_template.get('amount_step', max_offer_amount)
                 wallet_balance: float = float(wallet_from['balance'])
                 min_wallet_from_amount: float = float(offer_template['min_coin_from_amt'])
                 if wallet_balance - min_offer_amount <= min_wallet_from_amount:

--- a/tests/basicswap/extended/test_scripts.py
+++ b/tests/basicswap/extended/test_scripts.py
@@ -560,7 +560,7 @@ class Test(unittest.TestCase):
         rv_stdout = result.stdout.decode().split('\n')
         '''
 
-    def test_offer_min_amount(self):
+    def test_offer_amount_step(self):
         waitForServer(self.delay_event, UI_PORT + 0)
         waitForServer(self.delay_event, UI_PORT + 1)
 
@@ -587,9 +587,9 @@ class Test(unittest.TestCase):
             }
             json_rv = read_json_api(UI_PORT + 1, 'wallets/xmr/withdraw', post_json)
             assert (len(json_rv['txid']) == 64)
-            wait_for_balance(self.delay_event, f'http://127.0.0.1:{UI_PORT + 1}/json/wallets/xmr', 'balance', expect_balance)
+            wait_for_balance(self.delay_event, f'http://127.0.0.1:{UI_PORT + 0}/json/wallets/xmr', 'balance', expect_balance)
 
-            xmr_wallet_balance = read_json_api(UI_PORT + 0, 'wallets/xmr')['balance']
+            xmr_wallet_balance = float(read_json_api(UI_PORT + 0, 'wallets/xmr')['balance'])
 
         assert (xmr_wallet_balance > offer_min_amount)
         assert (xmr_wallet_balance < offer_amount)
@@ -601,7 +601,7 @@ class Test(unittest.TestCase):
                     'coin_from': 'XMR',
                     'coin_to': 'Particl',
                     'amount': offer_amount,
-                    'min_amount': offer_min_amount,
+                    'amount_step': offer_min_amount,
                     'minrate': 0.05,
                     'amount_variable': True,
                     'address': -1,


### PR DESCRIPTION
If min_amount is set offers will be created for amounts between "min_coin_from_amt" and "amount" in increments of "min_amount".