### PR TITLE
Add BTC descriptor wallet support.

### DIFF
--- a/basicswap/basicswap.py
+++ b/basicswap/basicswap.py
@@ -599,7 +599,12 @@ class BasicSwap(BaseApp):
         }
 
         # Passthrough settings
-        for setting_name in ("wallet_name", "mweb_wallet_name"):
+        for setting_name in (
+            "use_descriptors",
+            "wallet_name",
+            "watch_wallet_name",
+            "mweb_wallet_name",
+        ):
             if setting_name in chain_client_settings:
                 self.coin_clients[coin][setting_name] = chain_client_settings[
                     setting_name

--- a/basicswap/chainparams.py
+++ b/basicswap/chainparams.py
@@ -91,6 +91,8 @@ chainparams = {
             "bip44": 0,
             "min_amount": 100000,
             "max_amount": 10000000 * COIN,
+            "ext_public_key_prefix": 0x0488B21E,
+            "ext_secret_key_prefix": 0x0488ADE4,
         },
         "testnet": {
             "rpcport": 18332,
@@ -102,6 +104,8 @@ chainparams = {
             "min_amount": 100000,
             "max_amount": 10000000 * COIN,
             "name": "testnet3",
+            "ext_public_key_prefix": 0x043587CF,
+            "ext_secret_key_prefix": 0x04358394,
         },
         "regtest": {
             "rpcport": 18443,
@@ -112,6 +116,8 @@ chainparams = {
             "bip44": 1,
             "min_amount": 100000,
             "max_amount": 10000000 * COIN,
+            "ext_public_key_prefix": 0x043587CF,
+            "ext_secret_key_prefix": 0x04358394,
         },
     },
     Coins.LTC: {

--- a/basicswap/contrib/test_framework/descriptors.py
+++ b/basicswap/contrib/test_framework/descriptors.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+# Copyright (c) 2019 Pieter Wuille
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""Utility functions related to output descriptors"""
+
+import re
+
+INPUT_CHARSET = "0123456789()[],'/*abcdefgh@:$%{}IJKLMNOPQRSTUVWXYZ&+-.;<=>?!^_|~ijklmnopqrstuvwxyzABCDEFGH`#\"\\ "
+CHECKSUM_CHARSET = "qpzry9x8gf2tvdw0s3jn54khce6mua7l"
+GENERATOR = [0xf5dee51989, 0xa9fdca3312, 0x1bab10e32d, 0x3706b1677a, 0x644d626ffd]
+
+def descsum_polymod(symbols):
+    """Internal function that computes the descriptor checksum."""
+    chk = 1
+    for value in symbols:
+        top = chk >> 35
+        chk = (chk & 0x7ffffffff) << 5 ^ value
+        for i in range(5):
+            chk ^= GENERATOR[i] if ((top >> i) & 1) else 0
+    return chk
+
+def descsum_expand(s):
+    """Internal function that does the character to symbol expansion"""
+    groups = []
+    symbols = []
+    for c in s:
+        if not c in INPUT_CHARSET:
+            return None
+        v = INPUT_CHARSET.find(c)
+        symbols.append(v & 31)
+        groups.append(v >> 5)
+        if len(groups) == 3:
+            symbols.append(groups[0] * 9 + groups[1] * 3 + groups[2])
+            groups = []
+    if len(groups) == 1:
+        symbols.append(groups[0])
+    elif len(groups) == 2:
+        symbols.append(groups[0] * 3 + groups[1])
+    return symbols
+
+def descsum_create(s):
+    """Add a checksum to a descriptor without"""
+    symbols = descsum_expand(s) + [0, 0, 0, 0, 0, 0, 0, 0]
+    checksum = descsum_polymod(symbols) ^ 1
+    return s + '#' + ''.join(CHECKSUM_CHARSET[(checksum >> (5 * (7 - i))) & 31] for i in range(8))
+
+def descsum_check(s, require=True):
+    """Verify that the checksum is correct in a descriptor"""
+    if not '#' in s:
+        return not require
+    if s[-9] != '#':
+        return False
+    if not all(x in CHECKSUM_CHARSET for x in s[-8:]):
+        return False
+    symbols = descsum_expand(s[:-9]) + [CHECKSUM_CHARSET.find(x) for x in s[-8:]]
+    return descsum_polymod(symbols) == 1
+
+def drop_origins(s):
+    '''Drop the key origins from a descriptor'''
+    desc = re.sub(r'\[.+?\]', '', s)
+    if '#' in s:
+        desc = desc[:desc.index('#')]
+    return descsum_create(desc)

--- a/tests/basicswap/common.py
+++ b/tests/basicswap/common.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 
 # Copyright (c) 2020-2024 tecnovert
-# Copyright (c) 2024 The Basicswap developers
+# Copyright (c) 2024-2025 The Basicswap developers
 # Distributed under the MIT software license, see the accompanying
 # file LICENSE.txt or http://www.opensource.org/licenses/mit-license.php.
 
@@ -14,6 +14,7 @@ from urllib.request import urlopen
 
 from .util import read_json_api
 from basicswap.rpc import callrpc
+from basicswap.util import toBool
 from basicswap.contrib.rpcauth import generate_salt, password_to_hmac
 from basicswap.bin.prepare import downloadPIVXParams
 
@@ -43,6 +44,8 @@ PIVX_BASE_RPC_PORT = 35892
 PIVX_BASE_ZMQ_PORT = 36892
 
 PREFIX_SECRET_KEY_REGTEST = 0x2E
+
+BTC_USE_DESCRIPTORS = toBool(os.getenv("BTC_USE_DESCRIPTORS", False))
 
 
 def prepareDataDir(

--- a/tests/basicswap/common_xmr.py
+++ b/tests/basicswap/common_xmr.py
@@ -6,26 +6,23 @@
 # Distributed under the MIT software license, see the accompanying
 # file LICENSE or http://www.opensource.org/licenses/mit-license.php.
 
-import os
-import sys
 import json
+import logging
+import multiprocessing
+import os
 import shutil
 import signal
-import logging
-import unittest
+import sys
 import threading
-import multiprocessing
+import unittest
 from io import StringIO
 from urllib.request import urlopen
 from unittest.mock import patch
 
-from basicswap.rpc_xmr import (
-    callrpc_xmr,
-)
+from basicswap.contrib.rpcauth import generate_salt, password_to_hmac
+from basicswap.rpc_xmr import callrpc_xmr
 from tests.basicswap.mnemonics import mnemonics
-from tests.basicswap.util import (
-    waitForServer,
-)
+from tests.basicswap.util import waitForServer
 from tests.basicswap.common import (
     BASE_PORT,
     BASE_RPC_PORT,
@@ -35,6 +32,7 @@ from tests.basicswap.common import (
     LTC_BASE_PORT,
     LTC_BASE_RPC_PORT,
     PIVX_BASE_PORT,
+    BTC_USE_DESCRIPTORS,
 )
 from tests.basicswap.extended.test_dcr import (
     DCR_BASE_PORT,
@@ -48,8 +46,6 @@ from tests.basicswap.extended.test_doge import (
     DOGE_BASE_PORT,
     DOGE_BASE_RPC_PORT,
 )
-
-from basicswap.contrib.rpcauth import generate_salt, password_to_hmac
 
 import basicswap.config as cfg
 import basicswap.bin.run as runSystem
@@ -133,6 +129,7 @@ def run_prepare(
     os.environ["PART_RPC_PORT"] = str(PARTICL_RPC_PORT_BASE)
     os.environ["BTC_RPC_PORT"] = str(BITCOIN_RPC_PORT_BASE)
     os.environ["BTC_PORT"] = str(BITCOIN_PORT_BASE)
+    os.environ["BTC_USE_DESCRIPTORS"] = str(BTC_USE_DESCRIPTORS)
     os.environ["LTC_RPC_PORT"] = str(LITECOIN_RPC_PORT_BASE)
     os.environ["DCR_RPC_PORT"] = str(DECRED_RPC_PORT_BASE)
     os.environ["FIRO_RPC_PORT"] = str(FIRO_RPC_PORT_BASE)


### PR DESCRIPTION
Set BTC_USE_DESCRIPTORS env var to true to enable descriptors in the prepare script and test_btc_xmr A separate watchonly wallet is created when using descriptor wallets.