### PR TITLE
Missing coinid

### DIFF
--- a/basicswap/basicswap.py
+++ b/basicswap/basicswap.py
@@ -11776,8 +11776,12 @@ class BasicSwap(BaseApp, BSXNetwork, UIApp):
             for row in q:
                 coin_id = row[0]
 
-                if self.isCoinActive(coin_id) is False:
-                    # Skip cached info if coin was disabled
+                try:
+                    if self.isCoinActive(coin_id) is False:
+                        # Skip cached info if coin was disabled
+                        continue
+                except (ValueError, KeyError):
+                    # Skip coins not known in this build
                     continue
 
                 wallet_data = json.loads(row[2])

--- a/basicswap/basicswap.py
+++ b/basicswap/basicswap.py
@@ -11762,6 +11762,7 @@ class BasicSwap(BaseApp, BSXNetwork, UIApp):
 
     def getCachedWalletsInfo(self, opts=None):
         rv = {}
+        skipped_coin_ids = set()
         try:
             cursor = self.openDB()
             query_data: dict = {}
@@ -11781,7 +11782,8 @@ class BasicSwap(BaseApp, BSXNetwork, UIApp):
                         # Skip cached info if coin was disabled
                         continue
                 except (ValueError, KeyError):
-                    # Skip coins not known in this build
+                    # Coin not known in this build — track for UI warning
+                    skipped_coin_ids.add(coin_id)
                     continue
 
                 wallet_data = json.loads(row[2])
@@ -11827,7 +11829,7 @@ class BasicSwap(BaseApp, BSXNetwork, UIApp):
                     "updating": self._updating_wallets_info.get(coin_id, False),
                 }
 
-        return rv
+        return rv, skipped_coin_ids
 
     def countAcceptedBids(self, offer_id: bytes = None) -> int:
         cursor = self.openDB()

--- a/basicswap/js_server.py
+++ b/basicswap/js_server.py
@@ -129,7 +129,7 @@ def js_walletbalances(self, url_split, post_string, is_json) -> bytes:
     try:
 
         swap_client.updateWalletsInfo()
-        wallets = swap_client.getCachedWalletsInfo()
+        wallets, _skipped = swap_client.getCachedWalletsInfo()
         coins_with_balances = []
 
         for k, v in swap_client.coin_clients.items():

--- a/basicswap/ui/page_wallet.py
+++ b/basicswap/ui/page_wallet.py
@@ -97,7 +97,25 @@ def page_wallets(self, url_split, post_string):
     err_messages = []
 
     swap_client.updateWalletsInfo()
-    wallets = swap_client.getCachedWalletsInfo()
+    wallets, skipped_coin_ids = swap_client.getCachedWalletsInfo()
+
+    if skipped_coin_ids:
+        # Resolve names: check config chainclients that aren't in chainparams
+        unknown_config_names = []
+        for cc_name in swap_client.settings.get("chainclients", {}):
+            try:
+                swap_client.getCoinIdFromName(cc_name)
+            except Exception:
+                unknown_config_names.append(cc_name.capitalize())
+
+        if unknown_config_names:
+            names_str = ", ".join(unknown_config_names)
+        else:
+            names_str = ", ".join(f"coin ID {cid}" for cid in sorted(skipped_coin_ids))
+        messages.append(
+            f"Cached wallet data found for {names_str}, but this coin is not available in the current build. "
+            f"Its wallet is hidden until the coin is re-enabled."
+        )
 
     wallets_formatted = []
     sk = sorted(wallets.keys())
@@ -308,7 +326,7 @@ def page_wallet(self, url_split, post_string):
     swap_client.updateWalletsInfo(
         force_refresh, only_coin=coin_id, wait_for_complete=True
     )
-    wallets = swap_client.getCachedWalletsInfo({"coin_id": coin_id})
+    wallets, _skipped = swap_client.getCachedWalletsInfo({"coin_id": coin_id})
     wallet_data = {}
     for k in wallets.keys():
         w = wallets[k]

--- a/basicswap/ui/page_wallet.py
+++ b/basicswap/ui/page_wallet.py
@@ -112,7 +112,7 @@ def page_wallets(self, url_split, post_string):
             names_str = ", ".join(unknown_config_names)
         else:
             names_str = ", ".join(f"coin ID {cid}" for cid in sorted(skipped_coin_ids))
-        messages.append(
+        err_messages.append(
             f"Cached wallet data found for {names_str}, but this coin is not available in the current build. "
             f"Its wallet is hidden until the coin is re-enabled."
         )

--- a/basicswap/ui/util.py
+++ b/basicswap/ui/util.py
@@ -662,7 +662,7 @@ def listAvailableCoins(swap_client, with_variants=True, split_from=False):
 
 def listAvailableCoinsWithBalances(swap_client, with_variants=True, split_from=False):
     swap_client.updateWalletsInfo()
-    wallets = swap_client.getCachedWalletsInfo()
+    wallets, _skipped = swap_client.getCachedWalletsInfo()
 
     coins_from = []
     coins = []


### PR DESCRIPTION
## Fix: handle unknown coin IDs in cached wallet data gracefully

Fixes a crash / unhandled exception that occurs on the wallets page when the BasicSwap database contains cached wallet rows for a coin that is not compiled into the current build (e.g. a Rincoin entry present in the DB while running the Yenten branch).

### Root cause

`getCachedWalletsInfo` called `isCoinActive(coin_id)` for every DB row without guarding against `ValueError` / `KeyError` raised for unknown coin IDs, causing an unhandled exception that crashed the wallets page.

### Changes

**`basicswap/basicswap.py`**
- Wrap the `isCoinActive` call in a `try/except (ValueError, KeyError)` block and skip rows whose coin ID is not known in the current build
- Return a `(wallets, skipped_coin_ids)` tuple instead of `wallets` alone so callers can surface a warning about the hidden coins

**`basicswap/ui/page_wallet.py`**
- Unpack the new tuple in `page_wallets` and `page_wallet`
- When `skipped_coin_ids` is non-empty, resolve coin names from the config `chainclients` keys and append a user-visible banner:  
  *"Cached wallet data found for \<name\>, but this coin is not available in the current build. Its wallet is hidden until the coin is re-enabled."*
- Escalate that banner from an INFO message to an **ERROR** message so it is displayed prominently

**`basicswap/js_server.py`** / **`basicswap/ui/util.py`**  
- Update all other `getCachedWalletsInfo()` call sites to unpack the new tuple (`wallets, _skipped = …`)

### Behaviour after fix

- The wallets page loads normally; all coins present in the current build are shown
- A red error banner names any coin whose data is cached but unavailable, instead of crashing the page
