### PR TITLE
firo: v0.14.14.3 emergency release

### DIFF
--- a/basicswap/bin/prepare.py
+++ b/basicswap/bin/prepare.py
@@ -85,7 +85,7 @@ PIVX_VERSION_TAG = os.getenv("PIVX_VERSION_TAG", "")
 DASH_VERSION = os.getenv("DASH_VERSION", "22.1.3")
 DASH_VERSION_TAG = os.getenv("DASH_VERSION_TAG", "")
 
-FIRO_VERSION = os.getenv("FIRO_VERSION", "0.14.14.1")
+FIRO_VERSION = os.getenv("FIRO_VERSION", "0.14.14.3")
 FIRO_VERSION_TAG = os.getenv("FIRO_VERSION_TAG", "")
 
 NAV_VERSION = os.getenv("NAV_VERSION", "7.0.3")


### PR DESCRIPTION
text from https://github.com/firoorg/firo/releases/tag/v0.14.14.3

-------
If you're on an earlier version than Firo v0.14.14.2 and your node is stuck, update to this version and follow the instructions below.
Please backup your wallet prior to updating for safety.

Add allowdeepreorg=1 to the firo.conf
restart firod or firo-qt

Execute the following commands in console or firo-cli

```
removeislock fb5e6efe2d3c633c2176b3dc84cf151fb6a29f5419067992387cc55fa7b3d7cb
removeislock 794d98433d94a8c616856ea7f4f5f87d1d3080ec5737a143a4a16c3b1a359f9d
removeislock 70fd365cfecc4be66586476a9074809887ac9c767c957e38647ec0020c296de0
removeislock a2abd1093d8d8dea46ec25735ba7134cae34baf95c2fe2b1827ca0e06645c2e2
removeislock 654c08867ef9d0755f26d9ee7ef7b1a03a010409794b13d25fecacc4ef936119
removeislock 521ea34b6d326c74fbcae71c4ad5a6ff4d497542cc64d0bcc61727cc83e62184
invalidateblock 6e5c8ca003d5386558fefce1c1dae134e8f9b4770bc6eee74539c0e405344a4f
reconsiderblock bce69b1f20fea873b219c5a63f986498b45d0a678f1ee27a70fd91ebffca7c9a
reconsiderblock a6b78772b21693ea841f8871a260c9c4397f00c5f44db10257925670bf38a69c
clearbanned
```
After doing this, remove the line allowdeepreorg=1 from the firo.conf and restart firod/firo-qt