### PR TITLE
prepare: Set changetype=bech32 in BTC and LTC .conf files.

### DIFF
--- a/basicswap/bin/prepare.py
+++ b/basicswap/bin/prepare.py
@@ -1315,7 +1315,7 @@ def prepareDataDir(coin, settings, chain, particl_mnemonic, extra_opts={}):
         )
         wallet_conf_path = os.path.join(data_dir, wallet_conf_filename)
         if os.path.exists(wallet_conf_path):
-            exitWithError("{} exists".format(wallet_conf_path))
+            exitWithError(f"{wallet_conf_path} exists")
         with open(wallet_conf_path, "w") as fp:
             if chain != "mainnet":
                 fp.write(chainname + "=1\n")
@@ -1342,7 +1342,7 @@ def prepareDataDir(coin, settings, chain, particl_mnemonic, extra_opts={}):
     core_conf_name: str = core_settings.get("config_filename", coin + ".conf")
     core_conf_path = os.path.join(data_dir, core_conf_name)
     if os.path.exists(core_conf_path):
-        exitWithError("{} exists".format(core_conf_path))
+        exitWithError(f"{core_conf_path} exists")
     with open(core_conf_path, "w") as fp:
         if chain != "mainnet":
             if coin in ("navcoin",):
@@ -1393,6 +1393,7 @@ def prepareDataDir(coin, settings, chain, particl_mnemonic, extra_opts={}):
                 )
         elif coin == "litecoin":
             fp.write("prune=4000\n")
