### PR TITLE
Show notification when new release of BSX

### DIFF
--- a/basicswap/basicswap_util.py
+++ b/basicswap/basicswap_util.py
@@ -244,6 +244,7 @@ class NotificationTypes(IntEnum):
     BID_RECEIVED = auto()
     BID_ACCEPTED = auto()
     SWAP_COMPLETED = auto()
+    UPDATE_AVAILABLE = auto()
 
 
 class ConnectionRequestTypes(IntEnum):

--- a/basicswap/templates/settings.html
+++ b/basicswap/templates/settings.html
@@ -503,6 +503,17 @@
            <p class="text-xs text-gray-500 dark:text-gray-400 ml-7 mt-1">Show notifications when swaps complete successfully</p>
           </div>
 
+          <div class="py-2">
+           <div class="flex items-center">
+            <input type="checkbox" id="check_updates" name="check_updates" value="true" class="w-4 h-4 text-blue-600 bg-gray-100 border-gray-300 rounded focus:ring-blue-500 dark:focus:ring-blue-600 dark:ring-offset-gray-800 focus:ring-2 dark:bg-gray-600 dark:border-gray-500"{% if general_settings.check_updates %} checked{% endif %}>
+            <label for="check_updates" class="ml-3 text-sm font-medium text-gray-700 dark:text-gray-300">Update Notifications</label>
+            <button type="button" onclick="checkForUpdatesNow()" class="ml-3 text-xs bg-gray-600 hover:bg-gray-700 text-white font-medium py-1 px-3 rounded transition-colors focus:outline-none">
+             Check Now
+            </button>
+           </div>
+           <p class="text-xs text-gray-500 dark:text-gray-400 ml-7 mt-1">Check for BasicSwap updates and show notifications when available</p>
+          </div>
+
 
 
          </div>
@@ -537,9 +548,15 @@
        <div>
         <h4 class="text-sm font-medium text-gray-900 dark:text-white mb-4">Test Notifications</h4>
         <div class="bg-gray-50 dark:bg-gray-700 rounded-lg p-4">
-         <div>
+         <div class="space-y-3">
           <button type="button" onclick="window.NotificationManager && window.NotificationManager.testToasts()" class="bg-blue-600 hover:bg-blue-700 text-white font-medium py-2 px-4 rounded-lg transition-colors focus:outline-none">
            Test All Notification Types
+          </button>
+          <button type="button" onclick="testUpdateNotification()" class="bg-blue-600 hover:bg-blue-700 text-white font-medium py-2 px-4 rounded-lg transition-colors focus:outline-none">
+           Test Update Notification
+          </button>
+          <button type="button" onclick="testLiveUpdateCheck()" class="bg-green-600 hover:bg-green-700 text-white font-medium py-2 px-4 rounded-lg transition-colors focus:outline-none">
+           Test Live Update Check
           </button>
          </div>
         </div>
@@ -570,6 +587,7 @@
           showBalanceChanges: document.getElementById('notifications_balance_changes').checked,
           showOutgoingTransactions: document.getElementById('notifications_outgoing_transactions').checked,
           showSwapCompleted: document.getElementById('notifications_swap_completed').checked,
+          showUpdateNotifications: document.getElementById('check_updates').checked,
           notificationDuration: parseInt(document.getElementById('notifications_duration').value) * 1000
         };
 
@@ -580,6 +598,141 @@
     document.getElementById('notifications-tab').addEventListener('click', function() {
       setTimeout(syncNotificationSettings, 100);
     });
