### PR TITLE
xmr: detect corrupt wallets

### DIFF
--- a/basicswap/basicswap.py
+++ b/basicswap/basicswap.py
@@ -1054,7 +1054,9 @@ class BasicSwap(BaseApp):
                 elif c in (Coins.XMR, Coins.WOW):
                     try:
                         ci.ensureWalletExists()
-                    except Exception as e:  # noqa: F841
+                    except Exception as e:
+                        if "invalid signature" in str(e):  # wallet is corrupt
+                            raise
                         self.log.warning(
                             f"Can't open {ci.coin_name()} wallet, could be locked."
                         )

--- a/basicswap/interface/wow.py
+++ b/basicswap/interface/wow.py
@@ -30,3 +30,27 @@ class WOWInterface(XMRInterface):
     @staticmethod
     def depth_spendable() -> int:
         return 3
+
+    # below only needed until wow is rebased to monero v0.18.4.0+
+    def openWallet(self, filename):
+        params = {"filename": filename}
+        if self._wallet_password is not None:
+            params["password"] = self._wallet_password
+
+        try:
+            self.rpc_wallet("open_wallet", params)
+        except Exception as e:
+            if "no connection to daemon" in str(e):
+                self._log.debug(f"{self.coin_name()} {e}")
+                return  # bypass refresh error to allow startup with a busy daemon
+
+            try:
+                # TODO Remove `store` after upstream fix to autosave on close_wallet
+                self.rpc_wallet("store")
+                self.rpc_wallet("close_wallet")
+                self._log.debug(f"Attempt to save and close {self.coin_name()} wallet")
+            except Exception as e:  # noqa: F841
+                pass
+
+            self.rpc_wallet("open_wallet", params)
+            self._log.debug(f"Reattempt to open {self.coin_name()} wallet")

--- a/basicswap/interface/xmr.py
+++ b/basicswap/interface/xmr.py
@@ -205,17 +205,18 @@ class XMRInterface(CoinInterface):
             if "no connection to daemon" in str(e):
                 self._log.debug(f"{self.coin_name()} {e}")
                 return  # bypass refresh error to allow startup with a busy daemon
+            if "invalid signature" in str(e):
+                self._log.debug(f"{self.coin_name()} wallet is corrupt")
+                raise
 
             try:
-                # TODO Remove `store` after upstream fix to autosave on close_wallet
-                self.rpc_wallet("store")
                 self.rpc_wallet("close_wallet")
-                self._log.debug(f"Attempt to save and close {self.coin_name()} wallet")
+                self._log.debug(f"Closing {self.coin_name()} wallet")
             except Exception as e:  # noqa: F841
                 pass
 
             self.rpc_wallet("open_wallet", params)
-            self._log.debug(f"Reattempt to open {self.coin_name()} wallet")
+            self._log.debug(f"Attempting to open {self.coin_name()} wallet")
 
     def initialiseWallet(
         self, key_view: bytes, key_spend: bytes, restore_height=None


### PR DESCRIPTION
monero-wallet-rpc v0.18.4.0 actually reports the full error instead of just `Failed to open wallet`. This allows us to properly handle issues. An example being when a wallet cache file is corrupted. The cache file is the file w/o the `.keys` extension

this pr catches the error and wont let basicswap start if the wallet cache file is corrupted.

- [x] suggested improvement (I don't know how): ideally it would move the file (swap_wallet -> swap_wallet.corrupt) and then try again. Trying again w/o a cache file will recreate it and begin the sync.

This pr also removes the "store" command that preceeds close_wallet (it was fixed upstream). Had to add override to wownero until wow rebases