### PR TITLE
GUI: Dynamic balances (WS) + Better Notifications (Toasts) + various fixes.

### DIFF
--- a/basicswap/basicswap.py
+++ b/basicswap/basicswap.py
@@ -206,14 +206,20 @@ def threadPollXMRChainState(swap_client, coin_type):
                         cached_balance = cc.get("cached_balance", None)
                         cached_total_balance = cc.get("cached_total_balance", None)
 
+                        current_unconfirmed = current_total_balance - current_balance
+                        cached_unconfirmed = cc.get("cached_unconfirmed", None)
+
                         if (
                             cached_balance is None
                             or current_balance != cached_balance
                             or cached_total_balance is None
                             or current_total_balance != cached_total_balance
+                            or cached_unconfirmed is None
+                            or current_unconfirmed != cached_unconfirmed
                         ):
                             cc["cached_balance"] = current_balance
                             cc["cached_total_balance"] = current_total_balance
+                            cc["cached_unconfirmed"] = current_unconfirmed
                             balance_event = {
                                 "event": "coin_balance_updated",
                                 "coin": ci.ticker(),
@@ -225,6 +231,7 @@ def threadPollXMRChainState(swap_client, coin_type):
                     except Exception:
                         cc["cached_balance"] = None
                         cc["cached_total_balance"] = None
+                        cc["cached_unconfirmed"] = None
 
         except Exception as e:
             swap_client.log.warning(
@@ -255,14 +262,20 @@ def threadPollWOWChainState(swap_client, coin_type):
                         cached_balance = cc.get("cached_balance", None)
                         cached_total_balance = cc.get("cached_total_balance", None)
 
+                        current_unconfirmed = current_total_balance - current_balance
+                        cached_unconfirmed = cc.get("cached_unconfirmed", None)
+
                         if (
                             cached_balance is None
                             or current_balance != cached_balance
                             or cached_total_balance is None
                             or current_total_balance != cached_total_balance
+                            or cached_unconfirmed is None
+                            or current_unconfirmed != cached_unconfirmed
                         ):
                             cc["cached_balance"] = current_balance
                             cc["cached_total_balance"] = current_total_balance
+                            cc["cached_unconfirmed"] = current_unconfirmed
                             balance_event = {
                                 "event": "coin_balance_updated",
                                 "coin": ci.ticker(),
@@ -274,6 +287,7 @@ def threadPollWOWChainState(swap_client, coin_type):
                     except Exception:
                         cc["cached_balance"] = None
                         cc["cached_total_balance"] = None
+                        cc["cached_unconfirmed"] = None
 
         except Exception as e:
             swap_client.log.warning(
@@ -308,14 +322,20 @@ def threadPollChainState(swap_client, coin_type):
                         cached_balance = cc.get("cached_balance", None)
                         cached_total_balance = cc.get("cached_total_balance", None)
 
+                        current_unconfirmed = current_total_balance - current_balance
+                        cached_unconfirmed = cc.get("cached_unconfirmed", None)
+
                         if (
                             cached_balance is None
                             or current_balance != cached_balance
                             or cached_total_balance is None
                             or current_total_balance != cached_total_balance
+                            or cached_unconfirmed is None
+                            or current_unconfirmed != cached_unconfirmed
                         ):
                             cc["cached_balance"] = current_balance
                             cc["cached_total_balance"] = current_total_balance
+                            cc["cached_unconfirmed"] = current_unconfirmed
                             balance_event = {
                                 "event": "coin_balance_updated",
                                 "coin": ci.ticker(),
@@ -327,6 +347,7 @@ def threadPollChainState(swap_client, coin_type):
                     except Exception:
                         cc["cached_balance"] = None
                         cc["cached_total_balance"] = None
+                        cc["cached_unconfirmed"] = None
 
         except Exception as e:
             swap_client.log.warning(f"threadPollChainState {ci.ticker()}, error: {e}")
@@ -10946,6 +10967,76 @@ class BasicSwap(BaseApp, UIApp):
                         seen_tickers.append(upcased_ticker)
                 if settings_copy.get("enabled_chart_coins", "") != new_value:
                     settings_copy["enabled_chart_coins"] = new_value
+                    settings_changed = True
+
+            if "notifications_new_offers" in data:
+                new_value = data["notifications_new_offers"]
+                ensure(
+                    isinstance(new_value, bool),
+                    "New notifications_new_offers value not boolean",
+                )
+                if settings_copy.get("notifications_new_offers", False) != new_value:
+                    settings_copy["notifications_new_offers"] = new_value
+                    settings_changed = True
+
+            if "notifications_new_bids" in data:
+                new_value = data["notifications_new_bids"]
+                ensure(
+                    isinstance(new_value, bool),
+                    "New notifications_new_bids value not boolean",
+                )
+                if settings_copy.get("notifications_new_bids", True) != new_value:
+                    settings_copy["notifications_new_bids"] = new_value
+                    settings_changed = True
+
+            if "notifications_bid_accepted" in data:
+                new_value = data["notifications_bid_accepted"]
+                ensure(
+                    isinstance(new_value, bool),
+                    "New notifications_bid_accepted value not boolean",
+                )
+                if settings_copy.get("notifications_bid_accepted", True) != new_value:
+                    settings_copy["notifications_bid_accepted"] = new_value
+                    settings_changed = True
+
+            if "notifications_balance_changes" in data:
+                new_value = data["notifications_balance_changes"]
+                ensure(
+                    isinstance(new_value, bool),
+                    "New notifications_balance_changes value not boolean",
+                )
+                if (
+                    settings_copy.get("notifications_balance_changes", True)
+                    != new_value
+                ):
+                    settings_copy["notifications_balance_changes"] = new_value
+                    settings_changed = True
+
+            if "notifications_outgoing_transactions" in data:
+                new_value = data["notifications_outgoing_transactions"]
+                ensure(
+                    isinstance(new_value, bool),
+                    "New notifications_outgoing_transactions value not boolean",
+                )
+                if (
+                    settings_copy.get("notifications_outgoing_transactions", True)
+                    != new_value
+                ):
+                    settings_copy["notifications_outgoing_transactions"] = new_value
+                    settings_changed = True
+
+            if "notifications_duration" in data:
+                new_value = data["notifications_duration"]
+                ensure(
+                    isinstance(new_value, int),
+                    "New notifications_duration value not integer",
+                )
+                ensure(
+                    5 <= new_value <= 60,
+                    "notifications_duration must be between 5 and 60 seconds",
+                )
+                if settings_copy.get("notifications_duration", 20) != new_value:
+                    settings_copy["notifications_duration"] = new_value
                     settings_changed = True
 
             if settings_changed:

--- a/basicswap/basicswap.py
+++ b/basicswap/basicswap.py
@@ -198,6 +198,25 @@ def threadPollXMRChainState(swap_client, coin_type):
                 )
                 with swap_client.mxDB:
                     cc["chain_height"] = new_height
+
+                if swap_client.ws_server:
+                    try:
+                        current_balance = ci.getSpendableBalance()
+                        cached_balance = cc.get("cached_balance", None)
+
+                        if cached_balance is None or current_balance != cached_balance:
+                            cc["cached_balance"] = current_balance
+                            balance_event = {
+                                "event": "coin_balance_updated",
+                                "coin": ci.ticker(),
+                                "height": new_height,
+                            }
+                            swap_client.ws_server.send_message_to_all(
+                                json.dumps(balance_event)
+                            )
+                    except Exception as e:
+                        cc["cached_balance"] = None
+
         except Exception as e:
             swap_client.log.warning(
                 f"threadPollXMRChainState {ci.ticker()}, error: {e}"
@@ -219,6 +238,25 @@ def threadPollWOWChainState(swap_client, coin_type):
                 )
                 with swap_client.mxDB:
                     cc["chain_height"] = new_height
+
+                if swap_client.ws_server:
+                    try:
+                        current_balance = ci.getSpendableBalance()
+                        cached_balance = cc.get("cached_balance", None)
+
+                        if cached_balance is None or current_balance != cached_balance:
+                            cc["cached_balance"] = current_balance
+                            balance_event = {
+                                "event": "coin_balance_updated",
+                                "coin": ci.ticker(),
+                                "height": new_height,
+                            }
+                            swap_client.ws_server.send_message_to_all(
+                                json.dumps(balance_event)
+                            )
+                    except Exception as e:
+                        cc["cached_balance"] = None
+
         except Exception as e:
             swap_client.log.warning(
                 f"threadPollWOWChainState {ci.ticker()}, error: {e}"
@@ -244,6 +282,25 @@ def threadPollChainState(swap_client, coin_type):
                     cc["chain_best_block"] = chain_state["bestblockhash"]
                     if "mediantime" in chain_state:
                         cc["chain_median_time"] = chain_state["mediantime"]
+
+                if swap_client.ws_server:
+                    try:
+                        current_balance = ci.getSpendableBalance()
+                        cached_balance = cc.get("cached_balance", None)
+
+                        if cached_balance is None or current_balance != cached_balance:
+                            cc["cached_balance"] = current_balance
+                            balance_event = {
+                                "event": "coin_balance_updated",
+                                "coin": ci.ticker(),
+                                "height": new_height,
+                            }
+                            swap_client.ws_server.send_message_to_all(
+                                json.dumps(balance_event)
+                            )
+                    except Exception as e:
+                        cc["cached_balance"] = None
+
         except Exception as e:
             swap_client.log.warning(f"threadPollChainState {ci.ticker()}, error: {e}")
         swap_client.chainstate_delay_event.wait(

--- a/basicswap/basicswap.py
+++ b/basicswap/basicswap.py
@@ -214,7 +214,7 @@ def threadPollXMRChainState(swap_client, coin_type):
                             swap_client.ws_server.send_message_to_all(
                                 json.dumps(balance_event)
                             )
-                    except Exception as e:
+                    except Exception:
                         cc["cached_balance"] = None
 
         except Exception as e:
@@ -254,7 +254,7 @@ def threadPollWOWChainState(swap_client, coin_type):
                             swap_client.ws_server.send_message_to_all(
                                 json.dumps(balance_event)
                             )
-                    except Exception as e:
+                    except Exception:
                         cc["cached_balance"] = None
 
         except Exception as e:
@@ -298,7 +298,7 @@ def threadPollChainState(swap_client, coin_type):
                             swap_client.ws_server.send_message_to_all(
                                 json.dumps(balance_event)
                             )
-                    except Exception as e:
+                    except Exception:
                         cc["cached_balance"] = None
 
         except Exception as e:

--- a/basicswap/bin/prepare.py
+++ b/basicswap/bin/prepare.py
@@ -1382,6 +1382,11 @@ def prepareDataDir(coin, settings, chain, particl_mnemonic, extra_opts={}):
             fp.write(
                 "zmqpubsmsg=tcp://{}:{}\n".format(COINS_RPCBIND_IP, settings["zmqport"])
             )
+            fp.write(
+                "zmqpubhashwtx=tcp://{}:{}\n".format(
+                    COINS_RPCBIND_IP, settings["zmqport"]
+                )
+            )
             fp.write("spentindex=1\n")
             fp.write("txindex=1\n")
             fp.write("staking=0\n")

--- a/basicswap/js_server.py
+++ b/basicswap/js_server.py
@@ -232,8 +232,18 @@ def js_walletbalances(self, url_split, post_string, is_json) -> bytes:
                             if "mweb_balance" in w:
                                 variant_balance = w["mweb_balance"]
 
-                            if "mweb_pending" in w and float(w["mweb_pending"]) > 0.0:
-                                variant_pending = str(w["mweb_pending"])
+                            pending_amount = 0
+                            if (
+                                "mweb_unconfirmed" in w
+                                and float(w["mweb_unconfirmed"]) > 0.0
+                            ):
+                                pending_amount += float(w["mweb_unconfirmed"])
+                            if "mweb_immature" in w and float(w["mweb_immature"]) > 0.0:
+                                pending_amount += float(w["mweb_immature"])
+                            if pending_amount > 0:
+                                variant_pending = f"{pending_amount:.8f}".rstrip(
+                                    "0"
+                                ).rstrip(".")
 
                     variant_entry = {
                         "id": int(Coins.LTC_MWEB),

--- a/basicswap/js_server.py
+++ b/basicswap/js_server.py
@@ -243,6 +243,8 @@ def js_walletbalances(self, url_split, post_string, is_json) -> bytes:
                         "ticker": chainparams[Coins.LTC]["ticker"],
                     }
 
+                    coins_with_balances.append(variant_entry)
+
         return bytes(json.dumps(coins_with_balances), "UTF-8")
 
     except Exception as e:

--- a/basicswap/js_server.py
+++ b/basicswap/js_server.py
@@ -141,7 +141,13 @@ def js_walletbalances(self, url_split, post_string, is_json) -> bytes:
                 if k in wallets:
                     w = wallets[k]
                     if "balance" in w and "error" not in w and "no_data" not in w:
-                        balance = w["balance"]
+                        raw_balance = w["balance"]
+                        if isinstance(raw_balance, float):
+                            balance = f"{raw_balance:.8f}".rstrip("0").rstrip(".")
+                        elif isinstance(raw_balance, int):
+                            balance = str(raw_balance)
+                        else:
+                            balance = raw_balance
 
                 pending = "0.0"
                 if k in wallets:
@@ -188,7 +194,15 @@ def js_walletbalances(self, url_split, post_string, is_json) -> bytes:
                             w = wallets[k]
                             if "error" not in w and "no_data" not in w:
                                 if variant_info["balance_field"] in w:
-                                    variant_balance = w[variant_info["balance_field"]]
+                                    raw_balance = w[variant_info["balance_field"]]
+                                    if isinstance(raw_balance, float):
+                                        variant_balance = f"{raw_balance:.8f}".rstrip(
+                                            "0"
+                                        ).rstrip(".")
+                                    elif isinstance(raw_balance, int):
+                                        variant_balance = str(raw_balance)
+                                    else:
+                                        variant_balance = raw_balance
 
                                 if (
                                     variant_info["pending_field"] in w

--- a/basicswap/static/css/style.css
+++ b/basicswap/static/css/style.css
@@ -14,6 +14,62 @@
     z-index: 9999;
 }
 
+/* Toast Notification Animations */
+.toast-slide-in {
+    animation: slideInRight 0.3s ease-out;
+}
+
+.toast-slide-out {
+    animation: slideOutRight 0.3s ease-in forwards;
+}
+
+@keyframes slideInRight {
+    from {
+        transform: translateX(100%);
+        opacity: 0;
+    }
+    to {
+        transform: translateX(0);
+        opacity: 1;
+    }
+}
+
+@keyframes slideOutRight {
+    from {
+        transform: translateX(0);
+        opacity: 1;
+    }
+    to {
+        transform: translateX(100%);
+        opacity: 0;
+    }
+}
+
+/* Toast Container Styles */
+#ul_updates {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    max-width: 400px;
+}
+
+#ul_updates li {
+    margin-bottom: 0.5rem;
+}
+
+/* Toast Hover Effects */
+#ul_updates .bg-white:hover {
+    box-shadow: 0 10px 25px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -2px rgba(0, 0, 0, 0.05);
+    transform: translateY(-1px);
+    transition: all 0.2s ease-in-out;
+}
+
+.dark #ul_updates .dark\:bg-gray-800:hover {
+    box-shadow: 0 10px 25px -3px rgba(0, 0, 0, 0.3), 0 4px 6px -2px rgba(0, 0, 0, 0.2);
+    transform: translateY(-1px);
+    transition: all 0.2s ease-in-out;
+}
+
 /* Table Styles */
 .padded_row td {
     padding-top: 1.5em;

--- a/basicswap/static/js/modules/balance-updates.js
+++ b/basicswap/static/js/modules/balance-updates.js
@@ -1,0 +1,216 @@
+const BalanceUpdatesManager = (function() {
+  'use strict';
+
+  const config = {
+    balanceUpdateDelay: 2000,
+    swapEventDelay: 5000,
+    periodicRefreshInterval: 120000,
+    walletPeriodicRefreshInterval: 60000,
+  };
+
+  const state = {
+    handlers: new Map(),
+    timeouts: new Map(),
+    intervals: new Map(),
+    initialized: false
+  };
+
+  function fetchBalanceData() {
+    return fetch('/json/walletbalances', {
+      headers: {
+        'Accept': 'application/json',
+        'Content-Type': 'application/json'
+      }
+    })
+    .then(response => {
+      if (!response.ok) {
+        throw new Error(`Server error: ${response.status} ${response.statusText}`);
+      }
+      return response.json();
+    })
+    .then(balanceData => {
+      if (balanceData.error) {
+        throw new Error(balanceData.error);
+      }
+
+      if (!Array.isArray(balanceData)) {
+        throw new Error('Invalid response format');
+      }
+
+      return balanceData;
+    });
+  }
+
+  function clearTimeoutByKey(key) {
+    if (state.timeouts.has(key)) {
+      clearTimeout(state.timeouts.get(key));
+      state.timeouts.delete(key);
+    }
+  }
+
+  function setTimeoutByKey(key, callback, delay) {
+    clearTimeoutByKey(key);
+    const timeoutId = setTimeout(callback, delay);
+    state.timeouts.set(key, timeoutId);
+  }
+
+  function clearIntervalByKey(key) {
+    if (state.intervals.has(key)) {
+      clearInterval(state.intervals.get(key));
+      state.intervals.delete(key);
+    }
+  }
+
+  function setIntervalByKey(key, callback, interval) {
+    clearIntervalByKey(key);
+    const intervalId = setInterval(callback, interval);
+    state.intervals.set(key, intervalId);
+  }
+
+  function handleBalanceUpdate(contextKey, updateCallback, errorContext) {
+    clearTimeoutByKey(`${contextKey}_balance_update`);
+    setTimeoutByKey(`${contextKey}_balance_update`, () => {
+      fetchBalanceData()
+        .then(balanceData => {
+          updateCallback(balanceData);
+        })
+        .catch(error => {
+          console.error(`Error updating ${errorContext} balances via WebSocket:`, error);
+        });
+    }, config.balanceUpdateDelay);
+  }
+
+  function handleSwapEvent(contextKey, updateCallback, errorContext) {
+    clearTimeoutByKey(`${contextKey}_swap_event`);
+    setTimeoutByKey(`${contextKey}_swap_event`, () => {
+      fetchBalanceData()
+        .then(balanceData => {
+          updateCallback(balanceData);
+        })
+        .catch(error => {
+          console.error(`Error updating ${errorContext} balances via swap event:`, error);
+        });
+    }, config.swapEventDelay);
+  }
+
+  function setupWebSocketHandler(contextKey, balanceUpdateCallback, swapEventCallback, errorContext) {
+    const handlerId = window.WebSocketManager.addMessageHandler('message', (data) => {
+      if (data && data.event) {
+        if (data.event === 'coin_balance_updated') {
+          handleBalanceUpdate(contextKey, balanceUpdateCallback, errorContext);
+        }
+
+        if (swapEventCallback) {
+          const swapEvents = ['new_bid', 'bid_accepted', 'swap_completed'];
+          if (swapEvents.includes(data.event)) {
+            handleSwapEvent(contextKey, swapEventCallback, errorContext);
+          }
+        }
+      }
+    });
+
+    state.handlers.set(contextKey, handlerId);
+    return handlerId;
+  }
+
+  function setupPeriodicRefresh(contextKey, updateCallback, errorContext, interval) {
+    const refreshInterval = interval || config.periodicRefreshInterval;
+
+    setIntervalByKey(`${contextKey}_periodic`, () => {
+      fetchBalanceData()
+        .then(balanceData => {
+          updateCallback(balanceData);
+        })
+        .catch(error => {
+          console.error(`Error in periodic ${errorContext} balance refresh:`, error);
+        });
+    }, refreshInterval);
+  }
+
+  function cleanup(contextKey) {
+    if (state.handlers.has(contextKey)) {
+      const handlerId = state.handlers.get(contextKey);
+      if (window.WebSocketManager && typeof window.WebSocketManager.removeMessageHandler === 'function') {
+        window.WebSocketManager.removeMessageHandler('message', handlerId);
+      }
+      state.handlers.delete(contextKey);
+    }
+
+    clearTimeoutByKey(`${contextKey}_balance_update`);
+    clearTimeoutByKey(`${contextKey}_swap_event`);
+
+    clearIntervalByKey(`${contextKey}_periodic`);
+  }
+
+  function cleanupAll() {
+    state.handlers.forEach((handlerId) => {
+      if (window.WebSocketManager && typeof window.WebSocketManager.removeMessageHandler === 'function') {
+        window.WebSocketManager.removeMessageHandler('message', handlerId);
+      }
+    });
+    state.handlers.clear();
+
+    state.timeouts.forEach(timeoutId => clearTimeout(timeoutId));
+    state.timeouts.clear();
+
+    state.intervals.forEach(intervalId => clearInterval(intervalId));
+    state.intervals.clear();
+
+    state.initialized = false;
+  }
+
+  return {
+    initialize: function() {
+      if (state.initialized) {
+        return this;
+      }
+
+      if (window.CleanupManager) {
+        window.CleanupManager.registerResource('balanceUpdatesManager', this, (mgr) => mgr.dispose());
+      }
+
+      window.addEventListener('beforeunload', cleanupAll);
+
+      state.initialized = true;
+      console.log('BalanceUpdatesManager initialized');
+      return this;
+    },
+
+    setup: function(options) {
+      const {
+        contextKey,
+        balanceUpdateCallback,
+        swapEventCallback,
+        errorContext,
+        enablePeriodicRefresh = false,
+        periodicInterval
+      } = options;
+
+      if (!contextKey || !balanceUpdateCallback || !errorContext) {
+        throw new Error('Missing required options: contextKey, balanceUpdateCallback, errorContext');
+      }
+
+      setupWebSocketHandler(contextKey, balanceUpdateCallback, swapEventCallback, errorContext);
+
+      if (enablePeriodicRefresh) {
+        setupPeriodicRefresh(contextKey, balanceUpdateCallback, errorContext, periodicInterval);
+      }
+
+      return this;
+    },
+
+    fetchBalanceData: fetchBalanceData,
+
+    cleanup: cleanup,
+
+    dispose: cleanupAll,
+
+    isInitialized: function() {
+      return state.initialized;
+    }
+  };
+})();
+
+if (typeof window !== 'undefined') {
+  window.BalanceUpdatesManager = BalanceUpdatesManager;
+}

--- a/basicswap/static/js/modules/notification-manager.js
+++ b/basicswap/static/js/modules/notification-manager.js
@@ -1,10 +1,39 @@
 const NotificationManager = (function() {
 
-  const config = {
+
+  const defaultConfig = {
     showNewOffers: false,
     showNewBids: true,
-    showBidAccepted: true
+    showBidAccepted: true,
+    showBalanceChanges: true,
+    showOutgoingTransactions: true,
+    notificationDuration: 20000
   };
+
+
+  function loadConfig() {
+    const saved = localStorage.getItem('notification_settings');
+    if (saved) {
+      try {
+        return { ...defaultConfig, ...JSON.parse(saved) };
+      } catch (e) {
+        console.error('Error loading notification settings:', e);
+      }
+    }
+    return { ...defaultConfig };
+  }
+
+
+  function saveConfig(newConfig) {
+    try {
+      localStorage.setItem('notification_settings', JSON.stringify(newConfig));
+      Object.assign(config, newConfig);
+    } catch (e) {
+      console.error('Error saving notification settings:', e);
+    }
+  }
+
+  let config = loadConfig();
 
   function ensureToastContainer() {
     let container = document.getElementById('ul_updates');
@@ -19,13 +48,67 @@ const NotificationManager = (function() {
     return container;
   }
 
+  function getCoinIcon(coinSymbol) {
+    if (window.CoinManager && typeof window.CoinManager.getCoinIcon === 'function') {
+      return window.CoinManager.getCoinIcon(coinSymbol);
+    }
+    return 'default.png';
+  }
+
+  function getToastIcon(type) {
+    const icons = {
+      'new_offer': `<svg class="w-5 h-5" fill="currentColor" viewBox="0 0 20 20">
+        <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clip-rule="evenodd"></path>
+      </svg>`,
+      'new_bid': `<svg class="w-5 h-5" fill="currentColor" viewBox="0 0 20 20">
+        <path fill-rule="evenodd" d="M3 4a1 1 0 011-1h12a1 1 0 110 2H4a1 1 0 01-1-1zm0 4a1 1 0 011-1h12a1 1 0 110 2H4a1 1 0 01-1-1zm0 4a1 1 0 011-1h12a1 1 0 110 2H4a1 1 0 01-1-1z" clip-rule="evenodd"></path>
+      </svg>`,
+      'bid_accepted': `<svg class="w-5 h-5" fill="currentColor" viewBox="0 0 20 20">
+        <path fill-rule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clip-rule="evenodd"></path>
+      </svg>`,
+      'balance_change': `<svg class="w-5 h-5" fill="currentColor" viewBox="0 0 20 20">
+        <path fill-rule="evenodd" d="M4 4a2 2 0 00-2 2v4a2 2 0 002 2V6h10a2 2 0 00-2-2H4zm2 6a2 2 0 012-2h8a2 2 0 012 2v4a2 2 0 01-2 2H8a2 2 0 01-2-2v-4zm6 4a2 2 0 100-4 2 2 0 000 4z" clip-rule="evenodd"></path>
+      </svg>`,
+      'success': `<svg class="w-5 h-5" fill="currentColor" viewBox="0 0 20 20">
+        <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clip-rule="evenodd"></path>
+      </svg>`
+    };
+    return icons[type] || icons['success'];
+  }
+
+  function getToastColor(type, options = {}) {
+    const colors = {
+      'new_offer': 'bg-blue-500',
+      'new_bid': 'bg-green-500',
+      'bid_accepted': 'bg-purple-500',
+      'balance_change': 'bg-yellow-500',
+      'success': 'bg-blue-500'
+    };
+
+    if (type === 'balance_change' && options.subtitle) {
+      if (options.subtitle.includes('sent') || options.subtitle.includes('sending')) {
+        return 'bg-red-500';
+      } else {
+        return 'bg-green-500';
+      }
+    }
+
+    return colors[type] || colors['success'];
+  }
+
   const publicAPI = {
     initialize: function(options = {}) {
       Object.assign(config, options);
 
+
+      this.initializeBalanceTracking();
+
       if (window.CleanupManager) {
         window.CleanupManager.registerResource('notificationManager', this, (mgr) => {
-
+  
+          if (this.balanceTimeouts) {
+            Object.values(this.balanceTimeouts).forEach(timeout => clearTimeout(timeout));
+          }
           console.log('NotificationManager disposed');
         });
       }
@@ -33,33 +116,162 @@ const NotificationManager = (function() {
       return this;
     },
 
-    createToast: function(title, type = 'success') {
+    updateSettings: function(newSettings) {
+      saveConfig(newSettings);
+      return this;
+    },
+
+    getSettings: function() {
+      return { ...config };
+    },
+
+    testToasts: function() {
+      if (!this.createToast) return;
+
+      setTimeout(() => {
+        this.createToast(
+          '+0.05000000 PART',
+          'balance_change',
+          { coinSymbol: 'PART', subtitle: 'Incoming funds pending' }
+        );
+      }, 500);
+
+      setTimeout(() => {
+        this.createToast(
+          '+0.00123456 XMR',
+          'balance_change',
+          { coinSymbol: 'XMR', subtitle: 'Incoming funds confirmed' }
+        );
+      }, 1000);
+
+      setTimeout(() => {
+        this.createToast(
+          '-29.86277595 PART',
+          'balance_change',
+          { coinSymbol: 'PART', subtitle: 'Funds sent' }
+        );
+      }, 1500);
+
+      setTimeout(() => {
+        this.createToast(
+          '-0.05000000 PART (Anon)',
+          'balance_change',
+          { coinSymbol: 'PART', subtitle: 'Funds sending' }
+        );
+      }, 2000);
+
+      setTimeout(() => {
+        this.createToast(
+          '+1.23456789 PART (Anon)',
+          'balance_change',
+          { coinSymbol: 'PART', subtitle: 'Incoming funds confirmed' }
+        );
+      }, 2500);
+
+      setTimeout(() => {
+        this.createToast(
+          'New network offer',
+          'new_offer',
+          { offerId: '000000006873f4ef17d4f220730400f4fdd57157492289c5d414ea66', subtitle: 'Click to view offer' }
+        );
+      }, 3000);
+
+      setTimeout(() => {
+        this.createToast(
+          'New bid received',
+          'new_bid',
+          { bidId: '000000006873f4ef17d4f220730400f4fdd57157492289c5d414ea66', subtitle: 'Click to view bid' }
+        );
+      }, 3500);
+    },
+
+
+
+    initializeBalanceTracking: function() {
+
+      fetch('/json/walletbalances')
+        .then(response => response.json())
+        .then(balanceData => {
+          if (Array.isArray(balanceData)) {
+            balanceData.forEach(coin => {
+              const balance = parseFloat(coin.balance) || 0;
+              const pending = parseFloat(coin.pending) || 0;
+
+              const coinKey = coin.name.replace(/\s+/g, '_');
+              const storageKey = `prev_balance_${coinKey}`;
+              const pendingStorageKey = `prev_pending_${coinKey}`;
+
+
+              if (!localStorage.getItem(storageKey)) {
+                localStorage.setItem(storageKey, balance.toString());
+              }
+              if (!localStorage.getItem(pendingStorageKey)) {
+                localStorage.setItem(pendingStorageKey, pending.toString());
+              }
+            });
+          }
+        })
+        .catch(error => {
+          console.error('Error initializing balance tracking:', error);
+        });
+    },
+
+    createToast: function(title, type = 'success', options = {}) {
       const messages = ensureToastContainer();
       const message = document.createElement('li');
+      const toastId = `toast-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`;
+      const iconColor = getToastColor(type, options);
+      const icon = getToastIcon(type);
+
+
+      let coinIconHtml = '';
+      if (options.coinSymbol) {
+        const coinIcon = getCoinIcon(options.coinSymbol);
+        coinIconHtml = `<img src="/static/images/coins/${coinIcon}" class="w-5 h-5 mr-2" alt="${options.coinSymbol}" onerror="this.style.display='none'">`;
+      }
+
+
+      let clickAction = '';
+      let cursorStyle = 'cursor-default';
+
+      if (options.offerId) {
+        clickAction = `onclick="window.location.href='/offer/${options.offerId}'"`;
+        cursorStyle = 'cursor-pointer';
+      } else if (options.bidId) {
+        clickAction = `onclick="window.location.href='/bid/${options.bidId}'"`;
+        cursorStyle = 'cursor-pointer';
+      } else if (options.coinSymbol) {
+
+        const coinParam = options.coinSymbol.toLowerCase();
+        clickAction = `onclick="window.location.href='/wallet/${coinParam}'"`;
+        cursorStyle = 'cursor-pointer';
+      }
+
       message.innerHTML = `
-        <div id="hide">
-          <div id="toast-${type}" class="flex items-center p-4 mb-4 w-full max-w-xs text-gray-500 
-            bg-white rounded-lg shadow" role="alert">
-            <div class="inline-flex flex-shrink-0 justify-center items-center w-10 h-10 
-              bg-blue-500 rounded-lg">
-              <svg class="w-5 h-5" xmlns="http://www.w3.org/2000/svg" height="18" width="18" 
-                viewBox="0 0 24 24">
-                <g fill="#ffffff">
-                  <path d="M8.5,20a1.5,1.5,0,0,1-1.061-.439L.379,12.5,2.5,10.379l6,6,13-13L23.621,
-                    5.5,9.561,19.561A1.5,1.5,0,0,1,8.5,20Z"></path>
-                </g>
-              </svg>
+        <div class="toast-slide-in">
+          <div id="${toastId}" class="flex items-center p-4 mb-3 w-full max-w-sm text-gray-500
+            bg-white dark:bg-gray-800 dark:text-gray-400 rounded-lg shadow-lg border border-gray-200
+            dark:border-gray-700 ${cursorStyle} hover:shadow-xl transition-shadow" role="alert" ${clickAction}>
+            <div class="inline-flex flex-shrink-0 justify-center items-center w-10 h-10
+              ${iconColor} rounded-lg text-white">
+              ${icon}
             </div>
-            <div class="uppercase w-40 ml-3 text-sm font-semibold text-gray-900">${title}</div>
-            <button type="button" onclick="closeAlert(event)" class="ml-auto -mx-1.5 -my-1.5 
-              bg-white text-gray-400 hover:text-gray-900 rounded-lg focus:ring-0 focus:outline-none 
-              focus:ring-gray-300 p-1.5 hover:bg-gray-100 inline-flex h-8 w-8">
+            <div class="flex items-center ml-3 text-sm font-medium text-gray-900 dark:text-white">
+              ${coinIconHtml}
+              <div class="flex flex-col">
+                <span class="font-semibold">${title}</span>
+                ${options.subtitle ? `<span class="text-xs text-gray-500 dark:text-gray-400">${options.subtitle}</span>` : ''}
+              </div>
+            </div>
+            <button type="button" onclick="event.stopPropagation(); closeAlert(event)" class="ml-auto -mx-1.5 -my-1.5
+              bg-white dark:bg-gray-800 text-gray-400 hover:text-gray-900 dark:hover:text-white
+              rounded-lg p-1.5 hover:bg-gray-100 dark:hover:bg-gray-700 inline-flex h-8 w-8 transition-colors
+              focus:outline-none">
               <span class="sr-only">Close</span>
-              <svg aria-hidden="true" class="w-5 h-5" fill="currentColor" viewBox="0 0 20 20" 
-                xmlns="http://www.w3.org/2000/svg">
-                <path fill-rule="evenodd" d="M4.293 4.293a1 1 0 011.414 0L10 8.586l4.293-4.293a1 
-                  1 0 111.414 1.414L11.414 10l4.293 4.293a1 1 0 01-1.414 1.414L10 11.414l-4.293 
-                  4.293a1 1 0 01-1.414-1.414L8.586 10 4.293 5.707a1 1 0 010-1.414z" 
+              <svg aria-hidden="true" class="w-5 h-5" fill="currentColor" viewBox="0 0 20 20">
+                <path fill-rule="evenodd" d="M4.293 4.293a1 1 0 011.414 0L10 8.586l4.293-4.293a1
+                  1 0 111.414 1.414L11.414 10l4.293 4.293a1 1 0 01-1.414 1.414L10 11.414l-4.293
+                  4.293a1 1 0 01-1.414-1.414L8.586 10 4.293 5.707a1 1 0 010-1.414z"
                   clip-rule="evenodd"></path>
               </svg>
             </button>
@@ -67,33 +279,205 @@ const NotificationManager = (function() {
         </div>
       `;
       messages.appendChild(message);
+
+
+      setTimeout(() => {
+        if (message.parentNode) {
+          message.classList.add('toast-slide-out');
+          setTimeout(() => {
+            if (message.parentNode) {
+              message.parentNode.removeChild(message);
+            }
+          }, 300);
+        }
+      }, config.notificationDuration);
     },
 
     handleWebSocketEvent: function(data) {
       if (!data || !data.event) return;
-      let toastTitle;
+      let toastTitle, toastType, toastOptions = {};
       let shouldShowToast = false;
 
       switch (data.event) {
         case 'new_offer':
-          toastTitle = `New network <a class="underline" href=/offer/${data.offer_id}>offer</a>`;
+          toastTitle = `New network offer`;
+          toastType = 'new_offer';
+          toastOptions.offerId = data.offer_id;
+          toastOptions.subtitle = 'Click to view offer';
           shouldShowToast = config.showNewOffers;
           break;
         case 'new_bid':
-          toastTitle = `<a class="underline" href=/bid/${data.bid_id}>New bid</a> on 
-            <a class="underline" href=/offer/${data.offer_id}>offer</a>`;
+          toastTitle = `New bid received`;
+          toastOptions.bidId = data.bid_id;
+          toastOptions.subtitle = 'Click to view bid';
+          toastType = 'new_bid';
           shouldShowToast = config.showNewBids;
           break;
         case 'bid_accepted':
-          toastTitle = `<a class="underline" href=/bid/${data.bid_id}>Bid</a> accepted`;
+          toastTitle = `Bid accepted`;
+          toastOptions.bidId = data.bid_id;
+          toastOptions.subtitle = 'Click to view swap';
+          toastType = 'bid_accepted';
           shouldShowToast = config.showBidAccepted;
           break;
+        case 'coin_balance_updated':
+          if (data.coin && config.showBalanceChanges) {
+            this.handleBalanceUpdate(data);
+          }
+          return;
       }
 
       if (toastTitle && shouldShowToast) {
-        this.createToast(toastTitle);
+        this.createToast(toastTitle, toastType, toastOptions);
       }
     },
+
+    handleBalanceUpdate: function(data) {
+      if (!data.coin) return;
+
+      this.fetchAndShowBalanceChange(data.coin);
+      const balanceKey = `balance_${data.coin}`;
+
+      if (this.balanceTimeouts && this.balanceTimeouts[balanceKey]) {
+        clearTimeout(this.balanceTimeouts[balanceKey]);
+      }
+
+      if (!this.balanceTimeouts) {
+        this.balanceTimeouts = {};
+      }
+
+      this.balanceTimeouts[balanceKey] = setTimeout(() => {
+        this.fetchAndShowBalanceChange(data.coin);
+      }, 2000);
+    },
+
+    fetchAndShowBalanceChange: function(coinSymbol) {
+
+      fetch('/json/walletbalances')
+        .then(response => response.json())
+        .then(balanceData => {
+          if (Array.isArray(balanceData)) {
+
+            let coinsToCheck;
+            if (coinSymbol === 'PART') {
+              coinsToCheck = balanceData.filter(coin => coin.ticker === 'PART');
+            } else if (coinSymbol === 'LTC') {
+              coinsToCheck = balanceData.filter(coin => coin.ticker === 'LTC');
+            } else {
+              coinsToCheck = balanceData.filter(coin =>
+                coin.ticker === coinSymbol ||
+                coin.name.toLowerCase() === coinSymbol.toLowerCase()
+              );
+            }
+
+            coinsToCheck.forEach(coinData => {
+              this.checkSingleCoinBalance(coinData, coinSymbol);
+            });
+          }
+        })
+        .catch(error => {
+          console.error('Error fetching balance for notification:', error);
+        });
+    },
+
+    checkSingleCoinBalance: function(coinData, originalCoinSymbol) {
+      const currentBalance = parseFloat(coinData.balance) || 0;
+      const currentPending = parseFloat(coinData.pending) || 0;
+
+      const coinKey = coinData.name.replace(/\s+/g, '_');
+      const storageKey = `prev_balance_${coinKey}`;
+      const pendingStorageKey = `prev_pending_${coinKey}`;
+      const prevBalance = parseFloat(localStorage.getItem(storageKey)) || 0;
+      const prevPending = parseFloat(localStorage.getItem(pendingStorageKey)) || 0;
+
+
+      const balanceIncrease = currentBalance - prevBalance;
+      const pendingIncrease = currentPending - prevPending;
+      const pendingDecrease = prevPending - currentPending;
+
+
+      const isPendingToConfirmed = pendingDecrease > 0.00000001 && balanceIncrease > 0.00000001;
+
+
+      const displaySymbol = originalCoinSymbol;
+      let variantInfo = '';
+
+      if (coinData.name !== 'Particl' && coinData.name.includes('Particl')) {
+
+        variantInfo = ` (${coinData.name.replace('Particl ', '')})`;
+      } else if (coinData.name !== 'Litecoin' && coinData.name.includes('Litecoin')) {
+
+        variantInfo = ` (${coinData.name.replace('Litecoin ', '')})`;
+      }
+
+      if (balanceIncrease > 0.00000001) {
+        const displayAmount = balanceIncrease.toFixed(8).replace(/\.?0+$/, '');
+        const subtitle = isPendingToConfirmed ? 'Funds confirmed' : 'Incoming funds confirmed';
+        this.createToast(
+          `+${displayAmount} ${displaySymbol}${variantInfo}`,
+          'balance_change',
+          {
+            coinSymbol: originalCoinSymbol,
+            subtitle: subtitle
+          }
+        );
+      }
+
+      if (balanceIncrease < -0.00000001 && config.showOutgoingTransactions) {
+        const displayAmount = Math.abs(balanceIncrease).toFixed(8).replace(/\.?0+$/, '');
+        this.createToast(
+          `-${displayAmount} ${displaySymbol}${variantInfo}`,
+          'balance_change',
+          {
+            coinSymbol: originalCoinSymbol,
+            subtitle: 'Funds sent'
+          }
+        );
+      }
+
+      if (pendingIncrease > 0.00000001) {
+        const displayAmount = pendingIncrease.toFixed(8).replace(/\.?0+$/, '');
+        this.createToast(
+          `+${displayAmount} ${displaySymbol}${variantInfo}`,
+          'balance_change',
+          {
+            coinSymbol: originalCoinSymbol,
+            subtitle: 'Incoming funds pending'
+          }
+        );
+      }
+
+      if (pendingIncrease < -0.00000001 && config.showOutgoingTransactions && !isPendingToConfirmed) {
+        const displayAmount = Math.abs(pendingIncrease).toFixed(8).replace(/\.?0+$/, '');
+        this.createToast(
+          `-${displayAmount} ${displaySymbol}${variantInfo}`,
+          'balance_change',
+          {
+            coinSymbol: originalCoinSymbol,
+            subtitle: 'Funds sending'
+          }
+        );
+      }
+
+
+      if (pendingDecrease > 0.00000001 && !isPendingToConfirmed) {
+        const displayAmount = pendingDecrease.toFixed(8).replace(/\.?0+$/, '');
+        this.createToast(
+          `${displayAmount} ${displaySymbol}${variantInfo}`,
+          'balance_change',
+          {
+            coinSymbol: originalCoinSymbol,
+            subtitle: 'Pending funds confirmed'
+          }
+        );
+      }
+
+
+      localStorage.setItem(storageKey, currentBalance.toString());
+      localStorage.setItem(pendingStorageKey, currentPending.toString());
+    },
+
+
 
     updateConfig: function(newConfig) {
       Object.assign(config, newConfig);
@@ -122,5 +506,5 @@ document.addEventListener('DOMContentLoaded', function() {
   }
 });
 
-//console.log('NotificationManager initialized with methods:', Object.keys(NotificationManager));
+
 console.log('NotificationManager initialized');

--- a/basicswap/static/js/modules/notification-manager.js
+++ b/basicswap/static/js/modules/notification-manager.js
@@ -241,9 +241,7 @@ const NotificationManager = (function() {
         clickAction = `onclick="window.location.href='/bid/${options.bidId}'"`;
         cursorStyle = 'cursor-pointer';
       } else if (options.coinSymbol) {
-
-        const coinParam = options.coinSymbol.toLowerCase();
-        clickAction = `onclick="window.location.href='/wallet/${coinParam}'"`;
+        clickAction = `onclick="window.location.href='/wallet/${options.coinSymbol}'"`;
         cursorStyle = 'cursor-pointer';
       }
 

--- a/basicswap/static/js/modules/price-manager.js
+++ b/basicswap/static/js/modules/price-manager.js
@@ -44,6 +44,7 @@ const PriceManager = (function() {
 
             setTimeout(() => this.getPrices(), 1500);
             isInitialized = true;
+            console.log('PriceManager initialized');
             return this;
         },
 
@@ -59,7 +60,7 @@ const PriceManager = (function() {
                 return fetchPromise;
             }
 
-            //console.log('PriceManager: Fetching latest prices.');
+
             lastFetchTime = Date.now();
             fetchPromise = this.fetchPrices()
                 .then(prices => {
@@ -166,14 +167,14 @@ const PriceManager = (function() {
 
                 const cachedData = CacheManager.get(PRICES_CACHE_KEY);
                 if (cachedData) {
-                    console.log('Using cached price data');
+
                     return cachedData.value;
                 }
 
                 try {
                     const existingCache = localStorage.getItem(PRICES_CACHE_KEY);
                     if (existingCache) {
-                        console.log('Using localStorage cached price data');
+
                         return JSON.parse(existingCache).value;
                     }
                 } catch (e) {
@@ -230,4 +231,4 @@ document.addEventListener('DOMContentLoaded', function() {
     }
 });
 
-console.log('PriceManager initialized');
+

--- a/basicswap/static/js/modules/summary-manager.js
+++ b/basicswap/static/js/modules/summary-manager.js
@@ -261,9 +261,12 @@ const SummaryManager = (function() {
       }
 
       if (data.event) {
-        publicAPI.fetchSummaryData()
-          .then(() => {})
-          .catch(() => {});
+        const summaryEvents = ['new_offer', 'offer_revoked', 'new_bid', 'bid_accepted', 'swap_completed'];
+        if (summaryEvents.includes(data.event)) {
+          publicAPI.fetchSummaryData()
+            .then(() => {})
+            .catch(() => {});
+        }
 
         if (window.NotificationManager && typeof window.NotificationManager.handleWebSocketEvent === 'function') {
           window.NotificationManager.handleWebSocketEvent(data);
@@ -334,9 +337,12 @@ const SummaryManager = (function() {
 
         wsManager.addMessageHandler('message', (data) => {
           if (data.event) {
-            this.fetchSummaryData()
-              .then(() => {})
-              .catch(() => {});
+            const summaryEvents = ['new_offer', 'offer_revoked', 'new_bid', 'bid_accepted', 'swap_completed'];
+            if (summaryEvents.includes(data.event)) {
+              this.fetchSummaryData()
+                .then(() => {})
+                .catch(() => {});
+            }
 
             if (window.NotificationManager && typeof window.NotificationManager.handleWebSocketEvent === 'function') {
               window.NotificationManager.handleWebSocketEvent(data);

--- a/basicswap/static/js/modules/wallet-manager.js
+++ b/basicswap/static/js/modules/wallet-manager.js
@@ -180,8 +180,29 @@ const WalletManager = (function() {
 
         if (coinSymbol) {
           if (coinName === 'Particl') {
-            const isBlind = el.closest('.flex')?.querySelector('h4')?.textContent?.includes('Blind');
-            const isAnon = el.closest('.flex')?.querySelector('h4')?.textContent?.includes('Anon');
+            let isBlind = false;
+            let isAnon = false;
+
+            const flexContainer = el.closest('.flex');
+            if (flexContainer) {
+              const h4Element = flexContainer.querySelector('h4');
+              if (h4Element) {
+                isBlind = h4Element.textContent?.includes('Blind');
+                isAnon = h4Element.textContent?.includes('Anon');
+              }
+            }
+
+            if (!isBlind && !isAnon) {
+              const parentRow = el.closest('tr');
+              if (parentRow) {
+                const labelCell = parentRow.querySelector('td:first-child');
+                if (labelCell) {
+                  isBlind = labelCell.textContent?.includes('Blind');
+                  isAnon = labelCell.textContent?.includes('Anon');
+                }
+              }
+            }
+
             const balanceType = isBlind ? 'blind' : isAnon ? 'anon' : 'public';
             localStorage.setItem(`particl-${balanceType}-amount`, amount.toString());
           } else if (coinName === 'Litecoin') {
@@ -248,8 +269,29 @@ const WalletManager = (function() {
         const usdValue = (amount * price).toFixed(2);
 
         if (coinName === 'Particl') {
-          const isBlind = el.closest('.flex')?.querySelector('h4')?.textContent?.includes('Blind');
-          const isAnon = el.closest('.flex')?.querySelector('h4')?.textContent?.includes('Anon');
+          let isBlind = false;
+          let isAnon = false;
+
+          const flexContainer = el.closest('.flex');
+          if (flexContainer) {
+            const h4Element = flexContainer.querySelector('h4');
+            if (h4Element) {
+              isBlind = h4Element.textContent?.includes('Blind');
+              isAnon = h4Element.textContent?.includes('Anon');
+            }
+          }
+
+          if (!isBlind && !isAnon) {
+            const parentRow = el.closest('tr');
+            if (parentRow) {
+              const labelCell = parentRow.querySelector('td:first-child');
+              if (labelCell) {
+                isBlind = labelCell.textContent?.includes('Blind');
+                isAnon = labelCell.textContent?.includes('Anon');
+              }
+            }
+          }
+
           const balanceType = isBlind ? 'blind' : isAnon ? 'anon' : 'public';
           localStorage.setItem(`particl-${balanceType}-last-value`, usdValue);
           localStorage.setItem(`particl-${balanceType}-amount`, amount.toString());

--- a/basicswap/static/js/new_offer.js
+++ b/basicswap/static/js/new_offer.js
@@ -443,7 +443,45 @@ const UIEnhancer = {
 
             const selectNameElement = select.nextElementSibling?.querySelector('.select-name');
             if (selectNameElement) {
-                selectNameElement.textContent = name;
+
+                if (select.id === 'coin_from' && name.includes(' - Balance: ')) {
+
+                    const parts = name.split(' - Balance: ');
+                    const coinName = parts[0];
+                    const balanceInfo = parts[1] || '';
+
+
+                    selectNameElement.innerHTML = '';
+                    selectNameElement.style.display = 'flex';
+                    selectNameElement.style.flexDirection = 'column';
+                    selectNameElement.style.alignItems = 'flex-start';
+                    selectNameElement.style.lineHeight = '1.2';
+
+
+                    const coinNameDiv = document.createElement('div');
+                    coinNameDiv.textContent = coinName;
+                    coinNameDiv.style.fontWeight = 'normal';
+                    coinNameDiv.style.color = 'inherit';
+
+
+                    const balanceDiv = document.createElement('div');
+                    balanceDiv.textContent = `Balance: ${balanceInfo}`;
+                    balanceDiv.style.fontSize = '0.75rem';
+                    balanceDiv.style.color = '#6b7280';
+                    balanceDiv.style.marginTop = '1px';
+
+                    selectNameElement.appendChild(coinNameDiv);
+                    selectNameElement.appendChild(balanceDiv);
+
+
+
+                } else {
+
+                    selectNameElement.textContent = name;
+                    selectNameElement.style.display = 'block';
+                    selectNameElement.style.flexDirection = '';
+                    selectNameElement.style.alignItems = '';
+                }
             }
 
             updateSelectCache(select);

--- a/basicswap/static/js/ui/bids-tab-navigation.js
+++ b/basicswap/static/js/ui/bids-tab-navigation.js
@@ -43,7 +43,7 @@
         });
 
         window.bidsTabNavigationInitialized = true;
-        console.log('Bids tab navigation initialized');
+        //console.log('Bids tab navigation initialized');
     }
 
     function handleInitialNavigation() {
@@ -54,14 +54,14 @@
         const tabToActivate = localStorage.getItem('bidsTabToActivate');
         
         if (tabToActivate) {
-            //console.log('Activating tab from localStorage:', tabToActivate);
+
             localStorage.removeItem('bidsTabToActivate');
             activateTabWithRetry('#' + tabToActivate);
         } else if (window.location.hash) {
-            //console.log('Activating tab from hash:', window.location.hash);
+
             activateTabWithRetry(window.location.hash);
         } else {
-            //console.log('Activating default tab: #all');
+
             activateTabWithRetry('#all');
         }
     }
@@ -73,10 +73,10 @@
         
         const hash = window.location.hash;
         if (hash) {
-            //console.log('Hash changed, activating tab:', hash);
+
             activateTabWithRetry(hash);
         } else {
-            //console.log('Hash cleared, activating default tab: #all');
+
             activateTabWithRetry('#all');
         }
     }
@@ -85,7 +85,7 @@
         const normalizedTabId = tabId.startsWith('#') ? tabId : '#' + tabId;
 
         if (normalizedTabId !== '#all' && normalizedTabId !== '#sent' && normalizedTabId !== '#received') {
-            //console.log('Invalid tab ID, defaulting to #all');
+
             activateTabWithRetry('#all');
             return;
         }
@@ -96,17 +96,17 @@
         
         if (!tabButton) {
             if (retryCount < 5) {
-                //console.log('Tab button not found, retrying...', retryCount + 1);
+
                 setTimeout(() => {
                     activateTabWithRetry(normalizedTabId, retryCount + 1);
                 }, 100);
             } else {
-                //console.error('Failed to find tab button after retries');
+
             }
             return;
         }
         
-        //console.log('Activating tab:', normalizedTabId);
+
 
         tabButton.click();
 
@@ -168,7 +168,7 @@
                                           (tabId === '#sent' ? 'sent' : 'received');
 
                 if (typeof window.updateBidsTable === 'function') {
-                    //console.log('Triggering data load for', tabId);
+
                     window.updateBidsTable();
                 }
             }

--- a/basicswap/templates/amm.html
+++ b/basicswap/templates/amm.html
@@ -51,12 +51,7 @@
             Add Bid
           </button>
           {% endif %}
-          <button id="refreshAmmTables" class="flex items-center px-4 py-2.5 bg-blue-600 hover:bg-blue-600 border-blue-500 font-medium text-sm text-white border rounded-md shadow-button focus:ring-0 focus:outline-none">
-            <svg class="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
-              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15"></path>
-            </svg>
-            Refresh
-          </button>
+
         </div>
       </div>
 
@@ -290,6 +285,7 @@
            <button type="submit" name="kill_orphans" value="1" class="inline-flex items-center px-3 py-1.5 bg-red-500 hover:bg-red-600 text-white text-xs font-medium rounded-md shadow-sm focus:ring-0 focus:outline-none" title="Kill orphaned AMM processes">
              Kill Orphans
            </button>
+
          </div>
          <p class="text-xs text-gray-500 dark:text-gray-400 mt-2">
            Use "Check Processes" to see running AMM processes. Use "Kill Orphans" to clean up duplicate processes. Use "Force Start" to automatically clean up and start fresh.
@@ -974,7 +970,7 @@
 
            if (localStorage.getItem('amm_create_default_refresh') === 'true') {
              localStorage.removeItem('amm_create_default_refresh');
-             console.log('[AMM] Page loaded after create default config - redirecting to fresh page');
+
 
              setTimeout(function() {
                window.location.href = window.location.pathname + window.location.search;
@@ -1066,7 +1062,7 @@
       <div class="absolute inset-0 bg-gray-500 opacity-75 dark:bg-gray-900 dark:opacity-90"></div>
     </div>
 
-    <div class="inline-block align-bottom bg-white dark:bg-gray-800 rounded-lg text-left overflow-hidden shadow-xl transform transition-all sm:my-8 sm:align-middle md:max-w-2xl md:w-full">
+    <div class="inline-block align-bottom bg-white dark:bg-gray-800 rounded-lg text-left overflow-visible shadow-xl transform transition-all sm:my-8 sm:align-middle md:max-w-2xl md:w-full">
       <div class="bg-white dark:bg-gray-800 px-4 pt-5 pb-4 sm:p-6 sm:pb-4">
         <div class="sm:flex sm:items-start">
           <div class="mt-3 text-center sm:mt-0 sm:text-left w-full">
@@ -1086,7 +1082,7 @@
                 </div>
 
                 <div class="grid grid-cols-2 gap-4">
-                  <div>
+                  <div class="min-h-[80px]">
                     <label for="add-amm-coin-from" class="block text-sm font-medium text-gray-700 dark:text-gray-300">Maker</label>
                     <div class="relative">
                       <svg class="absolute top-1/2 right-3 transform -translate-y-1/2 w-4 h-4 text-gray-400 pointer-events-none" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -1094,15 +1090,14 @@
                       </svg>
                       <select id="add-amm-coin-from" class="bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500 appearance-none">
                         {% for c in coins %}
-                        <option value="{{ c[1] }}" data-symbol="{{ c[0] }}">
-                          {{ c[1] }}
-                        </option>
+                        <option value="{{ c[1] }}" data-symbol="{{ c[0] }}" data-balance="{{ c[2] }}">{{ c[1] }}</option>
                         {% endfor %}
                       </select>
                     </div>
+
                   </div>
 
-                  <div>
+                  <div class="min-h-[80px]">
                     <label for="add-amm-coin-to" class="block text-sm font-medium text-gray-700 dark:text-gray-300">Taker</label>
                     <div class="relative">
                       <svg class="absolute top-1/2 right-3 transform -translate-y-1/2 w-4 h-4 text-gray-400 pointer-events-none" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -1110,12 +1105,11 @@
                       </svg>
                       <select id="add-amm-coin-to" class="bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500 appearance-none">
                         {% for c in coins %}
-                        <option value="{{ c[1] }}" data-symbol="{{ c[0] }}">
-                          {{ c[1] }}
-                        </option>
+                        <option value="{{ c[1] }}" data-symbol="{{ c[0] }}" data-balance="{{ c[2] }}">{{ c[1] }}</option>
                         {% endfor %}
                       </select>
                     </div>
+
                   </div>
                 </div>
 
@@ -1123,13 +1117,18 @@
                   <div>
                     <label for="add-amm-amount" class="block text-sm font-medium text-gray-700 dark:text-gray-300">Offer Amount <span class="text-red-500">*</span></label>
                     <input type="text" id="add-amm-amount" pattern="[0-9]*\.?[0-9]*" class="bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500" placeholder="0.0">
+                    <div class="mt-2 flex space-x-2">
+                      <button type="button" class="hidden md:block py-1 px-2 bg-blue-500 text-white text-xs rounded-md focus:outline-none" onclick="setAmmAmount(0.25, 'add-amm-amount')">25%</button>
+                      <button type="button" class="hidden md:block py-1 px-2 bg-blue-500 text-white text-xs rounded-md focus:outline-none" onclick="setAmmAmount(0.5, 'add-amm-amount')">50%</button>
+                      <button type="button" class="py-1 px-2 bg-blue-500 text-white text-xs rounded-md focus:outline-none" onclick="setAmmAmount(1, 'add-amm-amount')">100%</button>
+                    </div>
                   </div>
 
                   <div>
                     <label id="add-amm-rate-label" class="block text-sm font-medium text-gray-700 dark:text-gray-300">Minimum Rate <span class="text-red-500">*</span></label>
-                    <div class="flex items-center gap-2">
-                      <input type="text" id="add-amm-rate" pattern="[0-9]*\.?[0-9]*" class="bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500" placeholder="0.0">
-                      <button type="button" id="add-get-rate-button" class="px-2 py-1.5 bg-blue-500 hover:bg-blue-600 font-medium text-xs text-white border border-blue-500 rounded-md shadow-button focus:ring-0 focus:outline-none">Get Rate</button>
+                    <input type="text" id="add-amm-rate" pattern="[0-9]*\.?[0-9]*" class="bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500" placeholder="0.0">
+                    <div class="mt-2">
+                      <button type="button" id="add-get-rate-button" class="py-1 px-2 bg-blue-500 hover:bg-blue-600 text-white text-xs rounded-md focus:outline-none">Get Rate</button>
                     </div>
                   </div>
                 </div>
@@ -1348,7 +1347,7 @@
       <div class="absolute inset-0 bg-gray-500 opacity-75 dark:bg-gray-900 dark:opacity-90"></div>
     </div>
 
-    <div class="inline-block align-bottom bg-white dark:bg-gray-800 rounded-lg text-left overflow-hidden shadow-xl transform transition-all sm:my-8 sm:align-middle lg:max-w-xl md:max-w-2xl md:w-full">
+    <div class="inline-block align-bottom bg-white dark:bg-gray-800 rounded-lg text-left overflow-visible shadow-xl transform transition-all sm:my-8 sm:align-middle lg:max-w-xl md:max-w-2xl md:w-full">
       <div class="bg-white dark:bg-gray-800 px-4 pt-5 pb-4 sm:p-6 sm:pb-4">
         <div class="sm:flex sm:items-start">
           <div class="mt-3 text-center sm:mt-0 sm:text-left w-full">
@@ -1370,7 +1369,7 @@
                 </div>
 
                 <div class="grid grid-cols-2 gap-4">
-                  <div>
+                  <div class="min-h-[80px]">
                     <label for="edit-amm-coin-from" class="block text-sm font-medium text-gray-700 dark:text-gray-300">Maker</label>
                     <div class="relative">
                       <svg class="absolute top-1/2 right-3 transform -translate-y-1/2 w-4 h-4 text-gray-400 pointer-events-none" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -1378,15 +1377,14 @@
                       </svg>
                       <select id="edit-amm-coin-from" class="bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500 appearance-none">
                         {% for c in coins %}
-                        <option value="{{ c[1] }}" data-symbol="{{ c[0] }}">
-                          {{ c[1] }}
-                        </option>
+                        <option value="{{ c[1] }}" data-symbol="{{ c[0] }}" data-balance="{{ c[2] }}">{{ c[1] }}</option>
                         {% endfor %}
                       </select>
                     </div>
+
                   </div>
 
-                  <div>
+                  <div class="min-h-[80px]">
                     <label for="edit-amm-coin-to" class="block text-sm font-medium text-gray-700 dark:text-gray-300">Taker</label>
                     <div class="relative">
                       <svg class="absolute top-1/2 right-3 transform -translate-y-1/2 w-4 h-4 text-gray-400 pointer-events-none" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -1394,12 +1392,11 @@
                       </svg>
                       <select id="edit-amm-coin-to" class="bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500 appearance-none">
                         {% for c in coins %}
-                        <option value="{{ c[1] }}" data-symbol="{{ c[0] }}">
-                          {{ c[1] }}
-                        </option>
+                        <option value="{{ c[1] }}" data-symbol="{{ c[0] }}" data-balance="{{ c[2] }}">{{ c[1] }}</option>
                         {% endfor %}
                       </select>
                     </div>
+
                   </div>
                 </div>
 
@@ -1407,13 +1404,18 @@
                   <div>
                     <label for="edit-amm-amount" class="block text-sm font-medium text-gray-700 dark:text-gray-300">Offer Amount <span class="text-red-500">*</span></label>
                     <input type="text" id="edit-amm-amount" pattern="[0-9]*\.?[0-9]*" class="bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500" placeholder="0.0">
+                    <div class="mt-2 flex space-x-2">
+                      <button type="button" class="hidden md:block py-1 px-2 bg-blue-500 text-white text-xs rounded-md focus:outline-none" onclick="setAmmAmount(0.25, 'edit-amm-amount')">25%</button>
+                      <button type="button" class="hidden md:block py-1 px-2 bg-blue-500 text-white text-xs rounded-md focus:outline-none" onclick="setAmmAmount(0.5, 'edit-amm-amount')">50%</button>
+                      <button type="button" class="py-1 px-2 bg-blue-500 text-white text-xs rounded-md focus:outline-none" onclick="setAmmAmount(1, 'edit-amm-amount')">100%</button>
+                    </div>
                   </div>
 
                   <div>
                     <label id="edit-amm-rate-label" class="block text-sm font-medium text-gray-700 dark:text-gray-300">Minimum Rate <span class="text-red-500">*</span></label>
-                    <div class="flex items-center gap-2">
-                      <input type="text" id="edit-amm-rate" pattern="[0-9]*\.?[0-9]*" class="bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500" placeholder="0.0">
-                      <button type="button" id="edit-get-rate-button" class="px-2 py-1.5 bg-blue-500 hover:bg-blue-600 font-medium text-xs text-white border border-blue-500 rounded-md shadow-button focus:ring-0 focus:outline-none">Get Rate</button>
+                    <input type="text" id="edit-amm-rate" pattern="[0-9]*\.?[0-9]*" class="bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500" placeholder="0.0">
+                    <div class="mt-2">
+                      <button type="button" id="edit-get-rate-button" class="py-1 px-2 bg-blue-500 hover:bg-blue-600 text-white text-xs rounded-md focus:outline-none">Get Rate</button>
                     </div>
                   </div>
                 </div>
@@ -2033,6 +2035,304 @@
         });
       }
     });
+
+    function setAmmAmount(percent, fieldId) {
+      const amountInput = document.getElementById(fieldId);
+      let coinSelect;
+
+
+      let modalType = null;
+      if (fieldId.includes('add-amm')) {
+        const addModal = document.getElementById('add-amm-modal');
+        modalType = addModal ? addModal.getAttribute('data-amm-type') : null;
+      } else if (fieldId.includes('edit-amm')) {
+        const editModal = document.getElementById('edit-amm-modal');
+        modalType = editModal ? editModal.getAttribute('data-amm-type') : null;
+      }
+
+
+      if (fieldId.includes('add-amm')) {
+        const isBidModal = modalType === 'bid';
+        coinSelect = document.getElementById(isBidModal ? 'add-amm-coin-to' : 'add-amm-coin-from');
+      } else if (fieldId.includes('edit-amm')) {
+        const isBidModal = modalType === 'bid';
+        coinSelect = document.getElementById(isBidModal ? 'edit-amm-coin-to' : 'edit-amm-coin-from');
+      }
+
+      if (!amountInput || !coinSelect) {
+        console.error('Required elements not found');
+        return;
+      }
+
+      const selectedOption = coinSelect.options[coinSelect.selectedIndex];
+      if (!selectedOption) {
+        alert('Please select a coin first');
+        return;
+      }
+
+      const balance = selectedOption.getAttribute('data-balance');
+      if (!balance) {
+        console.error('Balance not found for selected coin');
+        return;
+      }
+
+      const floatBalance = parseFloat(balance);
+      if (isNaN(floatBalance) || floatBalance <= 0) {
+        alert('Invalid balance for selected coin');
+        return;
+      }
+
+      const calculatedAmount = floatBalance * percent;
+      amountInput.value = calculatedAmount.toFixed(8);
+
+
+      const event = new Event('input', { bubbles: true });
+      amountInput.dispatchEvent(event);
+    }
+
+    function fetchBalanceData() {
+      return fetch('/json/walletbalances', {
+        headers: {
+          'Accept': 'application/json',
+          'Content-Type': 'application/json'
+        }
+      })
+        .then(response => {
+          if (!response.ok) {
+            throw new Error(`Server error: ${response.status} ${response.statusText}`);
+          }
+          return response.json();
+        })
+        .then(balanceData => {
+          if (balanceData.error) {
+            throw new Error(balanceData.error);
+          }
+
+
+          if (!Array.isArray(balanceData)) {
+            throw new Error('Invalid response format');
+          }
+
+          return balanceData;
+        });
+    }
+
+    function setupWebSocketBalanceUpdates() {
+      if (window.WebSocketManager && typeof window.WebSocketManager.addMessageHandler === 'function') {
+
+
+
+        const balanceHandlerId = window.WebSocketManager.addMessageHandler('message', (data) => {
+          if (data && data.event) {
+
+            if (data.event === 'coin_balance_updated') {
+              clearTimeout(window.ammBalanceUpdateTimeout);
+              window.ammBalanceUpdateTimeout = setTimeout(() => {
+                fetchBalanceData()
+                  .then(balanceData => {
+
+                    const addModal = document.getElementById('add-amm-modal');
+                    const editModal = document.getElementById('edit-amm-modal');
+                    const addModalVisible = addModal && !addModal.classList.contains('hidden');
+                    const editModalVisible = editModal && !editModal.classList.contains('hidden');
+
+                    let modalType = null;
+                    if (addModalVisible) {
+                      modalType = addModal.getAttribute('data-amm-type');
+                    } else if (editModalVisible) {
+                      modalType = editModal.getAttribute('data-amm-type');
+                    }
+
+                    if (modalType === 'offer') {
+                      updateOfferDropdownBalances(balanceData);
+                    } else if (modalType === 'bid') {
+                      updateBidDropdownBalances(balanceData);
+                    }
+                  })
+                  .catch(error => {
+                    console.error('Error updating AMM balances via WebSocket:', error);
+                  });
+              }, 2000);
+            }
+
+            const swapEvents = ['new_bid', 'bid_accepted', 'swap_completed'];
+            if (swapEvents.includes(data.event)) {
+
+              clearTimeout(window.ammSwapEventTimeout);
+              window.ammSwapEventTimeout = setTimeout(() => {
+                fetchBalanceData()
+                  .then(balanceData => {
+
+                    const addModal = document.getElementById('add-amm-modal');
+                    const editModal = document.getElementById('edit-amm-modal');
+                    const addModalVisible = addModal && !addModal.classList.contains('hidden');
+                    const editModalVisible = editModal && !editModal.classList.contains('hidden');
+
+                    let modalType = null;
+                    if (addModalVisible) {
+                      modalType = addModal.getAttribute('data-amm-type');
+                    } else if (editModalVisible) {
+                      modalType = editModal.getAttribute('data-amm-type');
+                    }
+
+                    if (modalType === 'offer') {
+                      updateOfferDropdownBalances(balanceData);
+                    } else if (modalType === 'bid') {
+                      updateBidDropdownBalances(balanceData);
+                    }
+                  })
+                  .catch(error => {
+                    console.error('Error updating AMM balances via swap event:', error);
+                  });
+              }, 5000);
+            }
+          }
+        });
+
+        window.ammBalanceHandlerId = balanceHandlerId;
+
+      } else {
+
+      }
+
+      if (!window.ammPeriodicRefresh) {
+        window.ammPeriodicRefresh = setInterval(() => {
+          fetchBalanceData()
+            .then(balanceData => {
+
+              const addModal = document.getElementById('add-amm-modal');
+              const editModal = document.getElementById('edit-amm-modal');
+              const addModalVisible = addModal && !addModal.classList.contains('hidden');
+              const editModalVisible = editModal && !editModal.classList.contains('hidden');
+
+              let modalType = null;
+              if (addModalVisible) {
+                modalType = addModal.getAttribute('data-amm-type');
+              } else if (editModalVisible) {
+                modalType = editModal.getAttribute('data-amm-type');
+              }
+
+              if (modalType === 'offer') {
+                updateOfferDropdownBalances(balanceData);
+              } else if (modalType === 'bid') {
+                updateBidDropdownBalances(balanceData);
+              }
+            })
+            .catch(error => {
+              console.error('Error in periodic AMM balance refresh:', error);
+            });
+        }, 300000);
+
+      }
+    }
+
+    function updateAmmDropdownBalances(balanceData) {
+
+      const balanceMap = {};
+      const pendingMap = {};
+      balanceData.forEach(coin => {
+        balanceMap[coin.name] = coin.balance;
+        pendingMap[coin.name] = coin.pending || '0.0';
+      });
+
+      const dropdownIds = ['add-amm-coin-from', 'edit-amm-coin-from', 'add-amm-coin-to', 'edit-amm-coin-to'];
+
+      dropdownIds.forEach(dropdownId => {
+        const select = document.getElementById(dropdownId);
+        if (!select) {
+          return;
+        }
+
+
+        Array.from(select.options).forEach(option => {
+          const coinName = option.value;
+          const balance = balanceMap[coinName] || '0.0';
+          const pending = pendingMap[coinName] || '0.0';
+
+          option.setAttribute('data-balance', balance);
+          option.setAttribute('data-pending-balance', pending);
+        });
+      });
+
+
+      const addModal = document.getElementById('add-amm-modal');
+      const editModal = document.getElementById('edit-amm-modal');
+      const addModalVisible = addModal && !addModal.classList.contains('hidden');
+      const editModalVisible = editModal && !editModal.classList.contains('hidden');
+
+      let currentModalType = null;
+      if (addModalVisible) {
+        currentModalType = addModal.getAttribute('data-amm-type');
+      } else if (editModalVisible) {
+        currentModalType = editModal.getAttribute('data-amm-type');
+      }
+
+      if (currentModalType && window.ammTablesManager) {
+        if (currentModalType === 'offer' && typeof window.ammTablesManager.refreshOfferDropdownBalanceDisplay === 'function') {
+          window.ammTablesManager.refreshOfferDropdownBalanceDisplay();
+        } else if (currentModalType === 'bid' && typeof window.ammTablesManager.refreshBidDropdownBalanceDisplay === 'function') {
+          window.ammTablesManager.refreshBidDropdownBalanceDisplay();
+        }
+      }
+    }
+
+    function updateOfferDropdownBalances(balanceData) {
+      updateAmmDropdownBalances(balanceData);
+    }
+
+    function updateBidDropdownBalances(balanceData) {
+      updateAmmDropdownBalances(balanceData);
+    }
+
+    function updateOfferCustomDropdownDisplay(select, balanceMap, pendingMap) {
+      console.log(`[DEBUG] updateOfferCustomDropdownDisplay called for ${select.id} - doing nothing`);
+
+    }
+
+    function updateBidCustomDropdownDisplay(select, balanceMap, pendingMap) {
+      console.log(`[DEBUG] updateBidCustomDropdownDisplay called for ${select.id} - doing nothing`);
+
+    }
+
+    function updateCustomDropdownDisplay(select, balanceMap, pendingMap) {
+      console.log(`[DEBUG] updateCustomDropdownDisplay called for ${select.id} - doing nothing`);
+
+    }
+
+    setupWebSocketBalanceUpdates();
+
+    function cleanupAmmBalanceUpdates() {
+      if (window.ammBalanceHandlerId && window.WebSocketManager) {
+        window.WebSocketManager.removeMessageHandler('message', window.ammBalanceHandlerId);
+
+      }
+
+      if (window.ammPeriodicRefresh) {
+        clearInterval(window.ammPeriodicRefresh);
+        window.ammPeriodicRefresh = null;
+
+      }
+
+
+      if (window.ammDropdowns) {
+        window.ammDropdowns.forEach(dropdown => {
+          if (dropdown.parentNode) {
+            dropdown.parentNode.removeChild(dropdown);
+          }
+        });
+        window.ammDropdowns = [];
+      }
+
+      clearTimeout(window.ammBalanceUpdateTimeout);
+      clearTimeout(window.ammSwapEventTimeout);
+    }
+
+    if (window.CleanupManager) {
+      window.CleanupManager.registerResource('ammBalanceUpdates', null, cleanupAmmBalanceUpdates);
+    }
+
+    window.addEventListener('beforeunload', cleanupAmmBalanceUpdates);
+    window.setAmmAmount = setAmmAmount;
   </script>
 
 {% include 'footer.html' %}

--- a/basicswap/templates/amm.html
+++ b/basicswap/templates/amm.html
@@ -2221,7 +2221,7 @@
             .catch(error => {
               console.error('Error in periodic AMM balance refresh:', error);
             });
-        }, 300000);
+        }, 120000);
 
       }
     }

--- a/basicswap/templates/amm.html
+++ b/basicswap/templates/amm.html
@@ -55,7 +55,7 @@
         </div>
       </div>
 
-      <div class="border-b pb-5 border-gray-200 dark:border-gray-500">
+      <div class="pb-5">
         <ul class="flex flex-wrap text-sm font-medium text-center text-gray-500 dark:text-gray-400" id="ammTabs" role="tablist">
           <li class="mr-2" role="presentation">
             <button class="inline-block px-4 py-3 rounded-lg hover:text-gray-900 hover:bg-gray-100 dark:hover:bg-gray-600 dark:hover:text-white focus:outline-none focus:ring-0" id="offers-tab" data-tabs-target="#offers-content" type="button" role="tab" aria-controls="offers" aria-selected="true">
@@ -2090,140 +2090,35 @@
       amountInput.dispatchEvent(event);
     }
 
-    function fetchBalanceData() {
-      return fetch('/json/walletbalances', {
-        headers: {
-          'Accept': 'application/json',
-          'Content-Type': 'application/json'
-        }
-      })
-        .then(response => {
-          if (!response.ok) {
-            throw new Error(`Server error: ${response.status} ${response.statusText}`);
-          }
-          return response.json();
-        })
-        .then(balanceData => {
-          if (balanceData.error) {
-            throw new Error(balanceData.error);
-          }
+    function updateAmmModalBalances(balanceData) {
+      const addModal = document.getElementById('add-amm-modal');
+      const editModal = document.getElementById('edit-amm-modal');
+      const addModalVisible = addModal && !addModal.classList.contains('hidden');
+      const editModalVisible = editModal && !editModal.classList.contains('hidden');
 
+      let modalType = null;
+      if (addModalVisible) {
+        modalType = addModal.getAttribute('data-amm-type');
+      } else if (editModalVisible) {
+        modalType = editModal.getAttribute('data-amm-type');
+      }
 
-          if (!Array.isArray(balanceData)) {
-            throw new Error('Invalid response format');
-          }
-
-          return balanceData;
-        });
+      if (modalType === 'offer') {
+        updateOfferDropdownBalances(balanceData);
+      } else if (modalType === 'bid') {
+        updateBidDropdownBalances(balanceData);
+      }
     }
 
     function setupWebSocketBalanceUpdates() {
-      if (window.WebSocketManager && typeof window.WebSocketManager.addMessageHandler === 'function') {
-
-
-
-        const balanceHandlerId = window.WebSocketManager.addMessageHandler('message', (data) => {
-          if (data && data.event) {
-
-            if (data.event === 'coin_balance_updated') {
-              clearTimeout(window.ammBalanceUpdateTimeout);
-              window.ammBalanceUpdateTimeout = setTimeout(() => {
-                fetchBalanceData()
-                  .then(balanceData => {
-
-                    const addModal = document.getElementById('add-amm-modal');
-                    const editModal = document.getElementById('edit-amm-modal');
-                    const addModalVisible = addModal && !addModal.classList.contains('hidden');
-                    const editModalVisible = editModal && !editModal.classList.contains('hidden');
-
-                    let modalType = null;
-                    if (addModalVisible) {
-                      modalType = addModal.getAttribute('data-amm-type');
-                    } else if (editModalVisible) {
-                      modalType = editModal.getAttribute('data-amm-type');
-                    }
-
-                    if (modalType === 'offer') {
-                      updateOfferDropdownBalances(balanceData);
-                    } else if (modalType === 'bid') {
-                      updateBidDropdownBalances(balanceData);
-                    }
-                  })
-                  .catch(error => {
-                    console.error('Error updating AMM balances via WebSocket:', error);
-                  });
-              }, 2000);
-            }
-
-            const swapEvents = ['new_bid', 'bid_accepted', 'swap_completed'];
-            if (swapEvents.includes(data.event)) {
-
-              clearTimeout(window.ammSwapEventTimeout);
-              window.ammSwapEventTimeout = setTimeout(() => {
-                fetchBalanceData()
-                  .then(balanceData => {
-
-                    const addModal = document.getElementById('add-amm-modal');
-                    const editModal = document.getElementById('edit-amm-modal');
-                    const addModalVisible = addModal && !addModal.classList.contains('hidden');
-                    const editModalVisible = editModal && !editModal.classList.contains('hidden');
-
-                    let modalType = null;
-                    if (addModalVisible) {
-                      modalType = addModal.getAttribute('data-amm-type');
-                    } else if (editModalVisible) {
-                      modalType = editModal.getAttribute('data-amm-type');
-                    }
-
-                    if (modalType === 'offer') {
-                      updateOfferDropdownBalances(balanceData);
-                    } else if (modalType === 'bid') {
-                      updateBidDropdownBalances(balanceData);
-                    }
-                  })
-                  .catch(error => {
-                    console.error('Error updating AMM balances via swap event:', error);
-                  });
-              }, 5000);
-            }
-          }
-        });
-
-        window.ammBalanceHandlerId = balanceHandlerId;
-
-      } else {
-
-      }
-
-      if (!window.ammPeriodicRefresh) {
-        window.ammPeriodicRefresh = setInterval(() => {
-          fetchBalanceData()
-            .then(balanceData => {
-
-              const addModal = document.getElementById('add-amm-modal');
-              const editModal = document.getElementById('edit-amm-modal');
-              const addModalVisible = addModal && !addModal.classList.contains('hidden');
-              const editModalVisible = editModal && !editModal.classList.contains('hidden');
-
-              let modalType = null;
-              if (addModalVisible) {
-                modalType = addModal.getAttribute('data-amm-type');
-              } else if (editModalVisible) {
-                modalType = editModal.getAttribute('data-amm-type');
-              }
-
-              if (modalType === 'offer') {
-                updateOfferDropdownBalances(balanceData);
-              } else if (modalType === 'bid') {
-                updateBidDropdownBalances(balanceData);
-              }
-            })
-            .catch(error => {
-              console.error('Error in periodic AMM balance refresh:', error);
-            });
-        }, 120000);
-
-      }
+      window.BalanceUpdatesManager.setup({
+        contextKey: 'amm',
+        balanceUpdateCallback: updateAmmModalBalances,
+        swapEventCallback: updateAmmModalBalances,
+        errorContext: 'AMM',
+        enablePeriodicRefresh: true,
+        periodicInterval: 120000
+      });
     }
 
     function updateAmmDropdownBalances(balanceData) {
@@ -2299,20 +2194,11 @@
 
     }
 
+    window.BalanceUpdatesManager.initialize();
     setupWebSocketBalanceUpdates();
 
     function cleanupAmmBalanceUpdates() {
-      if (window.ammBalanceHandlerId && window.WebSocketManager) {
-        window.WebSocketManager.removeMessageHandler('message', window.ammBalanceHandlerId);
-
-      }
-
-      if (window.ammPeriodicRefresh) {
-        clearInterval(window.ammPeriodicRefresh);
-        window.ammPeriodicRefresh = null;
-
-      }
-
+      window.BalanceUpdatesManager.cleanup('amm');
 
       if (window.ammDropdowns) {
         window.ammDropdowns.forEach(dropdown => {
@@ -2322,9 +2208,6 @@
         });
         window.ammDropdowns = [];
       }
-
-      clearTimeout(window.ammBalanceUpdateTimeout);
-      clearTimeout(window.ammSwapEventTimeout);
     }
 
     if (window.CleanupManager) {

--- a/basicswap/templates/header.html
+++ b/basicswap/templates/header.html
@@ -75,6 +75,7 @@
   <script src="/static/js/modules/price-manager.js"></script>
   <script src="/static/js/modules/tooltips-manager.js"></script>
   <script src="/static/js/modules/notification-manager.js"></script>
+  <script src="/static/js/modules/balance-updates.js"></script>
   <script src="/static/js/modules/identity-manager.js"></script>
   <script src="/static/js/modules/summary-manager.js"></script>
   <script src="/static/js/amm_counter.js"></script>

--- a/basicswap/templates/offer_new_1.html
+++ b/basicswap/templates/offer_new_1.html
@@ -458,126 +458,17 @@ function updateCoinDropdownBalances(balanceData) {
   });
 }
 
-
-function fetchBalanceData() {
-  return fetch('/json/walletbalances', {
-    headers: {
-      'Accept': 'application/json',
-      'Content-Type': 'application/json'
-    }
-  })
-    .then(response => {
-      if (!response.ok) {
-        throw new Error(`Server error: ${response.status} ${response.statusText}`);
-      }
-      return response.json();
-    })
-    .then(balanceData => {
-      if (balanceData.error) {
-        throw new Error(balanceData.error);
-      }
-
-
-      if (!Array.isArray(balanceData)) {
-        throw new Error('Invalid response format');
-      }
-
-      return balanceData;
-    });
-}
-
-
-function setupWebSocketBalanceUpdates() {
-  if (window.WebSocketManager && typeof window.WebSocketManager.addMessageHandler === 'function') {
-
-
-
-    const balanceHandlerId = window.WebSocketManager.addMessageHandler('message', (data) => {
-      if (data && data.event) {
-
-        if (data.event === 'coin_balance_updated') {
-          clearTimeout(window.offerBalanceUpdateTimeout);
-          window.offerBalanceUpdateTimeout = setTimeout(() => {
-            fetchBalanceData()
-              .then(balanceData => {
-                updateCoinDropdownBalances(balanceData);
-              })
-              .catch(error => {
-                console.error('Error updating New Offer balances via WebSocket:', error);
-              });
-          }, 2000);
-        }
-
-
-        const swapEvents = ['new_bid', 'bid_accepted', 'swap_completed'];
-        if (swapEvents.includes(data.event)) {
-
-
-
-          clearTimeout(window.offerSwapEventTimeout);
-          window.offerSwapEventTimeout = setTimeout(() => {
-            fetchBalanceData()
-              .then(balanceData => {
-                updateCoinDropdownBalances(balanceData);
-
-              })
-              .catch(error => {
-                console.error('Error updating New Offer balances via swap event:', error);
-              });
-          }, 5000);
-        }
-      }
-    });
-
-
-    window.offerBalanceHandlerId = balanceHandlerId;
-
-  } else {
-
-  }
-
-
-  if (!window.offerPeriodicRefresh) {
-    window.offerPeriodicRefresh = setInterval(() => {
-      fetchBalanceData()
-        .then(balanceData => {
-          updateCoinDropdownBalances(balanceData);
-        })
-        .catch(error => {
-          console.error('Error in periodic New Offer balance refresh:', error);
-        });
-    }, 120000);
-  }
-}
-
-
-function cleanupOfferBalanceUpdates() {
-  if (window.offerBalanceHandlerId && window.WebSocketManager) {
-    window.WebSocketManager.removeMessageHandler('message', window.offerBalanceHandlerId);
-
-  }
-
-  if (window.offerPeriodicRefresh) {
-    clearInterval(window.offerPeriodicRefresh);
-    window.offerPeriodicRefresh = null;
-
-  }
-
-  clearTimeout(window.offerBalanceUpdateTimeout);
-  clearTimeout(window.offerSwapEventTimeout);
-}
-
-
 document.addEventListener('DOMContentLoaded', function() {
-  setupWebSocketBalanceUpdates();
+  window.BalanceUpdatesManager.initialize();
 
-
-  if (window.CleanupManager) {
-    window.CleanupManager.registerResource('offerBalanceUpdates', null, cleanupOfferBalanceUpdates);
-  }
-
-  window.addEventListener('beforeunload', cleanupOfferBalanceUpdates);
-
+  window.BalanceUpdatesManager.setup({
+    contextKey: 'offer',
+    balanceUpdateCallback: updateCoinDropdownBalances,
+    swapEventCallback: updateCoinDropdownBalances,
+    errorContext: 'New Offer',
+    enablePeriodicRefresh: true,
+    periodicInterval: 120000
+  });
 });
 
 </script>

--- a/basicswap/templates/offer_new_1.html
+++ b/basicswap/templates/offer_new_1.html
@@ -155,7 +155,7 @@
                           <select class="select hover:border-blue-500 pl-10 bg-gray-50 text-gray-900 appearance-none pr-10 dark:bg-gray-500 dark:text-white border border-gray-300 dark:border-gray-400 dark:text-gray-50 dark:placeholder-gray-400 text-sm rounded-lg outline-none focus:ring-blue-500 focus:border-blue-500 block w-full p-5 bold focus:ring-0" id="coin_from" name="coin_from" onchange="set_rate('coin_from');">
                             <option value="-1">Select coin you send</option>
                             {% for c in coins_from %}
-                            <option{% if data.coin_from==c[0] %} selected{% endif %} value="{{ c[0] }}" data-image="/static/images/coins/{{ c[1]|replace(" ", "-") }}-20.png">{{ c[1] }}</option>
+                            <option{% if data.coin_from==c[0] %} selected{% endif %} value="{{ c[0] }}" data-image="/static/images/coins/{{ c[1]|replace(" ", "-") }}-20.png" data-balance="{{ c[2] }}">{{ c[1] }} - Balance: {{ c[2] }}</option>
                             {% endfor %}
                           </select>
                           <div class="select-dropdown"> <img class="select-icon" src="" alt=""> <img class="select-image" src="" alt=""> </div>
@@ -166,6 +166,11 @@
                       <p class="mb-1.5 font-medium text-base text-coolGray-800 dark:text-white">Amount You Send</p>
                       <div class="relative">
                         <div class="flex absolute inset-y-0 left-0 items-center pl-3 pointer-events-none"> </div> <input class="hover:border-blue-500 bg-gray-50 text-gray-900 appearance-none pr-10 dark:bg-gray-500 dark:text-white border border-gray-300 dark:border-gray-400 dark:text-gray-50 dark:placeholder-gray-400 text-sm rounded-lg outline-none focus:ring-blue-500 focus:border-blue-500 block w-full p-5 focus:ring-0 bold" placeholder="0" type="text" id="amt_from" name="amt_from" value="{{ data.amt_from }}" onchange="set_rate('amt_from');">
+                      </div>
+                      <div class="mt-2 flex space-x-2">
+                        <button type="button" class="hidden md:block py-1 px-2 bg-blue-500 text-white text-lg lg:text-sm rounded-md focus:outline-none" onclick="setOfferAmount(0.25, 'amt_from')">25%</button>
+                        <button type="button" class="hidden md:block py-1 px-2 bg-blue-500 text-white text-lg lg:text-sm rounded-md focus:outline-none" onclick="setOfferAmount(0.5, 'amt_from')">50%</button>
+                        <button type="button" class="py-1 px-2 bg-blue-500 text-white text-lg lg:text-sm rounded-md focus:outline-none" onclick="setOfferAmount(1, 'amt_from')">100%</button>
                       </div>
                     </div>
                   </div>
@@ -332,6 +337,251 @@
     </div>
   </section>
 </div>
+
+<script>
+function setOfferAmount(percent, fieldId) {
+  const amountInput = document.getElementById(fieldId);
+  const coinFromSelect = document.getElementById('coin_from');
+
+  if (!amountInput || !coinFromSelect) {
+    console.error('Required elements not found');
+    return;
+  }
+
+  const selectedOption = coinFromSelect.options[coinFromSelect.selectedIndex];
+  if (!selectedOption || selectedOption.value === '-1') {
+    alert('Please select a coin first');
+    return;
+  }
+
+  const balance = selectedOption.getAttribute('data-balance');
+  if (!balance) {
+    console.error('Balance not found for selected coin');
+    return;
+  }
+
+  const floatBalance = parseFloat(balance);
+  if (isNaN(floatBalance) || floatBalance <= 0) {
+    alert('Invalid balance for selected coin');
+    return;
+  }
+
+  const calculatedAmount = floatBalance * percent;
+  amountInput.value = calculatedAmount.toFixed(8);
+
+
+  if (amountInput.onchange) {
+    amountInput.onchange();
+  }
+
+
+  if (typeof set_rate === 'function') {
+    set_rate(fieldId);
+  }
+}
+
+function updateCustomDropdownDisplay(select, coinName, balance, pending) {
+  const selectNameElement = select.nextElementSibling?.querySelector('.select-name');
+  if (!selectNameElement) return;
+
+
+  selectNameElement.innerHTML = '';
+  selectNameElement.style.display = 'flex';
+  selectNameElement.style.flexDirection = 'column';
+  selectNameElement.style.alignItems = 'flex-start';
+  selectNameElement.style.lineHeight = '1.2';
+
+
+  const coinNameDiv = document.createElement('div');
+  coinNameDiv.textContent = coinName;
+  coinNameDiv.style.fontWeight = 'normal';
+  coinNameDiv.style.color = 'inherit';
+
+
+  const balanceDiv = document.createElement('div');
+  balanceDiv.textContent = `Balance: ${balance}`;
+  balanceDiv.style.fontSize = '0.75rem';
+  balanceDiv.style.color = '#6b7280';
+  balanceDiv.style.marginTop = '1px';
+
+  selectNameElement.appendChild(coinNameDiv);
+  selectNameElement.appendChild(balanceDiv);
+
+
+  if (pending !== '0.0' && parseFloat(pending) > 0) {
+    const pendingDiv = document.createElement('div');
+    pendingDiv.textContent = `+${pending} pending`;
+    pendingDiv.style.fontSize = '0.75rem';
+    pendingDiv.style.color = '#10b981';
+    pendingDiv.style.marginTop = '1px';
+    selectNameElement.appendChild(pendingDiv);
+  }
+}
+
+function updateCoinDropdownBalances(balanceData) {
+
+  const coinFromSelect = document.getElementById('coin_from');
+  if (!coinFromSelect) return;
+
+
+  const balanceMap = {};
+  const pendingMap = {};
+  balanceData.forEach(coin => {
+    balanceMap[coin.id] = coin.balance;
+    pendingMap[coin.id] = coin.pending || '0.0';
+  });
+
+
+  Array.from(coinFromSelect.options).forEach(option => {
+    if (option.value === '-1') return;
+
+    const coinId = parseInt(option.value);
+    const balance = balanceMap[coinId] || '0.0';
+    const pending = pendingMap[coinId] || '0.0';
+
+
+    option.setAttribute('data-balance', balance);
+
+
+    const coinName = option.textContent.split(' - Balance:')[0];
+    if (pending !== '0.0' && parseFloat(pending) > 0) {
+      option.textContent = `${coinName} - Balance: ${balance} (+${pending} pending)`;
+    } else {
+      option.textContent = `${coinName} - Balance: ${balance}`;
+    }
+
+
+    const select = option.closest('select');
+    if (select && select.value === option.value) {
+      updateCustomDropdownDisplay(select, coinName, balance, pending);
+    }
+  });
+}
+
+
+function fetchBalanceData() {
+  return fetch('/json/walletbalances', {
+    headers: {
+      'Accept': 'application/json',
+      'Content-Type': 'application/json'
+    }
+  })
+    .then(response => {
+      if (!response.ok) {
+        throw new Error(`Server error: ${response.status} ${response.statusText}`);
+      }
+      return response.json();
+    })
+    .then(balanceData => {
+      if (balanceData.error) {
+        throw new Error(balanceData.error);
+      }
+
+
+      if (!Array.isArray(balanceData)) {
+        throw new Error('Invalid response format');
+      }
+
+      return balanceData;
+    });
+}
+
+
+function setupWebSocketBalanceUpdates() {
+  if (window.WebSocketManager && typeof window.WebSocketManager.addMessageHandler === 'function') {
+
+
+
+    const balanceHandlerId = window.WebSocketManager.addMessageHandler('message', (data) => {
+      if (data && data.event) {
+
+        if (data.event === 'coin_balance_updated') {
+          clearTimeout(window.offerBalanceUpdateTimeout);
+          window.offerBalanceUpdateTimeout = setTimeout(() => {
+            fetchBalanceData()
+              .then(balanceData => {
+                updateCoinDropdownBalances(balanceData);
+              })
+              .catch(error => {
+                console.error('Error updating New Offer balances via WebSocket:', error);
+              });
+          }, 2000);
+        }
+
+
+        const swapEvents = ['new_bid', 'bid_accepted', 'swap_completed'];
+        if (swapEvents.includes(data.event)) {
+
+
+
+          clearTimeout(window.offerSwapEventTimeout);
+          window.offerSwapEventTimeout = setTimeout(() => {
+            fetchBalanceData()
+              .then(balanceData => {
+                updateCoinDropdownBalances(balanceData);
+
+              })
+              .catch(error => {
+                console.error('Error updating New Offer balances via swap event:', error);
+              });
+          }, 5000);
+        }
+      }
+    });
+
+
+    window.offerBalanceHandlerId = balanceHandlerId;
+
+  } else {
+
+  }
+
+
+  if (!window.offerPeriodicRefresh) {
+    window.offerPeriodicRefresh = setInterval(() => {
+      fetchBalanceData()
+        .then(balanceData => {
+          updateCoinDropdownBalances(balanceData);
+        })
+        .catch(error => {
+          console.error('Error in periodic New Offer balance refresh:', error);
+        });
+    }, 300000);
+  }
+}
+
+
+function cleanupOfferBalanceUpdates() {
+  if (window.offerBalanceHandlerId && window.WebSocketManager) {
+    window.WebSocketManager.removeMessageHandler('message', window.offerBalanceHandlerId);
+
+  }
+
+  if (window.offerPeriodicRefresh) {
+    clearInterval(window.offerPeriodicRefresh);
+    window.offerPeriodicRefresh = null;
+
+  }
+
+  clearTimeout(window.offerBalanceUpdateTimeout);
+  clearTimeout(window.offerSwapEventTimeout);
+}
+
+
+document.addEventListener('DOMContentLoaded', function() {
+  setupWebSocketBalanceUpdates();
+
+
+  if (window.CleanupManager) {
+    window.CleanupManager.registerResource('offerBalanceUpdates', null, cleanupOfferBalanceUpdates);
+  }
+
+  window.addEventListener('beforeunload', cleanupOfferBalanceUpdates);
+
+});
+
+</script>
+
 <script src="static/js/new_offer.js"></script>
 {% include 'footer.html' %}
 </div>

--- a/basicswap/templates/offer_new_1.html
+++ b/basicswap/templates/offer_new_1.html
@@ -546,7 +546,7 @@ function setupWebSocketBalanceUpdates() {
         .catch(error => {
           console.error('Error in periodic New Offer balance refresh:', error);
         });
-    }, 300000);
+    }, 120000);
   }
 }
 

--- a/basicswap/templates/settings.html
+++ b/basicswap/templates/settings.html
@@ -49,6 +49,9 @@
       <button class="tab-button border-b-2 border-transparent text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300 hover:border-gray-300 dark:hover:border-gray-600 py-4 px-1 text-sm font-medium focus:outline-none focus:ring-0" data-tab="general" id="general-tab">
        General
       </button>
+      <button class="tab-button border-b-2 border-transparent text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300 hover:border-gray-300 dark:hover:border-gray-600 py-4 px-1 text-sm font-medium focus:outline-none focus:ring-0" data-tab="notifications" id="notifications-tab">
+       Notifications
+      </button>
       <button class="tab-button border-b-2 border-transparent text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300 hover:border-gray-300 dark:hover:border-gray-600 py-4 px-1 text-sm font-medium focus:outline-none focus:ring-0" data-tab="tor" id="tor-tab">
        Tor
       </button>
@@ -431,6 +434,153 @@
     <input type="hidden" name="formid" value="{{ form_id }}">
    </form>
   </div>
+
+  <div class="tab-content hidden" id="notifications" role="tabpanel" aria-labelledby="notifications-tab">
+   <form method="post">
+    <div class="space-y-6">
+
+     <div class="bg-coolGray-100 dark:bg-gray-500 rounded-xl">
+      <div class="px-6 py-4">
+       <h3 class="text-lg font-semibold text-gray-900 dark:text-white">
+        Notification Settings
+       </h3>
+       <p class="mt-1 text-sm text-gray-600 dark:text-gray-300">
+        Configure which notifications you want to see.
+       </p>
+      </div>
+      <div class="px-6 pb-6 space-y-6">
+
+       <div>
+        <h4 class="text-sm font-medium text-gray-900 dark:text-white mb-4">Notification Types</h4>
+        <div class="bg-gray-50 dark:bg-gray-700 rounded-lg p-4">
+         <div class="space-y-4">
+
+          <div class="py-2">
+           <div class="flex items-center">
+            <input type="checkbox" id="notifications_new_offers" name="notifications_new_offers" value="true" class="w-4 h-4 text-blue-600 bg-gray-100 border-gray-300 rounded focus:ring-blue-500 dark:focus:ring-blue-600 dark:ring-offset-gray-800 focus:ring-2 dark:bg-gray-600 dark:border-gray-500"{% if notification_settings.notifications_new_offers %} checked{% endif %}>
+            <label for="notifications_new_offers" class="ml-3 text-sm font-medium text-gray-700 dark:text-gray-300">New Offers</label>
+           </div>
+           <p class="text-xs text-gray-500 dark:text-gray-400 ml-7 mt-1">Show notifications for new network offers</p>
+          </div>
+
+          <div class="py-2">
+           <div class="flex items-center">
+            <input type="checkbox" id="notifications_new_bids" name="notifications_new_bids" value="true" class="w-4 h-4 text-blue-600 bg-gray-100 border-gray-300 rounded focus:ring-blue-500 dark:focus:ring-blue-600 dark:ring-offset-gray-800 focus:ring-2 dark:bg-gray-600 dark:border-gray-500"{% if notification_settings.notifications_new_bids %} checked{% endif %}>
+            <label for="notifications_new_bids" class="ml-3 text-sm font-medium text-gray-700 dark:text-gray-300">New Bids</label>
+           </div>
+           <p class="text-xs text-gray-500 dark:text-gray-400 ml-7 mt-1">Show notifications for new bids on your offers</p>
+          </div>
+
+          <div class="py-2">
+           <div class="flex items-center">
+            <input type="checkbox" id="notifications_bid_accepted" name="notifications_bid_accepted" value="true" class="w-4 h-4 text-blue-600 bg-gray-100 border-gray-300 rounded focus:ring-blue-500 dark:focus:ring-blue-600 dark:ring-offset-gray-800 focus:ring-2 dark:bg-gray-600 dark:border-gray-500"{% if notification_settings.notifications_bid_accepted %} checked{% endif %}>
+            <label for="notifications_bid_accepted" class="ml-3 text-sm font-medium text-gray-700 dark:text-gray-300">Bid Accepted</label>
+           </div>
+           <p class="text-xs text-gray-500 dark:text-gray-400 ml-7 mt-1">Show notifications when your bids are accepted</p>
+          </div>
+
+          <div class="py-2">
+           <div class="flex items-center">
+            <input type="checkbox" id="notifications_balance_changes" name="notifications_balance_changes" value="true" class="w-4 h-4 text-blue-600 bg-gray-100 border-gray-300 rounded focus:ring-blue-500 dark:focus:ring-blue-600 dark:ring-offset-gray-800 focus:ring-2 dark:bg-gray-600 dark:border-gray-500"{% if notification_settings.notifications_balance_changes %} checked{% endif %}>
+            <label for="notifications_balance_changes" class="ml-3 text-sm font-medium text-gray-700 dark:text-gray-300">Balance Changes</label>
+           </div>
+           <p class="text-xs text-gray-500 dark:text-gray-400 ml-7 mt-1">Show notifications for incoming and outgoing funds</p>
+          </div>
+
+          <div class="py-2">
+           <div class="flex items-center">
+            <input type="checkbox" id="notifications_outgoing_transactions" name="notifications_outgoing_transactions" value="true" class="w-4 h-4 text-blue-600 bg-gray-100 border-gray-300 rounded focus:ring-blue-500 dark:focus:ring-blue-600 dark:ring-offset-gray-800 focus:ring-2 dark:bg-gray-600 dark:border-gray-500"{% if notification_settings.notifications_outgoing_transactions %} checked{% endif %}>
+            <label for="notifications_outgoing_transactions" class="ml-3 text-sm font-medium text-gray-700 dark:text-gray-300">Outgoing Transactions</label>
+           </div>
+           <p class="text-xs text-gray-500 dark:text-gray-400 ml-7 mt-1">Show notifications for sent funds</p>
+          </div>
+
+         </div>
+        </div>
+       </div>
+
+       <div>
+        <h4 class="text-sm font-medium text-gray-900 dark:text-white mb-4">Display Duration</h4>
+        <div class="bg-gray-50 dark:bg-gray-700 rounded-lg p-4">
+         <div>
+          <label for="notifications_duration" class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">Duration</label>
+          <div class="relative w-48">
+           <select id="notifications_duration" name="notifications_duration" class="hover:border-blue-500 bg-gray-50 text-gray-900 appearance-none dark:bg-gray-700 dark:text-white border border-gray-300 dark:border-gray-600 dark:placeholder-gray-400 text-sm rounded-lg outline-none focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5 focus:ring-1 focus:outline-none">
+            <option value="5"{% if notification_settings.notifications_duration == 5 %} selected{% endif %}>5 seconds</option>
+            <option value="10"{% if notification_settings.notifications_duration == 10 %} selected{% endif %}>10 seconds</option>
+            <option value="15"{% if notification_settings.notifications_duration == 15 %} selected{% endif %}>15 seconds</option>
+            <option value="20"{% if notification_settings.notifications_duration == 20 %} selected{% endif %}>20 seconds</option>
+            <option value="30"{% if notification_settings.notifications_duration == 30 %} selected{% endif %}>30 seconds</option>
+            <option value="60"{% if notification_settings.notifications_duration == 60 %} selected{% endif %}>1 minute</option>
+           </select>
+           <div class="absolute inset-y-0 right-0 flex items-center px-2 pointer-events-none">
+            <svg class="w-4 h-4 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+            </svg>
+           </div>
+          </div>
+         </div>
+        </div>
+       </div>
+
+       {% if general_settings.debug_ui %}
+       <div>
+        <h4 class="text-sm font-medium text-gray-900 dark:text-white mb-4">Test Notifications</h4>
+        <div class="bg-gray-50 dark:bg-gray-700 rounded-lg p-4">
+         <div>
+          <button type="button" onclick="window.NotificationManager && window.NotificationManager.testToasts()" class="bg-blue-600 hover:bg-blue-700 text-white font-medium py-2 px-4 rounded-lg transition-colors focus:outline-none">
+           Test All Notification Types
+          </button>
+         </div>
+        </div>
+       </div>
+       {% endif %}
+
+       <div class="flex justify-end mt-6">
+        <button name="apply_notifications" value="Apply" type="submit" class="bg-blue-600 hover:bg-blue-700 text-white font-medium py-2 px-4 rounded-lg transition-colors focus:outline-none">
+         Apply Changes
+        </button>
+       </div>
+
+      </div>
+     </div>
+
+    </div>
+    <input type="hidden" name="formid" value="{{ form_id }}">
+   </form>
+  </div>
+
+  <script>
+    function syncNotificationSettings() {
+      if (window.NotificationManager && typeof window.NotificationManager.updateSettings === 'function') {
+
+        const backendSettings = {
+          showNewOffers: document.getElementById('notifications_new_offers').checked,
+          showNewBids: document.getElementById('notifications_new_bids').checked,
+          showBidAccepted: document.getElementById('notifications_bid_accepted').checked,
+          showBalanceChanges: document.getElementById('notifications_balance_changes').checked,
+          showOutgoingTransactions: document.getElementById('notifications_outgoing_transactions').checked,
+          notificationDuration: parseInt(document.getElementById('notifications_duration').value) * 1000
+        };
+
+        window.NotificationManager.updateSettings(backendSettings);
+      }
+    }
+
+    document.getElementById('notifications-tab').addEventListener('click', function() {
+      setTimeout(syncNotificationSettings, 100);
+    });
+
+    document.addEventListener('DOMContentLoaded', function() {
+      syncNotificationSettings();
+    });
+
+    document.addEventListener('change', function(e) {
+      if (e.target.closest('#notifications')) {
+        syncNotificationSettings();
+      }
+    });
+  </script>
 
   <div class="tab-content hidden" id="tor" role="tabpanel" aria-labelledby="tor-tab">
    <form method="post" id="tor-form">

--- a/basicswap/templates/wallet.html
+++ b/basicswap/templates/wallet.html
@@ -1157,12 +1157,17 @@ document.addEventListener('DOMContentLoaded', function() {
   function updatePercentageButtons(coinData) {
     const currentCoinId = {{ w.cid }};
 
-    if (coinData.id === currentCoinId) {
+    const isPartVariant = (currentCoinId === 1 && (coinData.name === 'Particl' || coinData.name === 'Particl Anon' || coinData.name === 'Particl Blind'));
+    const isLtcVariant = (currentCoinId === 3 && (coinData.name === 'Litecoin' || coinData.name === 'Litecoin MWEB'));
+    const isCurrentCoin = (coinData.id === currentCoinId);
+
+    if (isPartVariant || isLtcVariant || isCurrentCoin) {
+      console.log(`Updating percentage buttons for ${coinData.name} (ID: ${coinData.id}) on wallet page ${currentCoinId}`);
       const buttons = document.querySelectorAll('button[onclick*="setAmount"]');
       buttons.forEach(button => {
         const onclick = button.getAttribute('onclick');
         if (onclick) {
-          if (coinData.id === 1) {
+          if (currentCoinId === 1) {
             window.currentBalances = window.currentBalances || {};
 
             const anonBalance = coinData.name === 'Particl Anon' ? coinData.balance :
@@ -1181,7 +1186,7 @@ document.addEventListener('DOMContentLoaded', function() {
               `setAmount(${onclick.match(/setAmount\(([^,]+)/)[1]}, '${mainBalance}', ${currentCoinId}, '${blindBalance}', '${anonBalance}')`
             );
             button.setAttribute('onclick', newOnclick);
-          } else if (coinData.id === 3) {
+          } else if (currentCoinId === 3) {
             window.currentBalances = window.currentBalances || {};
 
             const mwebBalance = coinData.name === 'Litecoin MWEB' ? coinData.balance :

--- a/basicswap/templates/wallet.html
+++ b/basicswap/templates/wallet.html
@@ -1410,7 +1410,7 @@ document.addEventListener('DOMContentLoaded', function() {
 
   window.walletPeriodicRefresh = setInterval(() => {
     updateWalletBalances();
-  }, 300000);
+  }, 120000);
 
   window.addEventListener('beforeunload', cleanupWalletBalanceUpdates);
 

--- a/basicswap/templates/wallet.html
+++ b/basicswap/templates/wallet.html
@@ -1342,75 +1342,48 @@ document.addEventListener('DOMContentLoaded', function() {
   }
 
   function setupWalletWebSocketUpdates() {
+    window.BalanceUpdatesManager.setup({
+      contextKey: 'wallet',
+      balanceUpdateCallback: updateWalletBalances,
+      swapEventCallback: updateWalletBalances,
+      errorContext: 'Wallet',
+      enablePeriodicRefresh: true,
+      periodicInterval: 120000
+    });
+
     if (window.WebSocketManager && typeof window.WebSocketManager.addMessageHandler === 'function') {
-
-      const currentWalletTicker = window.location.pathname.split('/')[2]?.toUpperCase();
-
-
-      const balanceHandlerId = window.WebSocketManager.addMessageHandler('message', (data) => {
-
+      const priceHandlerId = window.WebSocketManager.addMessageHandler('message', (data) => {
         if (data && data.event) {
-
-          if (data.event === 'coin_balance_updated') {
-            clearTimeout(window.walletBalanceUpdateTimeout);
-            window.walletBalanceUpdateTimeout = setTimeout(() => {
-              updateWalletBalances();
-            }, 2000);
-          }
-
           if (data.event === 'price_updated' || data.event === 'prices_updated') {
-
             clearTimeout(window.walletPriceUpdateTimeout);
             window.walletPriceUpdateTimeout = setTimeout(() => {
               if (window.WalletManager && typeof window.WalletManager.updatePrices === 'function') {
-
                 window.WalletManager.updatePrices(true);
               }
-
             }, 500);
-          }
-
-
-          const swapEvents = ['new_bid', 'bid_accepted', 'swap_completed'];
-          if (swapEvents.includes(data.event)) {
-
-
-            clearTimeout(window.walletSwapEventTimeout);
-            window.walletSwapEventTimeout = setTimeout(() => {
-
-              updateWalletBalances();
-            }, 5000);
           }
         }
       });
-
-      window.walletBalanceHandlerId = balanceHandlerId;
+      window.walletPriceHandlerId = priceHandlerId;
     }
   }
 
   function cleanupWalletBalanceUpdates() {
-    if (window.walletBalanceHandlerId && window.WebSocketManager) {
-      window.WebSocketManager.removeMessageHandler('message', window.walletBalanceHandlerId);
-    }
-    clearTimeout(window.walletBalanceUpdateTimeout);
-    clearTimeout(window.walletSwapEventTimeout);
-    clearTimeout(window.walletPriceUpdateTimeout);
-    if (window.walletPeriodicRefresh) {
-      clearInterval(window.walletPeriodicRefresh);
-      window.walletPeriodicRefresh = null;
+    window.BalanceUpdatesManager.cleanup('wallet');
+
+    if (window.walletPriceHandlerId && window.WebSocketManager) {
+      window.WebSocketManager.removeMessageHandler('message', window.walletPriceHandlerId);
     }
 
+    clearTimeout(window.walletPriceUpdateTimeout);
   }
 
+  window.BalanceUpdatesManager.initialize();
   setupWalletWebSocketUpdates();
 
   setTimeout(() => {
     updateWalletBalances();
   }, 1000);
-
-  window.walletPeriodicRefresh = setInterval(() => {
-    updateWalletBalances();
-  }, 120000);
 
   window.addEventListener('beforeunload', cleanupWalletBalanceUpdates);
 

--- a/basicswap/templates/wallet.html
+++ b/basicswap/templates/wallet.html
@@ -1100,6 +1100,19 @@ document.addEventListener('DOMContentLoaded', function() {
 
   window.currentBalances = window.currentBalances || {};
 
+  {% if w.cid == '1' %}
+  window.currentBalances = {
+    mainBalance: '{{ w.balance }}',
+    blindBalance: '{{ w.blind_balance }}',
+    anonBalance: '{{ w.anon_balance }}'
+  };
+  {% elif w.cid == '3' %}
+  window.currentBalances = {
+    mainBalance: '{{ w.balance }}',
+    mwebBalance: '{{ w.mweb_balance }}'
+  };
+  {% endif %}
+
   function updateWalletBalances() {
     fetch('/json/walletbalances', {
       headers: {
@@ -1150,16 +1163,18 @@ document.addEventListener('DOMContentLoaded', function() {
         const onclick = button.getAttribute('onclick');
         if (onclick) {
           if (coinData.id === 1) {
-            const anonBalance = coinData.name === 'Particl Anon' ? coinData.balance :
-                              (window.currentBalances && window.currentBalances.anonBalance) || '0';
-            const blindBalance = coinData.name === 'Particl Blind' ? coinData.balance :
-                               (window.currentBalances && window.currentBalances.blindBalance) || '0';
-            const mainBalance = coinData.name === 'Particl' ? coinData.balance :
-                              (window.currentBalances && window.currentBalances.mainBalance) || '0';
+            window.currentBalances = window.currentBalances || {};
 
-            if (coinData.name === 'Particl') window.currentBalances = { ...window.currentBalances, mainBalance: coinData.balance };
-            if (coinData.name === 'Particl Anon') window.currentBalances = { ...window.currentBalances, anonBalance: coinData.balance };
-            if (coinData.name === 'Particl Blind') window.currentBalances = { ...window.currentBalances, blindBalance: coinData.balance };
+            const anonBalance = coinData.name === 'Particl Anon' ? coinData.balance :
+                              (window.currentBalances.anonBalance || '0');
+            const blindBalance = coinData.name === 'Particl Blind' ? coinData.balance :
+                               (window.currentBalances.blindBalance || '0');
+            const mainBalance = coinData.name === 'Particl' ? coinData.balance :
+                              (window.currentBalances.mainBalance || '0');
+
+            if (coinData.name === 'Particl') window.currentBalances.mainBalance = coinData.balance;
+            if (coinData.name === 'Particl Anon') window.currentBalances.anonBalance = coinData.balance;
+            if (coinData.name === 'Particl Blind') window.currentBalances.blindBalance = coinData.balance;
 
             const newOnclick = onclick.replace(
               /setAmount\([^,]+,\s*'[^']*',\s*\d+,\s*'[^']*',\s*'[^']*'\)/,
@@ -1167,13 +1182,15 @@ document.addEventListener('DOMContentLoaded', function() {
             );
             button.setAttribute('onclick', newOnclick);
           } else if (coinData.id === 3) {
-            const mwebBalance = coinData.name === 'Litecoin MWEB' ? coinData.balance :
-                              (window.currentBalances && window.currentBalances.mwebBalance) || '0';
-            const mainBalance = coinData.name === 'Litecoin' ? coinData.balance :
-                              (window.currentBalances && window.currentBalances.mainBalance) || '0';
+            window.currentBalances = window.currentBalances || {};
 
-            if (coinData.name === 'Litecoin') window.currentBalances = { ...window.currentBalances, mainBalance: coinData.balance };
-            if (coinData.name === 'Litecoin MWEB') window.currentBalances = { ...window.currentBalances, mwebBalance: coinData.balance };
+            const mwebBalance = coinData.name === 'Litecoin MWEB' ? coinData.balance :
+                              (window.currentBalances.mwebBalance || '0');
+            const mainBalance = coinData.name === 'Litecoin' ? coinData.balance :
+                              (window.currentBalances.mainBalance || '0');
+
+            if (coinData.name === 'Litecoin') window.currentBalances.mainBalance = coinData.balance;
+            if (coinData.name === 'Litecoin MWEB') window.currentBalances.mwebBalance = coinData.balance;
 
             const newOnclick = onclick.replace(
               /setAmount\([^,]+,\s*'[^']*',\s*\d+,\s*'[^']*'\)/,

--- a/basicswap/templates/wallet.html
+++ b/basicswap/templates/wallet.html
@@ -13,7 +13,7 @@
               <span class="inline-block align-middle">
               <img class="mr-2 h-16" src="/static/images/coins/{{ w.name }}.png" alt="{{ w.name }}"></span>({{ w.ticker }}) {{ w.name }} Wallet </h2>
           </div>
-          <div class="w-full md:w-1/2 p-3 p-6 container flex flex-wrap items-center justify-end items-center mx-auto"> <a class="rounded-full mr-5 flex flex-wrap justify-center px-5 py-3 bg-blue-500 hover:bg-blue-600 font-medium text-lg lg:text-sm text-white border dark:bg-gray-500 dark:hover:bg-gray-700 border-blue-500 rounded-md shadow-button focus:ring-0 focus:outline-none" id="refresh" href="/wallet/{{ w.ticker }}"> {{ circular_arrows_svg | safe }}<span>Refresh</span> </a> </div>
+          <div class="w-full md:w-1/2 p-3 p-6 container flex flex-wrap items-center justify-end items-center mx-auto"></div>
         </div>
       </div>
     </div>
@@ -667,16 +667,7 @@ function setAmount(percent, balance, cid, blindBalance, anonBalance) {
  var floatBalance;
  var calculatedAmount;
 
- console.log('SetAmount Called with:', {
-  percent: percent,
-  balance: balance,
-  cid: cid,
-  blindBalance: blindBalance,
-  anonBalance: anonBalance,
-  selectedType: selectedType,
-  blindBalanceType: typeof blindBalance,
-  blindBalanceNumeric: Number(blindBalance)
- });
+
 
  const safeParseFloat = (value) => {
   const numValue = Number(value);
@@ -706,11 +697,7 @@ function setAmount(percent, balance, cid, blindBalance, anonBalance) {
 
  calculatedAmount = Math.max(0, Math.floor(floatBalance * percent * 100000000) / 100000000);
  
- console.log('Calculated Amount:', {
-  floatBalance: floatBalance,
-  calculatedAmount: calculatedAmount,
-  percent: percent
- });
+
 
  if (percent === 1) {
   calculatedAmount = floatBalance;
@@ -727,43 +714,6 @@ function setAmount(percent, balance, cid, blindBalance, anonBalance) {
  if (subfeeCheckbox) {
   subfeeCheckbox.checked = (percent === 1);
  }
-
- console.log('Final Amount Set:', amountInput.value);
-}function setAmount(percent, balance, cid, blindBalance, anonBalance) {
- var amountInput = document.getElementById('amount');
- var typeSelect = document.getElementById('withdraw_type');
- var selectedType = typeSelect.value;
- var floatBalance;
- var calculatedAmount;
-
- switch(selectedType) {
-  case 'plain':
-   floatBalance = parseFloat(balance);
-   break;
-  case 'blind':
-   floatBalance = parseFloat(blindBalance);
-   break;
-  case 'anon':
-   floatBalance = parseFloat(anonBalance);
-   break;
-  default:
-   floatBalance = parseFloat(balance);
-   break;
- }
-
- calculatedAmount = Math.floor(floatBalance * percent * 100000000) / 100000000;
-
- if (percent === 1) {
-  calculatedAmount = floatBalance;
- }
-
- amountInput.value = calculatedAmount.toFixed(8);
-
- var subfeeCheckbox = document.querySelector(`[name="subfee_${cid}"]`);
- if (subfeeCheckbox) {
-  subfeeCheckbox.checked = (percent === 1);
- }
-
 }
 </script>
 
@@ -818,17 +768,14 @@ function setAmount(percent, balance, cid, blindBalance, anonBalance) {
 
   const specialCids = [6, 9];
 
-  console.log("CID:", cid);
-  console.log("Percent:", percent);
-  console.log("Balance:", balance);
-  console.log("Calculated Amount:", calculatedAmount);
+
 
   if (specialCids.includes(parseInt(cid)) && percent === 1) {
    amountInput.setAttribute('data-hidden', 'true');
    amountInput.placeholder = 'Sweep All';
    amountInput.value = '';
    amountInput.disabled = true;
-   console.log("Sweep All activated for special CID:", cid);
+
   } else {
    amountInput.value = calculatedAmount.toFixed(8);
    amountInput.setAttribute('data-hidden', 'false');
@@ -840,17 +787,15 @@ function setAmount(percent, balance, cid, blindBalance, anonBalance) {
   if (sweepAllCheckbox) {
    if (specialCids.includes(parseInt(cid)) && percent === 1) {
     sweepAllCheckbox.checked = true;
-    console.log("Sweep All checkbox checked");
    } else {
     sweepAllCheckbox.checked = false;
-    console.log("Sweep All checkbox unchecked");
    }
   }
 
   let subfeeCheckbox = document.querySelector(`[name="subfee_${cid}"]`);
   if (subfeeCheckbox) {
    subfeeCheckbox.checked = (percent === 1);
-   console.log("Subfee checkbox status for CID", cid, ":", subfeeCheckbox.checked);
+
   }
  }
 </script>
@@ -1148,6 +1093,336 @@ function confirmUTXOResize() {
 }
 
 document.addEventListener('DOMContentLoaded', function() {
+
+  if (window.WebSocketManager && typeof window.WebSocketManager.initialize === 'function') {
+    window.WebSocketManager.initialize();
+  }
+
+  function updateWalletBalances() {
+    fetch('/json/walletbalances', {
+      headers: {
+        'Accept': 'application/json',
+        'Content-Type': 'application/json'
+      }
+    })
+      .then(response => {
+        if (!response.ok) {
+          throw new Error(`Server error: ${response.status} ${response.statusText}`);
+        }
+        return response.json();
+      })
+      .then(balanceData => {
+        if (balanceData.error) {
+          throw new Error(balanceData.error);
+        }
+
+        if (!Array.isArray(balanceData)) {
+          throw new Error('Invalid response format');
+        }
+
+
+        balanceData.forEach(coin => {
+          updateWalletDisplay(coin);
+        });
+
+
+        setTimeout(() => {
+          if (window.WalletManager && typeof window.WalletManager.updatePrices === 'function') {
+            window.WalletManager.updatePrices(true);
+          }
+
+        }, 100);
+      })
+      .catch(error => {
+        console.error('[Wallet] Error updating wallet balances:', error);
+      });
+  }
+
+  function updateWalletDisplay(coinData) {
+
+    if (coinData.name === 'Particl') {
+
+      updateSpecificBalance('Particl', 'Balance:', coinData.balance, coinData.ticker || 'PART');
+    } else if (coinData.name === 'Particl Anon') {
+
+      updateSpecificBalance('Particl', 'Anon Balance:', coinData.balance, coinData.ticker || 'PART');
+
+      removePendingBalance('Particl', 'Anon Balance:');
+      if (coinData.pending && parseFloat(coinData.pending) > 0) {
+        updatePendingBalance('Particl', 'Anon Balance:', coinData.pending, coinData.ticker || 'PART', 'Pending:', coinData);
+      }
+    } else if (coinData.name === 'Particl Blind') {
+
+      updateSpecificBalance('Particl', 'Blind Balance:', coinData.balance, coinData.ticker || 'PART');
+
+      removePendingBalance('Particl', 'Blind Balance:');
+      if (coinData.pending && parseFloat(coinData.pending) > 0) {
+        updatePendingBalance('Particl', 'Blind Balance:', coinData.pending, coinData.ticker || 'PART', 'Unconfirmed:', coinData);
+      }
+    } else if (coinData.name === 'Litecoin') {
+
+      updateSpecificBalance('Litecoin', 'Balance:', coinData.balance, coinData.ticker || 'LTC');
+
+      if (coinData.pending && parseFloat(coinData.pending) > 0) {
+        updatePendingDisplay(coinData);
+      } else {
+        removePendingDisplay(coinData.name);
+      }
+    } else if (coinData.name === 'Litecoin MWEB') {
+
+      updateSpecificBalance('Litecoin', 'MWEB Balance:', coinData.balance, coinData.ticker || 'LTC');
+
+      if (coinData.pending && parseFloat(coinData.pending) > 0) {
+        updatePendingBalance('Litecoin', 'MWEB Balance:', coinData.pending, coinData.ticker || 'LTC', 'Pending:', coinData);
+      }
+    } else {
+
+      updateSpecificBalance(coinData.name, 'Balance:', coinData.balance, coinData.ticker || coinData.name);
+
+
+      if (coinData.pending && parseFloat(coinData.pending) > 0) {
+        updatePendingDisplay(coinData);
+      } else {
+        removePendingDisplay(coinData.name);
+      }
+    }
+  }
+
+  function updateSpecificBalance(coinName, labelText, balance, ticker, isPending = false) {
+    const balanceElements = document.querySelectorAll('.coinname-value[data-coinname]');
+    let found = false;
+
+    balanceElements.forEach(element => {
+      const elementCoinName = element.getAttribute('data-coinname');
+
+      if (elementCoinName === coinName) {
+        const parentRow = element.closest('tr');
+        if (parentRow) {
+          const labelCell = parentRow.querySelector('td:first-child');
+          if (labelCell) {
+            const currentLabel = labelCell.textContent.trim();
+
+            if (currentLabel.includes(labelText)) {
+              if (isPending) {
+                element.textContent = `+${balance} ${ticker}`;
+              } else {
+                element.textContent = `${balance} ${ticker}`;
+              }
+
+
+              setTimeout(() => {
+                if (window.WalletManager && typeof window.WalletManager.updatePrices === 'function') {
+                  window.WalletManager.updatePrices(false);
+                }
+              }, 50);
+
+              found = true;
+            }
+          }
+        }
+      }
+    });
+  }
+
+  function updatePendingDisplay(coinData) {
+
+    const balanceElements = document.querySelectorAll('.coinname-value[data-coinname]');
+
+    balanceElements.forEach(element => {
+      const elementCoinName = element.getAttribute('data-coinname');
+
+      if (elementCoinName === coinData.name) {
+        const parentRow = element.closest('tr');
+        if (parentRow) {
+          const labelCell = parentRow.querySelector('td:first-child');
+          if (labelCell && labelCell.textContent.includes('Balance:')) {
+
+            const balanceCell = parentRow.querySelector('td:nth-child(2)');
+            if (balanceCell) {
+              let pendingSpan = balanceCell.querySelector('.inline-block.py-1.px-2.rounded-full.bg-green-100');
+
+              if (coinData.pending && parseFloat(coinData.pending) > 0) {
+                if (!pendingSpan) {
+
+                  pendingSpan = document.createElement('span');
+                  pendingSpan.className = 'inline-block py-1 px-2 rounded-full bg-green-100 text-green-500 dark:bg-gray-500 dark:text-green-500';
+                  balanceCell.appendChild(document.createTextNode(' '));
+                  balanceCell.appendChild(pendingSpan);
+                }
+
+                const ticker = coinData.ticker || coinData.name;
+
+                pendingSpan.textContent = `Pending: +${coinData.pending} ${ticker}`;
+              } else {
+
+                if (pendingSpan) {
+                  pendingSpan.remove();
+                }
+              }
+            }
+          }
+        }
+      }
+    });
+  }
+
+  function removePendingDisplay(coinName) {
+    const balanceElements = document.querySelectorAll('.coinname-value[data-coinname]');
+
+    balanceElements.forEach(element => {
+      const elementCoinName = element.getAttribute('data-coinname');
+
+      if (elementCoinName === coinName) {
+        const parentRow = element.closest('tr');
+        if (parentRow) {
+          const balanceCell = parentRow.querySelector('td:nth-child(2)');
+          if (balanceCell) {
+            const pendingSpan = balanceCell.querySelector('.inline-block.py-1.px-2.rounded-full.bg-green-100');
+            if (pendingSpan) {
+              pendingSpan.remove();
+            }
+          }
+        }
+      }
+    });
+  }
+
+  function updatePendingBalance(coinName, balanceType, pendingAmount, ticker, pendingLabel, coinData) {
+    const balanceElements = document.querySelectorAll('.coinname-value[data-coinname]');
+
+    balanceElements.forEach(element => {
+      const elementCoinName = element.getAttribute('data-coinname');
+
+      if (elementCoinName === coinName) {
+        const parentRow = element.closest('tr');
+        if (parentRow) {
+          const labelCell = parentRow.querySelector('td:first-child');
+          if (labelCell && labelCell.textContent.includes(balanceType)) {
+
+            const balanceCell = parentRow.querySelector('td:nth-child(2)');
+            if (balanceCell) {
+              let pendingSpan = balanceCell.querySelector('.inline-block.py-1.px-2.rounded-full.bg-green-100');
+
+              if (pendingAmount && parseFloat(pendingAmount) > 0) {
+                if (!pendingSpan) {
+
+                  pendingSpan = document.createElement('span');
+                  pendingSpan.className = 'inline-block py-1 px-2 rounded-full bg-green-100 text-green-500 dark:bg-gray-500 dark:text-green-500';
+                  balanceCell.appendChild(document.createTextNode(' '));
+                  balanceCell.appendChild(pendingSpan);
+                }
+
+
+                pendingSpan.textContent = `${pendingLabel} +${pendingAmount} ${ticker}`;
+              } else if (pendingSpan) {
+
+                pendingSpan.remove();
+              }
+            }
+          }
+        }
+      }
+    });
+  }
+
+  function removePendingBalance(coinName, balanceType) {
+    const balanceElements = document.querySelectorAll('.coinname-value[data-coinname]');
+
+    balanceElements.forEach(element => {
+      const elementCoinName = element.getAttribute('data-coinname');
+
+      if (elementCoinName === coinName) {
+        const parentRow = element.closest('tr');
+        if (parentRow) {
+          const labelCell = parentRow.querySelector('td:first-child');
+          if (labelCell && labelCell.textContent.includes(balanceType)) {
+
+            const balanceCell = parentRow.querySelector('td:nth-child(2)');
+            if (balanceCell) {
+              const pendingSpan = balanceCell.querySelector('.inline-block.py-1.px-2.rounded-full.bg-green-100');
+              if (pendingSpan) {
+                pendingSpan.remove();
+              }
+            }
+          }
+        }
+      }
+    });
+  }
+
+  function setupWalletWebSocketUpdates() {
+    if (window.WebSocketManager && typeof window.WebSocketManager.addMessageHandler === 'function') {
+
+      const currentWalletTicker = window.location.pathname.split('/')[2]?.toUpperCase();
+
+
+      const balanceHandlerId = window.WebSocketManager.addMessageHandler('message', (data) => {
+
+        if (data && data.event) {
+
+          if (data.event === 'coin_balance_updated') {
+            clearTimeout(window.walletBalanceUpdateTimeout);
+            window.walletBalanceUpdateTimeout = setTimeout(() => {
+              updateWalletBalances();
+            }, 2000);
+          }
+
+          if (data.event === 'price_updated' || data.event === 'prices_updated') {
+
+            clearTimeout(window.walletPriceUpdateTimeout);
+            window.walletPriceUpdateTimeout = setTimeout(() => {
+              if (window.WalletManager && typeof window.WalletManager.updatePrices === 'function') {
+
+                window.WalletManager.updatePrices(true);
+              }
+
+            }, 500);
+          }
+
+
+          const swapEvents = ['new_bid', 'bid_accepted', 'swap_completed'];
+          if (swapEvents.includes(data.event)) {
+
+
+            clearTimeout(window.walletSwapEventTimeout);
+            window.walletSwapEventTimeout = setTimeout(() => {
+
+              updateWalletBalances();
+            }, 5000);
+          }
+        }
+      });
+
+      window.walletBalanceHandlerId = balanceHandlerId;
+    }
+  }
+
+  function cleanupWalletBalanceUpdates() {
+    if (window.walletBalanceHandlerId && window.WebSocketManager) {
+      window.WebSocketManager.removeMessageHandler('message', window.walletBalanceHandlerId);
+    }
+    clearTimeout(window.walletBalanceUpdateTimeout);
+    clearTimeout(window.walletSwapEventTimeout);
+    clearTimeout(window.walletPriceUpdateTimeout);
+    if (window.walletPeriodicRefresh) {
+      clearInterval(window.walletPeriodicRefresh);
+      window.walletPeriodicRefresh = null;
+    }
+
+  }
+
+  setupWalletWebSocketUpdates();
+
+  setTimeout(() => {
+    updateWalletBalances();
+  }, 1000);
+
+  window.walletPeriodicRefresh = setInterval(() => {
+    updateWalletBalances();
+  }, 300000);
+
+  window.addEventListener('beforeunload', cleanupWalletBalanceUpdates);
+
   document.getElementById('confirmYes').addEventListener('click', function() {
     if (typeof confirmCallback === 'function') {
       confirmCallback();

--- a/basicswap/templates/wallet.html
+++ b/basicswap/templates/wallet.html
@@ -1098,6 +1098,8 @@ document.addEventListener('DOMContentLoaded', function() {
     window.WebSocketManager.initialize();
   }
 
+  window.currentBalances = window.currentBalances || {};
+
   function updateWalletBalances() {
     fetch('/json/walletbalances', {
       headers: {
@@ -1123,6 +1125,7 @@ document.addEventListener('DOMContentLoaded', function() {
 
         balanceData.forEach(coin => {
           updateWalletDisplay(coin);
+          updatePercentageButtons(coin);
         });
 
 
@@ -1136,6 +1139,57 @@ document.addEventListener('DOMContentLoaded', function() {
       .catch(error => {
         console.error('[Wallet] Error updating wallet balances:', error);
       });
+  }
+
+  function updatePercentageButtons(coinData) {
+    const currentCoinId = {{ w.cid }};
+
+    if (coinData.id === currentCoinId) {
+      const buttons = document.querySelectorAll('button[onclick*="setAmount"]');
+      buttons.forEach(button => {
+        const onclick = button.getAttribute('onclick');
+        if (onclick) {
+          if (coinData.id === 1) {
+            const anonBalance = coinData.name === 'Particl Anon' ? coinData.balance :
+                              (window.currentBalances && window.currentBalances.anonBalance) || '0';
+            const blindBalance = coinData.name === 'Particl Blind' ? coinData.balance :
+                               (window.currentBalances && window.currentBalances.blindBalance) || '0';
+            const mainBalance = coinData.name === 'Particl' ? coinData.balance :
+                              (window.currentBalances && window.currentBalances.mainBalance) || '0';
+
+            if (coinData.name === 'Particl') window.currentBalances = { ...window.currentBalances, mainBalance: coinData.balance };
+            if (coinData.name === 'Particl Anon') window.currentBalances = { ...window.currentBalances, anonBalance: coinData.balance };
+            if (coinData.name === 'Particl Blind') window.currentBalances = { ...window.currentBalances, blindBalance: coinData.balance };
+
+            const newOnclick = onclick.replace(
+              /setAmount\([^,]+,\s*'[^']*',\s*\d+,\s*'[^']*',\s*'[^']*'\)/,
+              `setAmount(${onclick.match(/setAmount\(([^,]+)/)[1]}, '${mainBalance}', ${currentCoinId}, '${blindBalance}', '${anonBalance}')`
+            );
+            button.setAttribute('onclick', newOnclick);
+          } else if (coinData.id === 3) {
+            const mwebBalance = coinData.name === 'Litecoin MWEB' ? coinData.balance :
+                              (window.currentBalances && window.currentBalances.mwebBalance) || '0';
+            const mainBalance = coinData.name === 'Litecoin' ? coinData.balance :
+                              (window.currentBalances && window.currentBalances.mainBalance) || '0';
+
+            if (coinData.name === 'Litecoin') window.currentBalances = { ...window.currentBalances, mainBalance: coinData.balance };
+            if (coinData.name === 'Litecoin MWEB') window.currentBalances = { ...window.currentBalances, mwebBalance: coinData.balance };
+
+            const newOnclick = onclick.replace(
+              /setAmount\([^,]+,\s*'[^']*',\s*\d+,\s*'[^']*'\)/,
+              `setAmount(${onclick.match(/setAmount\(([^,]+)/)[1]}, '${mainBalance}', ${currentCoinId}, '${mwebBalance}')`
+            );
+            button.setAttribute('onclick', newOnclick);
+          } else {
+            const newOnclick = onclick.replace(
+              /setAmount\([^,]+,\s*'[^']*',\s*\d+\)/,
+              `setAmount(${onclick.match(/setAmount\(([^,]+)/)[1]}, '${coinData.balance}', ${currentCoinId})`
+            );
+            button.setAttribute('onclick', newOnclick);
+          }
+        }
+      });
+    }
   }
 
   function updateWalletDisplay(coinData) {

--- a/basicswap/templates/wallet.html
+++ b/basicswap/templates/wallet.html
@@ -1162,7 +1162,6 @@ document.addEventListener('DOMContentLoaded', function() {
     const isCurrentCoin = (coinData.id === currentCoinId);
 
     if (isPartVariant || isLtcVariant || isCurrentCoin) {
-      console.log(`Updating percentage buttons for ${coinData.name} (ID: ${coinData.id}) on wallet page ${currentCoinId}`);
       const buttons = document.querySelectorAll('button[onclick*="setAmount"]');
       buttons.forEach(button => {
         const onclick = button.getAttribute('onclick');

--- a/basicswap/templates/wallet.html
+++ b/basicswap/templates/wallet.html
@@ -1159,15 +1159,6 @@ document.addEventListener('DOMContentLoaded', function() {
       if (coinData.pending && parseFloat(coinData.pending) > 0) {
         updatePendingBalance('Particl', 'Blind Balance:', coinData.pending, coinData.ticker || 'PART', 'Unconfirmed:', coinData);
       }
-    } else if (coinData.name === 'Litecoin') {
-
-      updateSpecificBalance('Litecoin', 'Balance:', coinData.balance, coinData.ticker || 'LTC');
-
-      if (coinData.pending && parseFloat(coinData.pending) > 0) {
-        updatePendingDisplay(coinData);
-      } else {
-        removePendingDisplay(coinData.name);
-      }
     } else if (coinData.name === 'Litecoin MWEB') {
 
       updateSpecificBalance('Litecoin', 'MWEB Balance:', coinData.balance, coinData.ticker || 'LTC');

--- a/basicswap/templates/wallets.html
+++ b/basicswap/templates/wallets.html
@@ -198,21 +198,19 @@ document.addEventListener('DOMContentLoaded', function() {
   }
 
   function setupWalletsWebSocketUpdates() {
+    window.BalanceUpdatesManager.setup({
+      contextKey: 'wallets',
+      balanceUpdateCallback: updateWalletBalances,
+      swapEventCallback: updateWalletBalances,
+      errorContext: 'Wallets',
+      enablePeriodicRefresh: true,
+      periodicInterval: 60000
+    });
+
     if (window.WebSocketManager && typeof window.WebSocketManager.addMessageHandler === 'function') {
-
-
-      const balanceHandlerId = window.WebSocketManager.addMessageHandler('message', (data) => {
+      const priceHandlerId = window.WebSocketManager.addMessageHandler('message', (data) => {
         if (data && data.event) {
-
-          if (data.event === 'coin_balance_updated') {
-            clearTimeout(window.walletsBalanceUpdateTimeout);
-            window.walletsBalanceUpdateTimeout = setTimeout(() => {
-              updateWalletBalances();
-            }, 2000);
-          }
-
           if (data.event === 'price_updated' || data.event === 'prices_updated') {
-
             clearTimeout(window.walletsPriceUpdateTimeout);
             window.walletsPriceUpdateTimeout = setTimeout(() => {
               if (window.WalletManager && typeof window.WalletManager.updatePrices === 'function') {
@@ -220,51 +218,14 @@ document.addEventListener('DOMContentLoaded', function() {
               }
             }, 500);
           }
-
-
-          const swapEvents = ['new_bid', 'bid_accepted', 'swap_completed'];
-          if (swapEvents.includes(data.event)) {
-
-            clearTimeout(window.walletsSwapEventTimeout);
-            window.walletsSwapEventTimeout = setTimeout(() => {
-
-              updateWalletBalances();
-            }, 5000);
-          }
-
-
         }
       });
-
-      window.walletsBalanceHandlerId = balanceHandlerId;
-
-    } else {
-
+      window.walletsPriceHandlerId = priceHandlerId;
     }
   }
 
-  function updateWalletBalances() {
-    fetch('/json/walletbalances', {
-      headers: {
-        'Accept': 'application/json',
-        'Content-Type': 'application/json'
-      }
-    })
-    .then(response => {
-      if (!response.ok) {
-        throw new Error(`Server error: ${response.status} ${response.statusText}`);
-      }
-      return response.json();
-    })
-    .then(balanceData => {
-      if (balanceData.error) {
-        throw new Error(balanceData.error);
-      }
-
-      if (!Array.isArray(balanceData)) {
-        throw new Error('Invalid response format');
-      }
-
+  function updateWalletBalances(balanceData) {
+    if (balanceData) {
       balanceData.forEach(coin => {
         updateWalletDisplay(coin);
       });
@@ -274,10 +235,13 @@ document.addEventListener('DOMContentLoaded', function() {
           window.WalletManager.updatePrices(true);
         }
       }, 250);
-    })
-    .catch(error => {
-      console.error('Error updating wallet balances:', error);
-    });
+    } else {
+      window.BalanceUpdatesManager.fetchBalanceData()
+        .then(data => updateWalletBalances(data))
+        .catch(error => {
+          console.error('Error updating wallet balances:', error);
+        });
+    }
   }
 
   function updateWalletDisplay(coinData) {
@@ -622,33 +586,21 @@ document.addEventListener('DOMContentLoaded', function() {
   }
 
   function cleanupWalletsBalanceUpdates() {
-    if (window.walletsBalanceHandlerId && window.WebSocketManager) {
-      window.WebSocketManager.removeMessageHandler('message', window.walletsBalanceHandlerId);
+    window.BalanceUpdatesManager.cleanup('wallets');
 
+    if (window.walletsPriceHandlerId && window.WebSocketManager) {
+      window.WebSocketManager.removeMessageHandler('message', window.walletsPriceHandlerId);
     }
 
-    clearTimeout(window.walletsBalanceUpdateTimeout);
-    clearTimeout(window.walletsSwapEventTimeout);
     clearTimeout(window.walletsPriceUpdateTimeout);
-
-    if (window.walletsPeriodicRefresh) {
-      clearInterval(window.walletsPeriodicRefresh);
-      window.walletsPeriodicRefresh = null;
-    }
-
   }
 
+  window.BalanceUpdatesManager.initialize();
   setupWalletsWebSocketUpdates();
 
   setTimeout(() => {
     updateWalletBalances();
   }, 1000);
-
-  window.walletsPeriodicRefresh = setInterval(() => {
-    updateWalletBalances();
-  }, 60000);
-
-
 
   if (window.CleanupManager) {
     window.CleanupManager.registerResource('walletsBalanceUpdates', null, cleanupWalletsBalanceUpdates);

--- a/basicswap/templates/wallets.html
+++ b/basicswap/templates/wallets.html
@@ -21,8 +21,7 @@
         <div id="total-btc-value" class="text-sm text-white mt-2"></div>
      </div>
       <div class="w-full md:w-1/2 p-3 p-6 container flex flex-wrap items-center justify-end items-center mx-auto">
-        <a class="rounded-full mr-5 flex flex-wrap justify-center px-5 py-3 bg-blue-500 hover:bg-blue-600 font-medium text-sm text-white border dark:bg-gray-500 dark:hover:bg-gray-700 border-blue-500 rounded-md shadow-button focus:ring-0 focus:outline-none" id="refresh" href="/changepassword">{{ lock_svg | safe }}<span>Change/Set Password</span></a>
-        <a class="rounded-full flex flex-wrap justify-center px-5 py-3 bg-blue-500 hover:bg-blue-600 font-medium text-sm text-white border dark:bg-gray-500 dark:hover:bg-gray-700 border-blue-500 rounded-md shadow-button focus:ring-0 focus:outline-none" id="refresh" href="/wallets">{{ circular_arrows_svg | safe }}<span>Refresh</span></a>
+        <a class="rounded-full flex flex-wrap justify-center px-5 py-3 bg-blue-500 hover:bg-blue-600 font-medium text-sm text-white border dark:bg-gray-500 dark:hover:bg-gray-700 border-blue-500 rounded-md shadow-button focus:ring-0 focus:outline-none" href="/changepassword">{{ lock_svg | safe }}<span>Change/Set Password</span></a>
      </div>
     </div>
    </div>
@@ -190,5 +189,474 @@
  </section>
 
 {% include 'footer.html' %}
+
+<script>
+document.addEventListener('DOMContentLoaded', function() {
+
+  if (window.WebSocketManager && typeof window.WebSocketManager.initialize === 'function') {
+    window.WebSocketManager.initialize();
+  }
+
+  function setupWalletsWebSocketUpdates() {
+    if (window.WebSocketManager && typeof window.WebSocketManager.addMessageHandler === 'function') {
+
+
+      const balanceHandlerId = window.WebSocketManager.addMessageHandler('message', (data) => {
+        if (data && data.event) {
+
+          if (data.event === 'coin_balance_updated') {
+            clearTimeout(window.walletsBalanceUpdateTimeout);
+            window.walletsBalanceUpdateTimeout = setTimeout(() => {
+              updateWalletBalances();
+            }, 2000);
+          }
+
+          if (data.event === 'price_updated' || data.event === 'prices_updated') {
+
+            clearTimeout(window.walletsPriceUpdateTimeout);
+            window.walletsPriceUpdateTimeout = setTimeout(() => {
+              if (window.WalletManager && typeof window.WalletManager.updatePrices === 'function') {
+                window.WalletManager.updatePrices(true);
+              }
+            }, 500);
+          }
+
+
+          const swapEvents = ['new_bid', 'bid_accepted', 'swap_completed'];
+          if (swapEvents.includes(data.event)) {
+
+            clearTimeout(window.walletsSwapEventTimeout);
+            window.walletsSwapEventTimeout = setTimeout(() => {
+
+              updateWalletBalances();
+            }, 5000);
+          }
+
+
+        }
+      });
+
+      window.walletsBalanceHandlerId = balanceHandlerId;
+
+    } else {
+
+    }
+  }
+
+  function updateWalletBalances() {
+    fetch('/json/walletbalances', {
+      headers: {
+        'Accept': 'application/json',
+        'Content-Type': 'application/json'
+      }
+    })
+    .then(response => {
+      if (!response.ok) {
+        throw new Error(`Server error: ${response.status} ${response.statusText}`);
+      }
+      return response.json();
+    })
+    .then(balanceData => {
+      if (balanceData.error) {
+        throw new Error(balanceData.error);
+      }
+
+      if (!Array.isArray(balanceData)) {
+        throw new Error('Invalid response format');
+      }
+
+      balanceData.forEach(coin => {
+        updateWalletDisplay(coin);
+      });
+
+      setTimeout(() => {
+        if (window.WalletManager && typeof window.WalletManager.updatePrices === 'function') {
+          window.WalletManager.updatePrices(true);
+        }
+      }, 250);
+    })
+    .catch(error => {
+      console.error('Error updating wallet balances:', error);
+    });
+  }
+
+  function updateWalletDisplay(coinData) {
+    if (coinData.name === 'Particl') {
+      updateSpecificBalance('Particl', 'Balance:', coinData.balance, coinData.ticker || 'PART');
+    } else if (coinData.name === 'Particl Anon') {
+      updateSpecificBalance('Particl', 'Anon Balance:', coinData.balance, coinData.ticker || 'PART');
+      removePendingBalance('Particl', 'Anon Balance:');
+      if (coinData.pending && parseFloat(coinData.pending) > 0) {
+        updatePendingBalance('Particl', 'Anon Balance:', coinData.pending, coinData.ticker || 'PART', 'Anon Pending:', coinData);
+      }
+    } else if (coinData.name === 'Particl Blind') {
+      updateSpecificBalance('Particl', 'Blind Balance:', coinData.balance, coinData.ticker || 'PART');
+      removePendingBalance('Particl', 'Blind Balance:');
+      if (coinData.pending && parseFloat(coinData.pending) > 0) {
+        updatePendingBalance('Particl', 'Blind Balance:', coinData.pending, coinData.ticker || 'PART', 'Blind Unconfirmed:', coinData);
+      }
+    } else {
+      updateSpecificBalance(coinData.name, 'Balance:', coinData.balance, coinData.ticker || coinData.name);
+
+      if (coinData.name !== 'Particl Anon' && coinData.name !== 'Particl Blind' && coinData.name !== 'Litecoin MWEB') {
+        if (coinData.pending && parseFloat(coinData.pending) > 0) {
+          updatePendingDisplay(coinData);
+        } else {
+          removePendingDisplay(coinData.name);
+        }
+      }
+    }
+  }
+
+  function updateSpecificBalance(coinName, labelText, balance, ticker, isPending = false) {
+    const balanceElements = document.querySelectorAll('.coinname-value[data-coinname]');
+    let found = false;
+
+    balanceElements.forEach(element => {
+      const elementCoinName = element.getAttribute('data-coinname');
+
+      if (elementCoinName === coinName) {
+        const parentDiv = element.closest('.flex.mb-2.justify-between.items-center');
+        const labelElement = parentDiv ? parentDiv.querySelector('h4') : null;
+
+        if (labelElement) {
+          const currentLabel = labelElement.textContent.trim();
+
+          if (currentLabel === labelText) {
+            if (isPending) {
+              const cleanBalance = balance.toString().replace(/^\+/, '');
+              element.textContent = `+${cleanBalance} ${ticker}`;
+            } else {
+              element.textContent = `${balance} ${ticker}`;
+            }
+            found = true;
+          }
+        }
+      }
+    });
+
+  }
+
+  function updatePendingDisplay(coinData) {
+    const walletContainer = findWalletContainer(coinData.name);
+    if (!walletContainer) return;
+
+    const existingPendingElements = walletContainer.querySelectorAll('.flex.mb-2.justify-between.items-center');
+    let staticPendingElement = null;
+    let staticUsdElement = null;
+
+    existingPendingElements.forEach(element => {
+      const labelElement = element.querySelector('h4');
+      if (labelElement) {
+        const labelText = labelElement.textContent;
+        if (labelText.includes('Pending:') && !labelText.includes('USD')) {
+          staticPendingElement = element;
+        } else if (labelText.includes('Pending USD value:')) {
+          staticUsdElement = element;
+        }
+      }
+    });
+
+    if (staticPendingElement && staticUsdElement) {
+      const pendingSpan = staticPendingElement.querySelector('.coinname-value');
+      if (pendingSpan) {
+        const cleanPending = coinData.pending.toString().replace(/^\+/, '');
+        pendingSpan.textContent = `+${cleanPending} ${coinData.ticker || coinData.name}`;
+      }
+
+      let initialUSD = '$0.00';
+      if (window.WalletManager && window.WalletManager.coinPrices) {
+        const coinId = coinData.name.toLowerCase().replace(' ', '-');
+        const price = window.WalletManager.coinPrices[coinId];
+        if (price && price.usd) {
+          const cleanPending = coinData.pending.toString().replace(/^\+/, '');
+          const usdValue = (parseFloat(cleanPending) * price.usd).toFixed(2);
+          initialUSD = `$${usdValue}`;
+        }
+      }
+
+      const usdDiv = staticUsdElement.querySelector('.usd-value');
+      if (usdDiv) {
+        usdDiv.textContent = initialUSD;
+      }
+      return;
+    }
+
+    let pendingContainer = walletContainer.querySelector('.pending-container');
+
+    if (!pendingContainer) {
+      pendingContainer = document.createElement('div');
+      pendingContainer.className = 'pending-container';
+
+      const pendingRow = document.createElement('div');
+      pendingRow.className = 'flex mb-2 justify-between items-center';
+      const cleanPending = coinData.pending.toString().replace(/^\+/, '');
+      pendingRow.innerHTML = `
+        <h4 class="text-xs font-bold text-green-500 dark:text-green-500">Pending:</h4>
+        <span class="bold inline-block py-1 px-2 rounded-full bg-green-100 text-xs text-green-500 dark:bg-gray-500 dark:text-green-500 coinname-value" data-coinname="${coinData.name}">+${cleanPending} ${coinData.ticker || coinData.name}</span>
+      `;
+
+      pendingContainer.appendChild(pendingRow);
+
+      let initialUSD = '$0.00';
+      if (window.WalletManager && window.WalletManager.coinPrices) {
+        const coinId = coinData.name.toLowerCase().replace(' ', '-');
+        const price = window.WalletManager.coinPrices[coinId];
+        if (price && price.usd) {
+          const usdValue = (parseFloat(cleanPending) * price.usd).toFixed(2);
+          initialUSD = `$${usdValue}`;
+        }
+      }
+
+      const usdRow = document.createElement('div');
+      usdRow.className = 'flex mb-2 justify-between items-center';
+      usdRow.innerHTML = `
+        <h4 class="text-xs font-bold text-green-500 dark:text-green-500">Pending USD value:</h4>
+        <div class="bold inline-block py-1 px-2 rounded-full bg-green-100 text-xs text-green-500 dark:bg-gray-500 dark:text-green-500 usd-value">${initialUSD}</div>
+      `;
+      pendingContainer.appendChild(usdRow);
+
+      const balanceRow = walletContainer.querySelector('.flex.mb-2.justify-between.items-center');
+      let insertAfterElement = balanceRow;
+
+      if (balanceRow) {
+        let nextElement = balanceRow.nextElementSibling;
+        while (nextElement) {
+          const labelElement = nextElement.querySelector('h4');
+          if (labelElement && labelElement.textContent.includes('USD value:') &&
+              !labelElement.textContent.includes('Pending') && !labelElement.textContent.includes('Unconfirmed')) {
+            insertAfterElement = nextElement;
+            break;
+          }
+          nextElement = nextElement.nextElementSibling;
+        }
+      }
+
+      if (insertAfterElement && insertAfterElement.nextSibling) {
+        walletContainer.insertBefore(pendingContainer, insertAfterElement.nextSibling);
+      } else {
+        walletContainer.appendChild(pendingContainer);
+      }
+    } else {
+      const pendingElement = pendingContainer.querySelector('.coinname-value');
+      if (pendingElement) {
+        const cleanPending = coinData.pending.toString().replace(/^\+/, ''); // Remove existing + if any
+        pendingElement.textContent = `+${cleanPending} ${coinData.ticker || coinData.name}`;
+      }
+    }
+  }
+
+  function removePendingDisplay(coinName) {
+    const walletContainer = findWalletContainer(coinName);
+    if (!walletContainer) return;
+
+    const pendingContainer = walletContainer.querySelector('.pending-container');
+    if (pendingContainer) {
+      pendingContainer.remove();
+    }
+
+    const existingPendingElements = walletContainer.querySelectorAll('.flex.mb-2.justify-between.items-center');
+    existingPendingElements.forEach(element => {
+      const labelElement = element.querySelector('h4');
+      if (labelElement) {
+        const labelText = labelElement.textContent;
+        if (labelText.includes('Pending:') || labelText.includes('Pending USD value:')) {
+          element.style.display = 'none';
+        }
+      }
+    });
+  }
+
+  function removeSpecificPending(coinName, labelText) {
+    const balanceElements = document.querySelectorAll('.coinname-value[data-coinname]');
+
+    balanceElements.forEach(element => {
+      const elementCoinName = element.getAttribute('data-coinname');
+
+      if (elementCoinName === coinName) {
+        const parentDiv = element.closest('.flex.mb-2.justify-between.items-center');
+        const labelElement = parentDiv ? parentDiv.querySelector('h4') : null;
+
+        if (labelElement) {
+          const currentLabel = labelElement.textContent.trim();
+
+          if (currentLabel === labelText) {
+            parentDiv.remove();
+          }
+        }
+      }
+    });
+  }
+
+  function updatePendingBalance(coinName, balanceType, pendingAmount, ticker, pendingLabel, coinData) {
+    const balanceElements = document.querySelectorAll('.coinname-value[data-coinname]');
+    let targetElement = null;
+
+    balanceElements.forEach(element => {
+      const elementCoinName = element.getAttribute('data-coinname');
+      if (elementCoinName === coinName) {
+        const parentElement = element.closest('.flex.mb-2.justify-between.items-center');
+        if (parentElement) {
+          const labelElement = parentElement.querySelector('h4');
+          if (labelElement && labelElement.textContent.includes(balanceType)) {
+            targetElement = parentElement;
+          }
+        }
+      }
+    });
+
+    if (!targetElement) return;
+
+    let insertAfterElement = targetElement;
+    let nextElement = targetElement.nextElementSibling;
+    while (nextElement) {
+      const labelElement = nextElement.querySelector('h4');
+      if (labelElement) {
+        const labelText = labelElement.textContent;
+        if (labelText.includes('USD value:') && !labelText.includes('Pending') && !labelText.includes('Unconfirmed')) {
+          insertAfterElement = nextElement;
+          break;
+        }
+        if (labelText.includes('Balance:') || labelText.includes('Pending:') || labelText.includes('Unconfirmed:')) {
+          break;
+        }
+      }
+      nextElement = nextElement.nextElementSibling;
+    }
+
+    let pendingElement = insertAfterElement.nextElementSibling;
+    while (pendingElement && !pendingElement.querySelector('h4')?.textContent.includes(pendingLabel)) {
+      pendingElement = pendingElement.nextElementSibling;
+      if (pendingElement && pendingElement.querySelector('h4')?.textContent.includes('Balance:')) {
+        pendingElement = null;
+        break;
+      }
+    }
+
+    if (!pendingElement) {
+      const newPendingElement = document.createElement('div');
+      newPendingElement.className = 'flex mb-2 justify-between items-center';
+      newPendingElement.innerHTML = `
+        <h4 class="text-xs font-bold text-green-500 dark:text-green-500">${pendingLabel}</h4>
+        <span class="bold inline-block py-1 px-2 rounded-full bg-green-100 text-xs text-green-500 dark:bg-gray-500 dark:text-green-500 coinname-value" data-coinname="${coinName}">+${pendingAmount} ${ticker}</span>
+      `;
+
+      insertAfterElement.parentNode.insertBefore(newPendingElement, insertAfterElement.nextSibling);
+
+      let initialUSD = '$0.00';
+      if (window.WalletManager && window.WalletManager.coinPrices) {
+        const coinId = coinName.toLowerCase().replace(' ', '-');
+        const price = window.WalletManager.coinPrices[coinId];
+        if (price && price.usd) {
+          const usdValue = (parseFloat(pendingAmount) * price.usd).toFixed(2);
+          initialUSD = `$${usdValue}`;
+        }
+      }
+
+      const usdElement = document.createElement('div');
+      usdElement.className = 'flex mb-2 justify-between items-center';
+      usdElement.innerHTML = `
+        <h4 class="text-xs font-bold text-green-500 dark:text-green-500">${pendingLabel.replace(':', '')} USD value:</h4>
+        <div class="bold inline-block py-1 px-2 rounded-full bg-green-100 text-xs text-green-500 dark:bg-gray-500 dark:text-green-500 usd-value">${initialUSD}</div>
+      `;
+
+      newPendingElement.parentNode.insertBefore(usdElement, newPendingElement.nextSibling);
+    } else {
+      const pendingSpan = pendingElement.querySelector('.coinname-value');
+      if (pendingSpan) {
+        pendingSpan.textContent = `+${pendingAmount} ${ticker}`;
+      }
+    }
+  }
+
+  function removePendingBalance(coinName, balanceType) {
+    const balanceElements = document.querySelectorAll('.coinname-value[data-coinname]');
+    let targetElement = null;
+
+    balanceElements.forEach(element => {
+      const elementCoinName = element.getAttribute('data-coinname');
+      if (elementCoinName === coinName) {
+        const parentElement = element.closest('.flex.mb-2.justify-between.items-center');
+        if (parentElement) {
+          const labelElement = parentElement.querySelector('h4');
+          if (labelElement && labelElement.textContent.includes(balanceType)) {
+            targetElement = parentElement;
+          }
+        }
+      }
+    });
+
+    if (!targetElement) return;
+
+    let nextElement = targetElement.nextElementSibling;
+    while (nextElement) {
+      const labelElement = nextElement.querySelector('h4');
+      if (labelElement) {
+        const labelText = labelElement.textContent;
+        if (labelText.includes('Pending:') || labelText.includes('Unconfirmed:') ||
+            labelText.includes('Anon Pending:') || labelText.includes('Blind Unconfirmed:') ||
+            labelText.includes('Pending USD value:') || labelText.includes('Unconfirmed USD value:') ||
+            labelText.includes('Anon Pending USD value:') || labelText.includes('Blind Unconfirmed USD value:')) {
+          const elementToRemove = nextElement;
+          nextElement = nextElement.nextElementSibling;
+          elementToRemove.remove();
+        } else if (labelText.includes('Balance:')) {
+          break; // Stop if we hit another balance
+        } else {
+          nextElement = nextElement.nextElementSibling;
+        }
+      } else {
+        nextElement = nextElement.nextElementSibling;
+      }
+    }
+  }
+
+  function findWalletContainer(coinName) {
+    const balanceElements = document.querySelectorAll('.coinname-value[data-coinname]');
+    for (const element of balanceElements) {
+      if (element.getAttribute('data-coinname') === coinName) {
+        return element.closest('.bg-coolGray-100, .dark\\:bg-gray-600');
+      }
+    }
+    return null;
+  }
+
+  function cleanupWalletsBalanceUpdates() {
+    if (window.walletsBalanceHandlerId && window.WebSocketManager) {
+      window.WebSocketManager.removeMessageHandler('message', window.walletsBalanceHandlerId);
+
+    }
+
+    clearTimeout(window.walletsBalanceUpdateTimeout);
+    clearTimeout(window.walletsSwapEventTimeout);
+    clearTimeout(window.walletsPriceUpdateTimeout);
+
+    if (window.walletsPeriodicRefresh) {
+      clearInterval(window.walletsPeriodicRefresh);
+      window.walletsPeriodicRefresh = null;
+    }
+
+  }
+
+  setupWalletsWebSocketUpdates();
+
+  setTimeout(() => {
+    updateWalletBalances();
+  }, 1000);
+
+  window.walletsPeriodicRefresh = setInterval(() => {
+    updateWalletBalances();
+  }, 60000);
+
+
+
+  if (window.CleanupManager) {
+    window.CleanupManager.registerResource('walletsBalanceUpdates', null, cleanupWalletsBalanceUpdates);
+  }
+
+  window.addEventListener('beforeunload', cleanupWalletsBalanceUpdates);
+});
+</script>
+
 </body>
 </html>

--- a/basicswap/ui/page_amm.py
+++ b/basicswap/ui/page_amm.py
@@ -14,7 +14,7 @@ import traceback
 import sys
 from urllib import parse
 from urllib.request import Request, urlopen
-from .util import listAvailableCoins
+from .util import listAvailableCoinsWithBalances
 
 DEFAULT_AMM_CONFIG_FILE = "createoffers.json"
 DEFAULT_AMM_STATE_FILE = "createoffers_state.json"
@@ -1286,7 +1286,7 @@ def page_amm(self, _, post_string):
         except Exception as e:
             err_messages.append(f"Failed to read state file: {str(e)}")
 
-    coins = listAvailableCoins(swap_client)
+    coins = listAvailableCoinsWithBalances(swap_client)
 
     template = server.env.get_template("amm.html")
     return self.render_template(

--- a/basicswap/ui/page_offers.py
+++ b/basicswap/ui/page_offers.py
@@ -16,6 +16,7 @@ from .util import (
     have_data_entry,
     inputAmount,
     listAvailableCoins,
+    listAvailableCoinsWithBalances,
     PAGE_LIMIT,
     setCoinFilter,
     set_pagination_filters,
@@ -526,7 +527,7 @@ def page_newoffer(self, url_split, post_string):
     if swap_client.debug_ui:
         messages.append("Debug mode active.")
 
-    coins_from, coins_to = listAvailableCoins(swap_client, split_from=True)
+    coins_from, coins_to = listAvailableCoinsWithBalances(swap_client, split_from=True)
 
     addrs_from_raw = swap_client.listSMSGAddresses("offer_send_from")
     addrs_to_raw = swap_client.listSMSGAddresses("offer_send_to")

--- a/basicswap/ui/page_settings.py
+++ b/basicswap/ui/page_settings.py
@@ -60,6 +60,38 @@ def page_settings(self, url_split, post_string):
                     ),
                 }
                 swap_client.editGeneralSettings(data)
+            elif have_data_entry(form_data, "apply_notifications"):
+                active_tab = "notifications"
+                data = {
+                    "notifications_new_offers": toBool(
+                        get_data_entry_or(
+                            form_data, "notifications_new_offers", "false"
+                        )
+                    ),
+                    "notifications_new_bids": toBool(
+                        get_data_entry_or(form_data, "notifications_new_bids", "false")
+                    ),
+                    "notifications_bid_accepted": toBool(
+                        get_data_entry_or(
+                            form_data, "notifications_bid_accepted", "false"
+                        )
+                    ),
+                    "notifications_balance_changes": toBool(
+                        get_data_entry_or(
+                            form_data, "notifications_balance_changes", "false"
+                        )
+                    ),
+                    "notifications_outgoing_transactions": toBool(
+                        get_data_entry_or(
+                            form_data, "notifications_outgoing_transactions", "false"
+                        )
+                    ),
+                    "notifications_duration": int(
+                        get_data_entry_or(form_data, "notifications_duration", "20")
+                    ),
+                }
+                swap_client.editGeneralSettings(data)
+                messages.append("Notification settings applied.")
             elif have_data_entry(form_data, "apply_tor"):
                 active_tab = "tor"
                 # TODO: Detect if running in docker
@@ -186,6 +218,27 @@ def page_settings(self, url_split, post_string):
         "enabled_chart_coins": swap_client.settings.get("enabled_chart_coins", ""),
     }
 
+    notification_settings = {
+        "notifications_new_offers": swap_client.settings.get(
+            "notifications_new_offers", False
+        ),
+        "notifications_new_bids": swap_client.settings.get(
+            "notifications_new_bids", True
+        ),
+        "notifications_bid_accepted": swap_client.settings.get(
+            "notifications_bid_accepted", True
+        ),
+        "notifications_balance_changes": swap_client.settings.get(
+            "notifications_balance_changes", True
+        ),
+        "notifications_outgoing_transactions": swap_client.settings.get(
+            "notifications_outgoing_transactions", True
+        ),
+        "notifications_duration": swap_client.settings.get(
+            "notifications_duration", 20
+        ),
+    }
+
     tor_control_password = (
         ""
         if swap_client.tor_control_password is None
@@ -209,6 +262,7 @@ def page_settings(self, url_split, post_string):
             "chains": chains_formatted,
             "general_settings": general_settings,
             "chart_settings": chart_settings,
+            "notification_settings": notification_settings,
             "tor_settings": tor_settings,
             "active_tab": active_tab,
         },


### PR DESCRIPTION
- AMM: Balances (amounts per coin / wallet) in offfer/bid add/edit.
- New offer dropdown fromt/to (amounts per coin / wallet)
- Wallet/wallets removed refresh button.
- Wallet/wallets update dynamic now (no need for refresh or full page refresh) for wallet amounts/price.
- Balances update if in/out transaction.
- New json endpoint.
- Various fixes.
- Fix intervals. 
- Fix WS trigger for pending + normal balance and in/out.
- Fix amounts scientific notation (1e-8)
- Better notifications (toasts):
New Offers: Show notifications for new network offers (disabled by default).
New Bids: Show notifications for new bids on your offers.
Bid Accepted: Show notifications when your bids are accepted.
Balance Changes: Show notifications for incoming and outgoing funds.
Outgoing Transactions: Show notifications for sent funds
- Notifications better styling + animations.
- Notifications settings page tab (Configure which notifications you want to see + display Duration).
- Dev: Notifications settings debug_ui -> test all notification types.
- Removed (balance check) duplicated code and moved in one function.
- Moved balance updates JS in modules/balance-updates.js and cleaned up wallet/wallets/amm/offer_new_1 JS.
- Fixed mweb LTC toast issue.
- Added a check (balances updates) to skip if the chain is still syncing (else syncs will slow down a lot).
- Fixed GUI styling issues.
- Fix: Moving coins to-from mweb doesnt show as pending.
- Fix: When you withdraw funds, the 25/50/100% buttons reflect the old values until you reload the page.
- Fix: (cosmetic) Selecting wallet toast opens wallet page as wallet/xmr instead of wallet/XMR.
- Use ZMQ for part (pubhashwtx) balances (instant updated) + add on prepare/install particl config: zmqpubhashwtx=tcp: 
- Fix: ZMQ config for part.