### PR TITLE
firo: v0.14.15.0 hardfork 2025-11-19 mandatory

### DIFF
--- a/basicswap/bin/prepare.py
+++ b/basicswap/bin/prepare.py
@@ -85,7 +85,7 @@ PIVX_VERSION_TAG = os.getenv("PIVX_VERSION_TAG", "")
 DASH_VERSION = os.getenv("DASH_VERSION", "22.1.3")
 DASH_VERSION_TAG = os.getenv("DASH_VERSION_TAG", "")
 
-FIRO_VERSION = os.getenv("FIRO_VERSION", "0.14.14.3")
+FIRO_VERSION = os.getenv("FIRO_VERSION", "0.14.15.0")
 FIRO_VERSION_TAG = os.getenv("FIRO_VERSION_TAG", "")
 
 NAV_VERSION = os.getenv("NAV_VERSION", "7.0.3")


### PR DESCRIPTION
Upcoming hard fork at block 1,205,100 (approximately 19 November 2025).