### PR TITLE
prepare: addcoin - only start part daemon once

### DIFF
--- a/basicswap/bin/prepare.py
+++ b/basicswap/bin/prepare.py
@@ -2973,10 +2973,6 @@ def main():
                 "tor_control_password", None
             )
 
-        if particl_wallet_mnemonic != "none":
-            # Ensure Particl wallet is unencrypted or correct password is supplied
-            test_particl_encryption(data_dir, settings, chain, use_tor_proxy)
-
         settings["chainclients"][add_coin] = chainclients[add_coin]
 
         if not no_cores:


### PR DESCRIPTION
before: when running addcoin, the part daemon starts twice.

after: It only runs for the duration of the addcoin, not before. If wrong password is detected, it throws a noisy error. Should probably reduce the verbosity of the error


note: this causes test to fail, but (afaict) functionality is fine. Maybe need to modify the test?