### PR TITLE
Add upgradecores function to prepare script.

### DIFF
--- a/basicswap/bin/prepare.py
+++ b/basicswap/bin/prepare.py
@@ -165,6 +165,9 @@ if not len(logger.handlers):
 
 BSX_DOCKER_MODE = toBool(os.getenv("BSX_DOCKER_MODE", "false"))
 BSX_TEST_MODE = toBool(os.getenv("BSX_TEST_MODE", "false"))
+BSX_UPDATE_UNMANAGED = toBool(
+    os.getenv("BSX_UPDATE_UNMANAGED", "true")
+)  # Disable updating unmanaged coin cores.
 UI_HTML_PORT = int(os.getenv("UI_HTML_PORT", 12700))
 UI_WS_PORT = int(os.getenv("UI_WS_PORT", 11700))
 COINS_RPCBIND_IP = os.getenv("COINS_RPCBIND_IP", "127.0.0.1")
@@ -2703,7 +2706,7 @@ def main():
                 logger.info(
                     f"{coin_name}: have {have_version}, current {current_version}."
                 )
-                if not (
+                if not BSX_UPDATE_UNMANAGED and not (
                     coin_settings.get("manage_daemon", False)
                     or coin_settings.get("manage_wallet_daemon", False)
                 ):

--- a/basicswap/bin/run.py
+++ b/basicswap/bin/run.py
@@ -223,7 +223,7 @@ def getWalletBinName(coin_id: int, coin_settings, default_name: str) -> str:
     ) + (".exe" if os.name == "nt" else "")
 
 
-def getCoreBinArgs(coin_id: int, coin_settings):
+def getCoreBinArgs(coin_id: int, coin_settings, prepare=False):
     extra_args = []
     if "config_filename" in coin_settings:
         extra_args.append("--conf=" + coin_settings["config_filename"])
@@ -234,7 +234,7 @@ def getCoreBinArgs(coin_id: int, coin_settings):
     # As BCH may use port 8334, disable it here.
     # When tor is enabled a bind option for the onionport will be added to bitcoin.conf.
     # https://github.com/bitcoin/bitcoin/blob/master/doc/release-notes/release-notes-28.0.md?plain=1#L84
-    if coin_id == Coins.BTC:
+    if not prepare and coin_id == Coins.BTC:
         port: int = coin_settings.get("port", 8333)
         extra_args.append(f"--bind=0.0.0.0:{port}")
     return extra_args


### PR DESCRIPTION
Differences from preparebinonly:

- If with/withoutcoins isn't set
  - Read list of coins to update from basicswap.json
    - Only where manage_daemon or manage_wallet_daemon is true
- Store core version no in basicswap.json
  - Only update if missing or differs.
- Writes core_version_no and core_version_group to basicswap.json
  - Per core updated
  - Backup old config to timestamped file