### PR TITLE
Fix part balances checks

### DIFF
--- a/basicswap/interface/part.py
+++ b/basicswap/interface/part.py
@@ -974,7 +974,7 @@ class PARTInterfaceBlind(PARTInterface):
         return bytes.fromhex(lock_refund_swipe_tx_hex)
 
     def getSpendableBalance(self) -> int:
-        raise ValueError("getUnspentsByAddr is used to get the Blind balances")
+        return self.make_int(self.rpc_wallet("getbalances")["mine"]["blind_trusted"])
 
     def publishBLockTx(
         self,

--- a/basicswap/interface/part.py
+++ b/basicswap/interface/part.py
@@ -166,7 +166,13 @@ class PARTInterface(BTCInterface):
 
     def getUnspentsByAddr(self):
         unspent_addr = dict()
-        unspent = self.rpc_wallet("listunspent")
+        balance_type = self.balance_type()
+        if balance_type == BalanceTypes.PLAIN:
+            unspent = self.rpc_wallet("listunspent")
+        elif balance_type == BalanceTypes.BLIND:
+            unspent = self.rpc_wallet("listunspentblind")
+        else:
+            raise ValueError(f"getUnspentsByAddr not implemented for {balance_type} type")
         for u in unspent:
             if u["spendable"] is not True:
                 continue
@@ -968,7 +974,7 @@ class PARTInterfaceBlind(PARTInterface):
         return bytes.fromhex(lock_refund_swipe_tx_hex)
 
     def getSpendableBalance(self) -> int:
-        return self.make_int(self.rpc_wallet("getbalances")["mine"]["blind_trusted"])
+        raise ValueError("getUnspentsByAddr is used to get the Blind balances")
 
     def publishBLockTx(
         self,

--- a/scripts/createoffers.py
+++ b/scripts/createoffers.py
@@ -374,6 +374,20 @@ def main():
                 wallet_from = read_json_api_wallet(
                     "wallets/{}".format(coin_from_data["ticker"])
                 )
+                coin_ticker = coin_from_data["ticker"]
+                if coin_ticker=="PART" and "variant" in coin_from_data:
+                    coin_variant = coin_from_data["variant"]
+                    if coin_variant == "Anon":
+                        coin_from_data_name = "PART_ANON"
+                        wallet_balance: float = float(wallet_from["anon_balance"])
+                    elif coin_variant == "Blind":
+                        coin_from_data_name = "PART_BLIND"
+                        wallet_balance: float = float(wallet_from["blind_balance"])
+                    else:
+                        raise ValueError(f"{coin_ticker} variant {coin_variant} not handled")
+                else:
+                    coin_from_data_name = coin_ticker
+                    wallet_balance: float = float(wallet_from["balance"])
 
                 for offer in sent_offers:
                     created_offers = script_state.get("offers", {})
@@ -390,7 +404,7 @@ def main():
                         None,
                     ):
                         offers_found += 1
-                        if float(wallet_from["balance"]) <= float(
+                        if wallet_balance <= float(
                             offer_template["min_coin_from_amt"]
                         ):
                             offer_id = offer["offer_id"]
@@ -409,7 +423,7 @@ def main():
                 min_offer_amount: float = offer_template.get(
                     "amount_step", max_offer_amount
                 )
-                wallet_balance: float = float(wallet_from["balance"])
+                
                 min_wallet_from_amount: float = float(
                     offer_template["min_coin_from_amt"]
                 )
@@ -471,7 +485,7 @@ def main():
                     "addr_from": (
                         -1 if template_from_addr == "auto" else template_from_addr
                     ),
-                    "coin_from": coin_from_data["ticker"],
+                    "coin_from": coin_from_data_name,
                     "coin_to": coin_to_data["ticker"],
                     "amt_from": offer_amount,
                     "amt_var": offer_template["amount_variable"],


### PR DESCRIPTION
1. Fixed correct Anon and Blind PART balance checks in createoffers.py
2. Fixed the getUnspentByAddr to retrieve correctly the Blind PART UTXOs

Note: Consider changing the filter in the listunspent and listunspentblind to 0 confirmations since when one sends to PART to themselves the wallet balances are shown instantly (as opposed to "pending") or make sure that any balances with 0 confirmations are shown as pending. I think the latter is a more intuitive option