### PR TITLE
Offer page: Add info whether an offer is set to auto accept bid or not

### DIFF
--- a/basicswap/basicswap.py
+++ b/basicswap/basicswap.py
@@ -2165,6 +2165,24 @@ class BasicSwap(BaseApp):
                     msg_buf.fee_rate_to
                 )  # Unused: TODO - Set priority?
 
+            # Set auto-accept type
+            automation_id = extra_options.get("automation_id", -1)
+            if automation_id == -1 and auto_accept_bids:
+                automation_id = 1  # Default strategy
+
+            if automation_id != -1:
+                strategy = self.queryOne(
+                    AutomationStrategy,
+                    cursor,
+                    {"active_ind": 1, "record_id": automation_id},
+                )
+                if strategy:
+                    msg_buf.auto_accept_type = (
+                        2 if strategy.only_known_identities else 1
+                    )
+            else:
+                msg_buf.auto_accept_type = 0
+
             # If a prefunded txn is not used, check that the wallet balance can cover the tx fee.
             if "prefunded_itx" not in extra_options:
                 # TODO: Better tx size estimate, xmr_swap_b_lock_tx_vsize could be larger than xmr_swap_b_lock_spend_tx_vsize
@@ -2217,6 +2235,7 @@ class BasicSwap(BaseApp):
                 security_token=security_token,
                 from_feerate=msg_buf.fee_rate_from,
                 to_feerate=msg_buf.fee_rate_to,
+                auto_accept_type=msg_buf.auto_accept_type,
             )
             offer.setState(OfferStates.OFFER_SENT)
 
@@ -7052,6 +7071,11 @@ class BasicSwap(BaseApp):
                     expire_at=msg["sent"] + offer_data.time_valid,
                     was_sent=False,
                     bid_reversed=bid_reversed,
+                    auto_accept_type=(
+                        offer_data.auto_accept_type
+                        if b"\xa0\x01" in offer_bytes
+                        else None
+                    ),
                 )
                 offer.setState(OfferStates.OFFER_RECEIVED)
                 self.add(offer, cursor)

--- a/basicswap/db.py
+++ b/basicswap/db.py
@@ -13,7 +13,7 @@ from enum import IntEnum, auto
 from typing import Optional
 
 
-CURRENT_DB_VERSION = 26
+CURRENT_DB_VERSION = 27
 CURRENT_DB_DATA_VERSION = 6
 
 
@@ -183,6 +183,7 @@ class Offer(Table):
 
     amount_negotiable = Column("bool")
     rate_negotiable = Column("bool")
+    auto_accept_type = Column("integer")
 
     # Local fields
     auto_accept_bids = Column("bool")

--- a/basicswap/db_upgrades.py
+++ b/basicswap/db_upgrades.py
@@ -425,6 +425,9 @@ def upgradeDatabase(self, db_version):
                         last_updated INTEGER,
                         PRIMARY KEY (record_id))"""
                 )
+            elif current_version == 26:
+                db_version += 1
+                cursor.execute("ALTER TABLE offers ADD COLUMN auto_accept_type INTEGER")
             if current_version != db_version:
                 self.db_version = db_version
                 self.setIntKV("db_version", db_version, cursor)

--- a/basicswap/messages_npb.py
+++ b/basicswap/messages_npb.py
@@ -136,6 +136,7 @@ class OfferMessage(NonProtobufClass):
         17: ("amount_negotiable", 0, 2),
         18: ("rate_negotiable", 0, 2),
         19: ("proof_utxos", 2, 0),
+        20: ("auto_accept_type", 0, 0),
     }
 
 

--- a/basicswap/templates/offer.html
+++ b/basicswap/templates/offer.html
@@ -219,16 +219,17 @@
             <td class="py-3 px-6 bold">Revoked</td>
             <td class="py-3 px-6">{{ data.was_revoked }}</td>
            </tr>
-           {% if data.sent %}
            <tr class="opacity-100 text-gray-500 dark:text-gray-100 hover:bg-coolGray-200 dark:hover:bg-gray-600">
-            <td class="py-3 px-6 bold">Auto Accept Strategy</td>
+            <td class="py-3 px-6 bold">Auto Accept Type</td>
             <td class="py-3 px-6">
-            {% if data.automation_strat_id == -1 %} None {% else %}
-            <a href="/automationstrategy/{{ data.automation_strat_id }}">{{ data.automation_strat_label }}</a>
+            {% if data.auto_accept_type is none %} Unknown
+            {% elif data.auto_accept_type == 0 %} Bids are accepted manually
+            {% elif data.auto_accept_type == 1 %} Bids are accepted automatically
+            {% elif data.auto_accept_type == 2 %} Bids are accepted automatically from known identities
+            {% else %} Unknown ({{ data.auto_accept_type }})
             {% endif %}
             </td>
            </tr>
-           {% endif %}
            {% if data.xmr_type == true %}
            <tr class="opacity-100 text-gray-500 dark:text-gray-100 hover:bg-coolGray-200 dark:hover:bg-gray-600">
             <td class="py-3 px-6 bold">Chain A offer fee rate</td>
@@ -482,7 +483,7 @@ if (document.readyState === 'loading') {
                    name="bid_amount_send"
                    value=""
                    max="{{ data.amt_to }}"
-                   onchange="validateMaxAmount(this, {{ data.amt_to }}); updateBidParams('sending');">
+                   onchange="validateMaxAmount(this, parseFloat('{{ data.amt_to }}')); updateBidParams('sending');">
             <div class="absolute inset-y-0 right-3 flex items-center pointer-events-none text-gray-400 dark:text-gray-300 text-sm">
                 max {{ data.amt_to }} ({{ data.tla_to }})
             </div>
@@ -505,7 +506,7 @@ if (document.readyState === 'loading') {
                    name="bid_amount" 
                    value="" 
                    max="{{ data.amt_from }}"
-                   onchange="validateMaxAmount(this, {{ data.amt_from }}); updateBidParams('receiving');">
+                   onchange="validateMaxAmount(this, parseFloat('{{ data.amt_from }}')); updateBidParams('receiving');">
             <div class="absolute inset-y-0 right-3 flex items-center pointer-events-none text-gray-400 dark:text-gray-300 text-sm">
                 max {{ data.amt_from }} ({{ data.tla_from }})
             </div>

--- a/basicswap/ui/page_offers.py
+++ b/basicswap/ui/page_offers.py
@@ -733,6 +733,9 @@ def page_offer(self, url_split, post_string):
         "swap_type": strSwapDesc(offer.swap_type),
         "reverse": reverse_bid,
         "form_id": get_data_entry_or(form_data, "formid", "") if form_data else "",
+        "auto_accept_type": (
+            offer.auto_accept_type if hasattr(offer, "auto_accept_type") else 0
+        ),
     }
     data.update(extend_data)
 


### PR DESCRIPTION
Broadcasts via its SMSG message whether an offer is set to automatically accept bids (either accept all bids or only from known peers) or not. That information is subsequently displayed on the offer page. This can help users make better informed decisions before sending their bids to an offerer.

![image](https://github.com/user-attachments/assets/e4a2b486-2667-407d-960c-c2a7e18976e3)

resolves #284
