### PR TITLE
fixed coin config file f-strings

### DIFF
--- a/docker/production/scripts/build_yml_files.py
+++ b/docker/production/scripts/build_yml_files.py
@@ -79,13 +79,13 @@ def main():
                 continue
             if coin_name in ("monero", "wownero"):
                 with open(
-                    os.path.join(fragments_dir, "1_{coin_name}-wallet.yml"), "rb"
+                    os.path.join(fragments_dir, f"1_{coin_name}-wallet.yml"), "rb"
                 ) as fp_in:
                     for line in fp_in:
                         fp.write(line)
                         fpp.write(line)
                 with open(
-                    os.path.join(fragments_dir, "8_{coin_name}-daemon.yml"), "rb"
+                    os.path.join(fragments_dir, f"8_{coin_name}-daemon.yml"), "rb"
                 ) as fp_in:
                     for line in fp_in:
                         fp.write(line)


### PR DESCRIPTION
In "docker/production/scripts/build_yml_files.py" part of the main function copies the data from the wallet.yml and daemon.yml compose fragments to the docker-compose.yml and docker-compose-prepare.yml files. The copying is within a for loop that iterates over "monero" and "wownero" as coin_name. The construction of the compose fragment file names uses the coin_name variable but wasn't formatted as an f-string. This pr just fixes the string formatting so the source filenames are correct.