### PR TITLE
wallet: misc wallet.html

### DIFF
--- a/basicswap/templates/wallet.html
+++ b/basicswap/templates/wallet.html
@@ -266,31 +266,6 @@
                 <div class="px-6">
                   <div class="container mx-auto">
                     <div class="flex flex-wrap max-w-7xl mx-auto -m-3">
-                      {% if w.cid == '1' %} {# PART #}
-                      <div class="w-full md:w-1/2 p-3 flex justify-center items-center">
-                        <div class="h-full">
-                          <div class="flex flex-wrap -m-3">
-                            <div class="w-full p-3">
-                              <div class="mb-2 qrcode-container flex h-60 justify-center items-center">
-                                <div class="qrcode-border flex">
-                                  <div id="qrcode-stealth" class="qrcode"> </div>
-                                </div>
-                              </div>
-                              <div class="font-normal bold text-gray-500 text-center dark:text-white mb-5">{{ w.name }} Stealth Address: </div>
-                              <div class="relative flex justify-center items-center">
-                                <div data-tooltip-target="tooltip-copy-particl-stealth" class="input-like-container hover:border-blue-500 bg-gray-50 text-gray-900 appearance-none pr-10 dark:bg-gray-500 dark:text-white border border-gray-300 dark:border-gray-400 dark:text-gray-50 dark:placeholder-gray-400 text-sm rounded-lg outline-none focus:ring-blue-500 focus:border-blue-500 block w-full p-10 focus:ring-0" id="stealth_address"> {{ w.stealth_address }}
-                                </div>
-                              </div>
-                              <div id="tooltip-copy-particl-stealth" role="tooltip" class="inline-block absolute invisible z-10 py-2 px-3 text-sm font-medium text-white bg-blue-500 rounded-lg shadow-sm opacity-0 transition-opacity duration-300 tooltip">
-                                <p>Copy to clipboard</p>
-                                <div class="tooltip-arrow" data-popper-arrow></div>
-                              </div>
-                            </div>
-                          </div>
-                        </div>
-                      </div>
-                      {% endif %}
-                      {# / PART #}
                       {% if w.cid in '6, 9' %}
                       {# XMR | WOW #}
                       <div class="w-full md:w-1/2 p-3 flex justify-center items-center">
@@ -368,7 +343,31 @@
                         </div>
                       </div>
                       {% endif %}
-                      {% if w.cid == '3' %}
+                      {% if w.cid == '1' %} {# PART #}
+                      <div class="w-full md:w-1/2 p-3 flex justify-center items-center">
+                        <div class="h-full">
+                          <div class="flex flex-wrap -m-3">
+                            <div class="w-full p-3">
+                              <div class="mb-2 qrcode-container flex h-60 justify-center items-center">
+                                <div class="qrcode-border flex">
+                                  <div id="qrcode-stealth" class="qrcode"> </div>
+                                </div>
+                              </div>
+                              <div class="font-normal bold text-gray-500 text-center dark:text-white mb-5">{{ w.name }} Stealth Address: </div>
+                              <div class="relative flex justify-center items-center">
+                                <div data-tooltip-target="tooltip-copy-particl-stealth" class="input-like-container hover:border-blue-500 bg-gray-50 text-gray-900 appearance-none pr-10 dark:bg-gray-500 dark:text-white border border-gray-300 dark:border-gray-400 dark:text-gray-50 dark:placeholder-gray-400 text-sm rounded-lg outline-none focus:ring-blue-500 focus:border-blue-500 block w-full p-10 focus:ring-0" id="stealth_address"> {{ w.stealth_address }}
+                                </div>
+                              </div>
+                              <div id="tooltip-copy-particl-stealth" role="tooltip" class="inline-block absolute invisible z-10 py-2 px-3 text-sm font-medium text-white bg-blue-500 rounded-lg shadow-sm opacity-0 transition-opacity duration-300 tooltip">
+                                <p>Copy to clipboard</p>
+                                <div class="tooltip-arrow" data-popper-arrow></div>
+                              </div>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                      {# / PART #}
+                      {% elif w.cid == '3' %}
                       {# LTC #}
                       <div class="w-full md:w-1/2 p-3 flex justify-center items-center">
                         <div class="h-full">

--- a/basicswap/templates/wallet.html
+++ b/basicswap/templates/wallet.html
@@ -208,7 +208,7 @@
                         {# / encrypted #}
                         <tr class="opacity-100 text-gray-500 dark:text-gray-100 hover:bg-coolGray-200 dark:hover:bg-gray-600">
                           <td class="py-3 px-6 bold">Expected Seed:</td>
-                          <td class="py-3 px-6">{{ w.expected_seed }}</td> {% if block_unknown_seeds and w.expected_seed != true %} {# Only show addresses if wallet seed is correct #}
+                          <td class="py-3 px-6">{{ w.expected_seed }}</td>
                         </tr>
                       </table>
                     </div>
@@ -220,6 +220,7 @@
         </div>
       </div>
     </section>
+  {% if block_unknown_seeds and w.expected_seed != true %} {# Only show addresses if wallet seed is correct #}
     <section class="pl-6 pr-6 pt-0 pb-0 h-full overflow-hidden">
       <div class="pb-6 border-coolGray-100">
         <div class="flex flex-wrap items-center justify-between -m-2">
@@ -240,16 +241,6 @@
       </div>
     </section>
   {% else %}
-</table>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</div>
-</section>
 <section class="p-6">
   <div class="flex items-center">
     <h4 class="font-semibold text-2xl text-black dark:text-white">Deposit</h4>

--- a/basicswap/templates/wallet.html
+++ b/basicswap/templates/wallet.html
@@ -265,7 +265,7 @@
               <div class="pb-6 bg-coolGray-100 dark:bg-gray-500 rounded-xl">
                 <div class="px-6">
                   <div class="container mx-auto">
-                    <div class="flex flex-wrap max-w-7xl mx-auto -m-3">
+                    <div class="flex flex-wrap max-w-7xl mx-auto justify-center -m-3">
                       {% if w.cid in '6, 9' %}
                       {# XMR | WOW #}
                       <div class="w-full md:w-1/2 p-3 flex justify-center items-center">


### PR DESCRIPTION
- Other wallets (xmr, wow, ltc) have the "main" or transparent addr on the left. This moves part wallet to be consistent with those
- center qr code for coins with only 1 address 
- remove duplicate code for reseed section