### PR TITLE
utils: round inputAmount to avoid mantissa err

### DIFF
--- a/basicswap/ui/util.py
+++ b/basicswap/ui/util.py
@@ -55,7 +55,7 @@ def validateAmountString(amount, ci):
 
 def inputAmount(amount_str, ci):
     validateAmountString(amount_str, ci)
-    return make_int(amount_str, ci.exp())
+    return make_int(amount_str, ci.exp(), r=1)
 
 
 def get_data_entry_or(post_data, name, default):


### PR DESCRIPTION
occasionally (when using amount step), you'll run into the "mantissa too long" error upon creating an offer. This just rounds the offer's inputAmount