### PR TITLE
init: fail-fast if cookie auth fails

### DIFF
--- a/basicswap/basicswap.py
+++ b/basicswap/basicswap.py
@@ -1418,6 +1418,13 @@ class BasicSwap(BaseApp, BSXNetwork, UIApp):
                     self.log.info(
                         f"Waiting for {Coins(coin_type).name} RPC. Trying again in {5 * (1 + i)} seconds, {1 + i}/{startup_tries}."
                     )
+                elif any(
+                    log in str(ex)
+                    for log in [
+                        "Expecting value",  # Error after OOM shutdown
+                    ]
+                ):
+                    break
                 else:
                     self.log.warning(
                         f"Can't connect to {Coins(coin_type).name} RPC: {ex}.  Trying again in {5 * (1 + i)} seconds, {1 + i}/{startup_tries}."


### PR DESCRIPTION
After bsx is killed due to OOM, the next startup attempt will fail to start the PART daemon with an error of:

```
2026-03-25 12:26:15 WARNING : Can't connect to PART RPC: RPC server error: Expecting value: line 1 column 1 (char 0), method: getblockchaininfo.  Trying again in 15 seconds, 3/15.
2026-03-25 12:26:30 WARNING : Can't connect to PART RPC: RPC server error: Expecting value: line 1 column 1 (char 0), method: getblockchaininfo.  Trying again in 20 seconds, 4/15.
```

the PART debug.log shows
```
2026-03-25T12:26:15Z ThreadRPCServer incorrect password attempt from 127.0.0.1:40146
2026-03-25T12:26:30Z ThreadRPCServer incorrect password attempt from 127.0.0.1:56418
```