### PR TITLE
timeout bids before the script coin lock tx is mined.

### DIFF
--- a/basicswap/basicswap_util.py
+++ b/basicswap/basicswap_util.py
@@ -210,6 +210,8 @@ class EventLogTypes(IntEnum):
     LOCK_TX_B_IN_MEMPOOL = auto()
     BCH_MERCY_TX_PUBLISHED = auto()
     BCH_MERCY_TX_FOUND = auto()
+    LOCK_TX_A_IN_MEMPOOL = auto()
+    LOCK_TX_A_CONFLICTS = auto()
 
 
 class XmrSplitMsgTypes(IntEnum):
@@ -436,6 +438,10 @@ def describeEventEntry(event_type, event_msg):
         return "Lock tx B published"
     if event_type == EventLogTypes.FAILED_TX_B_SPEND:
         return "Failed to publish lock tx B spend: " + event_msg
+    if event_type == EventLogTypes.LOCK_TX_A_IN_MEMPOOL:
+        return "Lock tx A seen in mempool"
+    if event_type == EventLogTypes.LOCK_TX_A_CONFLICTS:
+        return "Lock tx A conflicting txn/s"
     if event_type == EventLogTypes.LOCK_TX_A_SEEN:
         return "Lock tx A seen in chain"
     if event_type == EventLogTypes.LOCK_TX_A_CONFIRMED:
@@ -602,6 +608,26 @@ def canAcceptBidState(state):
         BidStates.BID_RECEIVED,
         BidStates.BID_AACCEPT_DELAY,
         BidStates.BID_AACCEPT_FAIL,
+    )
+
+
+def canExpireBidState(state):
+    return state in (
+        BidStates.BID_SENT,
+        BidStates.BID_RECEIVING,
+        BidStates.BID_RECEIVED,
+        BidStates.BID_AACCEPT_DELAY,
+        BidStates.BID_AACCEPT_FAIL,
+        BidStates.BID_REQUEST_SENT,
+    )
+
+
+def canTimeoutBidState(state):
+    return state in (
+        BidStates.BID_ACCEPTED,
+        BidStates.XMR_SWAP_MSG_SCRIPT_LOCK_TX_SIGS,
+        BidStates.XMR_SWAP_HAVE_SCRIPT_COIN_SPEND_TX,
+        BidStates.XMR_SWAP_MSG_SCRIPT_LOCK_SPEND_TX,
     )
 
 

--- a/basicswap/db.py
+++ b/basicswap/db.py
@@ -13,8 +13,8 @@ from enum import IntEnum, auto
 from typing import Optional
 
 
-CURRENT_DB_VERSION = 30
-CURRENT_DB_DATA_VERSION = 6
+CURRENT_DB_VERSION = 31
+CURRENT_DB_DATA_VERSION = 7
 
 
 class Concepts(IntEnum):
@@ -619,6 +619,8 @@ class BidState(Table):
     swap_failed = Column("integer")
     swap_ended = Column("integer")
     can_accept = Column("integer")
+    can_expire = Column("integer")
+    can_timeout = Column("integer")
 
     note = Column("string")
     created_at = Column("integer")

--- a/basicswap/db_upgrades.py
+++ b/basicswap/db_upgrades.py
@@ -21,6 +21,8 @@ from .db import (
 from .basicswap_util import (
     BidStates,
     canAcceptBidState,
+    canExpireBidState,
+    canTimeoutBidState,
     isActiveBidState,
     isErrorBidState,
     isFailingBidState,
@@ -39,6 +41,8 @@ def addBidState(self, state, now, cursor):
             swap_failed=isFailingBidState(state),
             swap_ended=isFinalBidState(state),
             can_accept=canAcceptBidState(state),
+            can_expire=canExpireBidState(state),
+            can_timeout=canTimeoutBidState(state),
             label=strBidState(state),
             created_at=now,
         ),
@@ -105,19 +109,23 @@ def upgradeDatabaseData(self, data_version):
                     ),
                     cursor,
                 )
-        if data_version > 0 and data_version < 6:
+        if data_version > 0 and data_version < 7:
             for state in BidStates:
                 in_error = isErrorBidState(state)
                 swap_failed = isFailingBidState(state)
                 swap_ended = isFinalBidState(state)
                 can_accept = canAcceptBidState(state)
+                can_expire = canExpireBidState(state)
+                can_timeout = canTimeoutBidState(state)
                 cursor.execute(
-                    "UPDATE bidstates SET can_accept = :can_accept, in_error = :in_error, swap_failed = :swap_failed, swap_ended = :swap_ended WHERE state_id = :state_id",
+                    "UPDATE bidstates SET can_accept = :can_accept, can_expire = :can_expire, can_timeout = :can_timeout, in_error = :in_error, swap_failed = :swap_failed, swap_ended = :swap_ended WHERE state_id = :state_id",
                     {
                         "in_error": in_error,
                         "swap_failed": swap_failed,
                         "swap_ended": swap_ended,
                         "can_accept": can_accept,
+                        "can_expire": can_expire,
+                        "can_timeout": can_timeout,
                         "state_id": int(state),
                     },
                 )


### PR DESCRIPTION
Add events for script-coin lock tx seen in mempool and conflicted.

Accepted bids that have not exchanged further messages timeout after 1 hour as before.
Bids that have not seen the script-coin lock tx in the mempool timeout after 6 hours ("sc_lock_tx_timeout" setting).
With the script-coin lock tx in the mempool and not mined they timeout after 12 hours ("sc_lock_tx_mempool_timeout" setting).
If the node sent the script-coin lock tx the bid will not timeout.

Left RBF enabled for script-coin lock txns, if the bid times-out the lock tx could be recovered faster with RBF.