### PR TITLE
prepare: disablecoin/addcoin for manage_wallet_daemon

### DIFF
--- a/basicswap/bin/prepare.py
+++ b/basicswap/bin/prepare.py
@@ -2016,12 +2016,6 @@ def main():
     if add_coin != '':
         logger.info('Adding coin: %s', add_coin)
         settings = load_config(config_path)
-        if tor_control_password is None and settings.get('use_tor', False):
-            extra_opts['tor_control_password'] = settings.get('tor_control_password', None)
-
-        if particl_wallet_mnemonic != 'none':
-            # Ensure Particl wallet is unencrypted or correct password is supplied
-            test_particl_encryption(data_dir, settings, chain, use_tor_proxy)
 
         if add_coin in settings['chainclients']:
             coin_settings = settings['chainclients'][add_coin]
@@ -2036,6 +2030,13 @@ def main():
                 logger.info('Done.')
                 return 0
             exitWithError('{} is already in the settings file'.format(add_coin))
+
+        if tor_control_password is None and settings.get('use_tor', False):
+            extra_opts['tor_control_password'] = settings.get('tor_control_password', None)
+
+        if particl_wallet_mnemonic != 'none':
+            # Ensure Particl wallet is unencrypted or correct password is supplied
+            test_particl_encryption(data_dir, settings, chain, use_tor_proxy)
 
         settings['chainclients'][add_coin] = chainclients[add_coin]
         settings['use_tor_proxy'] = use_tor_proxy

--- a/basicswap/bin/prepare.py
+++ b/basicswap/bin/prepare.py
@@ -2001,6 +2001,8 @@ def main():
             exitWithError(f'{disable_coin} is already disabled')
         coin_settings['connection_type'] = 'none'
         coin_settings['manage_daemon'] = False
+        if 'manage_wallet_daemon' in coin_settings:
+            coin_settings['manage_wallet_daemon'] = False
 
         with open(config_path, 'w') as fp:
             json.dump(settings, fp, indent=4)
@@ -2027,6 +2029,8 @@ def main():
                 logger.info('Enabling coin: %s', add_coin)
                 coin_settings['connection_type'] = 'rpc'
                 coin_settings['manage_daemon'] = True
+                if 'manage_wallet_daemon' in coin_settings:
+                    coin_settings['manage_wallet_daemon'] = True
                 with open(config_path, 'w') as fp:
                     json.dump(settings, fp, indent=4)
                 logger.info('Done.')


### PR DESCRIPTION
- disable/enable `manage_wallet_daemon`
- don't require starting up the part daemon if the `addcoin` coin is only editing basicswap.json