### PR TITLE
xmr: --non-interactive doesnt have any functionality on wallet

### DIFF
--- a/basicswap/bin/run.py
+++ b/basicswap/bin/run.py
@@ -221,7 +221,7 @@ def startXmrDaemon(node_dir, bin_dir, daemon_bin, opts=[]):
 
 def startXmrWalletDaemon(node_dir, bin_dir, wallet_bin, opts=[]):
     daemon_path = os.path.expanduser(os.path.join(bin_dir, wallet_bin))
-    args = [daemon_path, "--non-interactive"]
+    args = [daemon_path]
 
     needs_rewrite: bool = False
     config_to_remove = [

--- a/docker/production/monero_wallet/Dockerfile
+++ b/docker/production/monero_wallet/Dockerfile
@@ -13,4 +13,4 @@ VOLUME $MONERO_DATA
 COPY entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]
 
-CMD ["/monero/monero-wallet-rpc", "--non-interactive", "--config-file=/data/monero_wallet.conf", "--confirm-external-bind"]
+CMD ["/monero/monero-wallet-rpc", "--config-file=/data/monero_wallet.conf", "--confirm-external-bind"]

--- a/docker/production/wownero_wallet/Dockerfile
+++ b/docker/production/wownero_wallet/Dockerfile
@@ -13,4 +13,4 @@ VOLUME $WOWNERO_DATA
 COPY entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]
 
-CMD ["/wownero/wownero-wallet-rpc", "--non-interactive", "--config-file=/data/wownero-wallet-rpc.conf", "--confirm-external-bind"]
+CMD ["/wownero/wownero-wallet-rpc", "--config-file=/data/wownero-wallet-rpc.conf", "--confirm-external-bind"]


### PR DESCRIPTION
[reference](https://github.com/monero-project/monero/pull/8772#issuecomment-1463097268)

old docs were misleading. No idea why this flag was added to monero-wallet-rpc, core repo, but it doesnt actually do anything