### PR TITLE
prepare/xmr: use a trusted bootstrap daemon to negate high fee attacks

### DIFF
--- a/basicswap/bin/prepare.py
+++ b/basicswap/bin/prepare.py
@@ -1198,11 +1198,16 @@ def prepareDataDir(coin, settings, chain, particl_mnemonic, extra_opts={}):
                 fp.write("regtest=1\n")
                 fp.write("keep-fakechain=1\n")
                 fp.write("fixed-difficulty=1\n")
-            else:
-                fp.write("bootstrap-daemon-address=auto\n")
-                fp.write("restricted-rpc=1\n")
-            if chain == "testnet":
+            elif chain == "testnet":
                 fp.write("testnet=1\n")
+                fp.write("bootstrap-daemon-address=auto\n")
+            else:
+                # Negate high-fee attack by using a trusted daemon
+                if coin == "monero":
+                    fp.write("bootstrap-daemon-address=node3.monerodevs.org:18089\n")
+                elif coin == "wownero":
+                    fp.write("bootstrap-daemon-address=node3.monerodevs.org:34568\n")
+                fp.write("restricted-rpc=1\n")
             config_datadir = data_dir
             if extra_opts.get("use_containers", False) is True:
                 config_datadir = "/data"


### PR DESCRIPTION
A node can return inflated fee suggestions, causing the wallet to spend huge and unrecoverable amounts on fees. The change here is to use a trusted node for the bootstrap instead of crawling and potentially ending up on a bad one. This isnt a theoretical attack - there are a couple of people who lost funds this way (not via basicswap, but via monero gui wallet's "simple mode" (which uses bootstrap auto).

the main con here, would be if the prescribed node is unreachable for whatever reason. Still, it's safer than crawling.

This attack has never been performed on wownero, but also set one there since it speeds up wownero init