### PR TITLE
scripts: allow setting reserve below increment

### DIFF
--- a/scripts/createoffers.py
+++ b/scripts/createoffers.py
@@ -168,11 +168,16 @@ def readConfig(args, known_coins):
             num_changes += 1
         offer_templates_map[offer_template['name']] = offer_template
 
-        min_offer_amount: float = float(offer_template.get('amount_step', offer_template['amount']))
-        if float(offer_template.get('min_coin_from_amt', 0)) < min_offer_amount:
-            print('Setting min_coin_from_amt for', offer_template['name'])
-            offer_template['min_coin_from_amt'] = min_offer_amount
-            num_changes += 1
+        if 'amount_step' not in offer_template:
+            if offer_template.get('min_coin_from_amt', 0) < offer_template['amount']:
+                print('Setting min_coin_from_amt for', offer_template['name'])
+                offer_template['min_coin_from_amt'] = offer_template['amount']
+                num_changes += 1
+        else:
+            if 'min_coin_from_amt' not in offer_template:
+                print('Setting min_coin_from_amt for', offer_template['name'])
+                offer_template['min_coin_from_amt'] = 0
+                num_changes += 1
 
         if 'address' not in offer_template:
             print('Setting address to auto for offer', offer_template['name'])


### PR DESCRIPTION
This allows `min_coin_from_amt` to be set to a lower value than `amount_step`. 

user story:
balance 1.5 LTC
Increment 1 LTC
Reserve 0.2 LTC

Result: 
Reserve gets bumped to 1 LTC, leaving 0.5 LTC available to be sold. Because the increment is 1 LTC, but only 0.5 LTC is available, the order will not post due to low balance.

Expected:
Post offers until balance would fall below 0.2 + 1.0 (reserve + increment).

This PR allow setting values below the increment when amount_step is present in config, and uses default behavior when `amount_step` is not configured.

When `amount_step` is present in config but `min_coin_from_amt` is not, it assumes the user wants to sell their full balance - it sets `min_coin_from_amt` to 0.  (perhaps this value should have a buffer for tx fees?)