### PR TITLE
interface: xmr.py allow startup with a busy daemon

### DIFF
--- a/basicswap/basicswap.py
+++ b/basicswap/basicswap.py
@@ -999,6 +999,12 @@ class BasicSwap(BaseApp):
                     except Exception as e:
                         self.log.error("Sanity checks failed: %s", str(e))
 
+                elif c in (Coins.XMR, Coins.WOW):
+                    try:
+                        ci.ensureWalletExists()
+                    except Exception as e:
+                        self.log.warning("Can't open %s wallet, could be locked.", ci.coin_name())
+                        continue
                 elif c == Coins.LTC:
                     ci_mweb = self.ci(Coins.LTC_MWEB)
                     is_encrypted, _ = self.getLockedState()


### PR DESCRIPTION
Old behavior:
open_wallet > auto_refreshes after a few seconds. The same "no connection" error would be thrown, but wouldn't be caught. busy/syncing daemon triggers this error.. and if no bootstrap daemons are found, same error

this should behave similarly.