### PR TITLE
fix: allow relative paths in inputs

### DIFF
--- a/basicswap/bin/prepare.py
+++ b/basicswap/bin/prepare.py
@@ -2350,10 +2350,10 @@ def main():
             continue
         if len(s) == 2:
             if name == "datadir":
-                data_dir = os.path.expanduser(s[1].strip('"'))
+                data_dir = os.path.abspath(os.path.expanduser(s[1].strip('"')))
                 continue
             if name == "bindir":
-                bin_dir = os.path.expanduser(s[1].strip('"'))
+                bin_dir = os.path.abspath(os.path.expanduser(s[1].strip('"')))
                 continue
             if name == "portoffset":
                 port_offset = int(s[1])
@@ -2410,7 +2410,9 @@ def main():
                 extra_opts["walletrestoretime"] = int(s[1])
                 continue
             if name == "keysdirpath":
-                extra_opts["keysdirpath"] = os.path.expanduser(s[1].strip('"'))
+                extra_opts["keysdirpath"] = os.path.abspath(
+                    os.path.expanduser(s[1].strip('"'))
+                )
                 continue
             if name == "trustremotenode":
                 extra_opts["trust_remote_node"] = toBool(s[1])

--- a/basicswap/bin/run.py
+++ b/basicswap/bin/run.py
@@ -797,7 +797,7 @@ def main():
             continue
         if len(s) == 2:
             if name == "datadir":
-                data_dir = os.path.expanduser(s[1])
+                data_dir = os.path.abspath(os.path.expanduser(s[1]))
                 continue
             if name == "logprefix":
                 log_prefix = s[1]


### PR DESCRIPTION
I didn't test this extensively, but it worked with `--datadir`.

Resolves: #345