+
+    function testUpdateNotification() {
+      if (window.NotificationManager) {
+        window.NotificationManager.createToast(
+          'Update Available: v0.15.0',
+          'update_available',
+          {
+            subtitle: 'Current: v{{ version }} • Click to view release',
+            releaseUrl: 'https://github.com/basicswap/basicswap/releases/tag/v0.15.0',
+            releaseNotes: 'New version v0.15.0 is available. Click to view details on GitHub.'
+          }
+        );
+      }
+    }
+
+    function testLiveUpdateCheck() {
+      const button = event.target;
+      const originalText = button.textContent;
+      button.textContent = 'Checking...';
+      button.disabled = true;
+
+      fetch('/json/checkupdates', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        }
+      })
+      .then(response => response.json())
+      .then(data => {
+        if (window.NotificationManager) {
+          if (data.update_available) {
+            window.NotificationManager.createToast(
+              `Live Update Available: v${data.latest_version}`,
+              'update_available',
+              {
+                subtitle: `Current: v${data.current_version} • Click to view release`,
+                releaseUrl: `https://github.com/basicswap/basicswap/releases/tag/v${data.latest_version}`,
+                releaseNotes: 'This is a real update check from GitHub API.'
+              }
+            );
+          } else {
+            window.NotificationManager.createToast(
+              'No Updates Available',
+              'success',
+              {
+                subtitle: `Current version v${data.current_version} is up to date`
+              }
+            );
+          }
+        }
+      })
+      .catch(error => {
+        console.error('Update check failed:', error);
+        if (window.NotificationManager) {
+          window.NotificationManager.createToast(
+            'Update Check Failed',
+            'error',
+            {
+              subtitle: 'Could not check for updates. See console for details.'
+            }
+          );
+        }
+      })
+      .finally(() => {
+        button.textContent = originalText;
+        button.disabled = false;
+      });
+    }
+
+    function checkForUpdatesNow() {
+      const button = event.target;
+      const originalText = button.textContent;
+      button.textContent = 'Checking...';
+      button.disabled = true;
+
+      fetch('/json/checkupdates', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        }
+      })
+      .then(response => response.json())
+      .then(data => {
+        if (data.error) {
+          if (window.NotificationManager) {
+            window.NotificationManager.createToast(
+              'Update Check Failed',
+              'error',
+              {
+                subtitle: data.error
+              }
+            );
+          }
+          return;
+        }
+
+        if (window.NotificationManager) {
+          if (data.update_available) {
+            window.NotificationManager.createToast(
+              `Update Available: v${data.latest_version}`,
+              'update_available',
+              {
+                subtitle: `Current: v${data.current_version} • Click to view release`,
+                releaseUrl: `https://github.com/basicswap/basicswap/releases/tag/v${data.latest_version}`,
+                releaseNotes: `New version v${data.latest_version} is available. Click to view details on GitHub.`
+              }
+            );
+          } else {
+            window.NotificationManager.createToast(
+              'You\'re Up to Date!',
+              'success',
+              {
+                subtitle: `Current version v${data.current_version} is the latest`
+              }
+            );
+          }
+        }
+      })
+      .catch(error => {
+        console.error('Update check failed:', error);
+        if (window.NotificationManager) {
+          window.NotificationManager.createToast(
+            'Update Check Failed',
+            'error',
+            {
+              subtitle: 'Network error. Please try again later.'
+            }
+          );
+        }
+      })
+      .finally(() => {
+        button.textContent = originalText;
+        button.disabled = false;
+      });
+    }
 
     document.addEventListener('DOMContentLoaded', function() {
       syncNotificationSettings();

--- a/basicswap/templates/wallet.html
+++ b/basicswap/templates/wallet.html
@@ -665,7 +665,7 @@ function fillDonationAddress(address, type) {
            </td>
           </tr>
           {% endif %}
-          {% if donation_info %}
+          {% if debug_ui and donation_info %}
           <tr>
            <td colspan="2" class="py-3 px-6">
              <div class="p-4 bg-coolGray-100 dark:bg-gray-500 border border-coolGray-200 dark:border-gray-400 rounded-lg">

--- a/basicswap/ui/page_settings.py
+++ b/basicswap/ui/page_settings.py
@@ -94,6 +94,9 @@ def page_settings(self, url_split, post_string):
                     "notifications_duration": int(
                         get_data_entry_or(form_data, "notifications_duration", "20")
                     ),
+                    "check_updates": toBool(
+                        get_data_entry_or(form_data, "check_updates", "true")
+                    ),
                 }
                 swap_client.editGeneralSettings(data)
                 messages.append("Notification settings applied.")
@@ -207,6 +210,7 @@ def page_settings(self, url_split, post_string):
         "debug": swap_client.debug,
         "debug_ui": swap_client.debug_ui,
         "expire_db_records": swap_client._expire_db_records,
+        "check_updates": swap_client.settings.get("check_updates", True),
     }
 
     chart_api_key = get_api_key_setting(

--- a/basicswap/ui/page_wallet.py
+++ b/basicswap/ui/page_wallet.py
@@ -410,5 +410,6 @@ def page_wallet(self, url_split, post_string):
             "summary": summary,
             "block_unknown_seeds": swap_client._restrict_unknown_seed_wallets,
             "donation_info": donation_info,
+            "debug_ui": swap_client.debug_ui,
         },
     )


### PR DESCRIPTION
- Will show notification when new release of BSX, notification will stay until user clicks it away.
- Checks for new release every 24h, checks github tag/release.
- If TOR enabled update check will go over BSX backend TOR connection.
- Updated settings page for disabled/enable update notification + check now function.
- Moved wallet donation section under debug_ui for now.
- Will also display over CLI if new release.

<img width="396" height="211" alt="bsx_update" src="https://github.com/user-attachments/assets/2c053f06-f0d1-486f-90cf-2f997149049f" />