+            fp.write("changetype=bech32\n")
             if LTC_RPC_USER != "":
                 fp.write(
                     "rpcauth={}:{}${}\n".format(
@@ -1410,6 +1411,7 @@ def prepareDataDir(coin, settings, chain, particl_mnemonic, extra_opts={}):
         elif coin == "bitcoin":
             fp.write("deprecatedrpc=create_bdb\n")
             fp.write("prune=2000\n")
+            fp.write("changetype=bech32\n")
             fp.write("fallbackfee=0.0002\n")
             if BTC_RPC_USER != "":
                 fp.write(
@@ -1784,7 +1786,7 @@ def test_particl_encryption(data_dir, settings, chain, use_tor_proxy):
         coin_name = "particl"
         coin_settings = settings["chainclients"][coin_name]
         daemon_args += getCoreBinArgs(c, coin_settings, prepare=True)
-        extra_config = {"stdout_to_file": True}
+        extra_config = {"stdout_to_file": True, "coin_name": coin_name}
         if coin_settings["manage_daemon"]:
             filename: str = getCoreBinName(c, coin_settings, coin_name + "d")
             daemons.append(
@@ -1906,7 +1908,7 @@ def initialise_wallets(
                             )
                         ]
 
-                    extra_config = {"stdout_to_file": True}
+                    extra_config = {"stdout_to_file": True, "coin_name": coin_name}
                     daemons.append(
                         startDaemon(
                             coin_settings["datadir"],

--- a/basicswap/interface/part.py
+++ b/basicswap/interface/part.py
@@ -187,6 +187,9 @@ class PARTInterface(BTCInterface):
             ) + self.make_int(u["amount"], r=1)
         return unspent_addr
 
+    def combine_non_segwit_prevouts(self):
+        raise RuntimeError("No non-segwit outputs found.")
+
 
 class PARTInterfaceBlind(PARTInterface):
 

--- a/basicswap/templates/debug.html
+++ b/basicswap/templates/debug.html
@@ -1,5 +1,5 @@
 {% include 'header.html' %}
-{% from 'style.html' import breadcrumb_line_svg, start_process_svg %} 
+{% from 'style.html' import breadcrumb_line_svg, start_process_svg %}
 <div class="container mx-auto">
  <section class="p-5 mt-5">
   <div class="flex flex-wrap items-center -m-2">
@@ -72,6 +72,27 @@
              <td td class="py-3 px-6 ">
               <button name="reinit_xmr" type="submit" value="Yes" class="w-60 flex flex-wrap justify-center py-2 px-4 bg-blue-500 hover:bg-blue-600 font-medium text-sm text-white border border-blue-500 rounded-md shadow-button focus:ring-0 focus:outline-none">
               {{ start_process_svg| safe }} Start Process</button>
+             </td>
+            </tr>
+            <tr class="opacity-100 text-gray-500 dark:text-gray-100">
+             <td class="py-3 px-6 bold">List non-segwit UTXOs</td>
+             <td td class="py-3 px-6 ">
+              <button name="list_non_segwit_prevouts" type="submit" value="Yes" class="w-60 flex flex-wrap justify-center py-2 px-4 bg-blue-500 hover:bg-blue-600 font-medium text-sm text-white border border-blue-500 rounded-md shadow-button focus:ring-0 focus:outline-none">
+              List</button>
+             </td>
+            </tr>
+            <tr class="opacity-100 text-gray-500 dark:text-gray-100">
+             <td class="py-3 px-6 bold">Combine non-segwit BTC UTXOs</td>
+             <td td class="py-3 px-6 ">
+              <button name="combine_non_segwit_prevouts_btc" type="submit" value="Yes" class="w-60 flex flex-wrap justify-center py-2 px-4 bg-blue-500 hover:bg-blue-600 font-medium text-sm text-white border border-blue-500 rounded-md shadow-button focus:ring-0 focus:outline-none">
+              Combine</button>
+             </td>
+            </tr>
+            <tr class="opacity-100 text-gray-500 dark:text-gray-100">
+             <td class="py-3 px-6 bold">Combine non-segwit LTC UTXOs</td>
+             <td td class="py-3 px-6 ">
+              <button name="combine_non_segwit_prevouts_ltc" type="submit" value="Yes" class="w-60 flex flex-wrap justify-center py-2 px-4 bg-blue-500 hover:bg-blue-600 font-medium text-sm text-white border border-blue-500 rounded-md shadow-button focus:ring-0 focus:outline-none">
+              Combine</button>
              </td>
             </tr>
             <input type="hidden" name="formid" value="{{ form_id }}">

--- a/basicswap/ui/page_debug.py
+++ b/basicswap/ui/page_debug.py
@@ -1,9 +1,10 @@
 # -*- coding: utf-8 -*-
 
-# Copyright (c) 2023-2024 The Basicswap developers
+# Copyright (c) 2023-2025 The Basicswap developers
 # Distributed under the MIT software license, see the accompanying
 # file LICENSE or http://www.opensource.org/licenses/mit-license.php.
 
+import json
 import traceback
 from .util import (
     have_data_entry,
@@ -32,6 +33,9 @@ def page_debug(self, url_split, post_string):
                 swap_client.initialiseWallet(Coins.XMR)
                 messages.append("Done.")
             except Exception as e:
+                swap_client.log.error(
+                    traceback.format_exc() if swap_client.debug else f"reinit_xmr: {e}"
+                )
                 err_messages.append(f"Failed: {e}.")
 
         if have_data_entry(form_data, "remove_expired"):
@@ -40,11 +44,58 @@ def page_debug(self, url_split, post_string):
                 remove_expired_data(swap_client)
                 messages.append("Done.")
             except Exception as e:
-                if swap_client.debug is True:
-                    swap_client.log.error(traceback.format_exc())
-                else:
-                    swap_client.log.error(f"remove_expired_data: {e}")
+                swap_client.log.error(
+                    traceback.format_exc()
+                    if swap_client.debug
+                    else f"remove_expired_data: {e}"
+                )
                 err_messages.append("Failed.")
+
+        if have_data_entry(form_data, "list_non_segwit_prevouts"):
+            try:
+                rvj = {}
+                rvj["BTC"] = swap_client.ci(Coins.BTC).getNonSegwitOutputs()
+                rvj["LTC"] = swap_client.ci(Coins.LTC).getNonSegwitOutputs()
+
+                # json.dumps indent=4 ends up in one line in html side
+                message_output = "BTC:<br/>"
+                for utxo in rvj["BTC"]:
+                    message_output += json.dumps(utxo) + "<br/>"
+                message_output += "LTC:<br/>"
+                for utxo in rvj["LTC"]:
+                    message_output += json.dumps(utxo) + "<br/>"
+                messages.append(message_output)
+            except Exception as e:
+                swap_client.log.error(
+                    traceback.format_exc()
+                    if swap_client.debug
+                    else f"list_non_segwit_prevouts: {e}"
+                )
+                err_messages.append(f"Failed: {e}.")
+        if have_data_entry(form_data, "combine_non_segwit_prevouts_btc"):
+            try:
+                ci = swap_client.ci(Coins.BTC)
+                txid = ci.combine_non_segwit_prevouts()
+                messages.append(f"Combined non-segwit BTC UTXOs, txid: {txid}.")
+            except Exception as e:
+                swap_client.log.error(
+                    traceback.format_exc()
+                    if swap_client.debug
+                    else f"combine_non_segwit_prevouts_btc: {e}"
+                )
+                err_messages.append(f"Failed: {e}.")
+        if have_data_entry(form_data, "combine_non_segwit_prevouts_ltc"):
+            try:
+                ci = swap_client.ci(Coins.LTC)
+                txid = ci.combine_non_segwit_prevouts()
+                messages.append(f"Combined non-segwit LTC UTXOs, txid: {txid}.")
+            except Exception as e:
+                swap_client.log.error(
+                    traceback.format_exc()
+                    if swap_client.debug
+                    else f"combine_non_segwit_prevouts_ltc: {e}"
+                )
+                err_messages.append(f"Failed: {e}.")
 
     template = server.env.get_template("debug.html")
     return self.render_template(

--- a/tests/basicswap/common.py
+++ b/tests/basicswap/common.py
@@ -102,6 +102,9 @@ def prepareDataDir(
 
         if base_p2p_port == BTC_BASE_PORT:
             fp.write("deprecatedrpc=create_bdb\n")
+            fp.write("changetype=bech32\n")
+        elif base_p2p_port == LTC_BASE_PORT:
+            fp.write("changetype=bech32\n")
         elif base_p2p_port == BASE_PORT:  # Particl
             fp.write("zmqpubsmsg=tcp://127.0.0.1:{}\n".format(BASE_ZMQ_PORT + node_id))
             # minstakeinterval=5  # Using walletsettings stakelimit instead


### PR DESCRIPTION
Set changetype=bech32 in BTC and LTC .conf files.
Rewrite .conf files to add changetype at startup if possible.
Add combine_non_segwit_prevouts function to coin interface.
Add option to list non-segwit UTXOs and combine_non_segwit_prevouts to gui.
Add test for changetype and combine_non_segwit_prevouts.