### PR TITLE
Add Bitcoin Cash to Available Assets on README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,12 @@ BasicSwap is compatible with the following digital assets.
    </td>
   </tr>
   <tr>
+   <td>Bitcoin Cash
+   </td>
+   <td>BCH
+   </td>
+  </tr>
+  <tr>
    <td>Dash
    </td>
    <td>DASH


### PR DESCRIPTION
Version 0.14.2 [now supports Bitcoin Cash](https://particl.news/basicswap-version-0-14-2-and-gui-3-1-1-now-available/). This PR adds Bitcoin Cash to the list of available assets on the main README.md