### PR TITLE
fix: remove workaround for blank wallet name

### DIFF
--- a/basicswap/interface/bch.py
+++ b/basicswap/interface/bch.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-# Copyright (c) 2024-2025 The Basicswap developers
+# Copyright (c) 2024-2026 The Basicswap developers
 # Distributed under the MIT software license, see the accompanying
 # file LICENSE or http://www.opensource.org/licenses/mit-license.php.
 
@@ -10,7 +10,6 @@ from basicswap.contrib.test_framework.messages import COutPoint, CTransaction, C
 from basicswap.util import b2i, ensure, i2b
 from basicswap.util.script import decodePushData, decodeScriptNum
 from .btc import BTCInterface, ensure_op, findOutput
-from basicswap.rpc import make_rpc_func
 from basicswap.chainparams import Coins
 from basicswap.interface.contrib.bch_test_framework.cashaddress import Address
 from basicswap.util.crypto import hash160, sha256
@@ -74,12 +73,7 @@ class BCHInterface(BTCInterface):
 
     def __init__(self, coin_settings, network, swap_client=None):
         super(BCHInterface, self).__init__(coin_settings, network, swap_client)
-        # No multiwallet support
         self.swap_client = swap_client
-        self.rpc_wallet = make_rpc_func(
-            self._rpcport, self._rpcauth, host=self._rpc_host
-        )
-        self.rpc_wallet_watch = self.rpc_wallet
 
     def has_segwit(self) -> bool:
         # bch does not have segwit, but we return true here to avoid extra checks in basicswap.py

--- a/basicswap/interface/btc.py
+++ b/basicswap/interface/btc.py
@@ -381,7 +381,7 @@ class BTCInterface(Secp256k1Interface):
 
         if self._rpc_wallet not in wallets:
             self._log.debug(
-                f"Wallet: {self._rpc_wallet} not active, attempting to load."
+                f'{self.ticker()} wallet: "{self._rpc_wallet}" not active, attempting to load.'
             )
             try:
                 self.rpc(
@@ -425,32 +425,43 @@ class BTCInterface(Secp256k1Interface):
                         except Exception as create_e:
                             self._log.error(f"Error creating wallet: {create_e}")
 
+        if (
+            self._rpc_wallet_watch != self._rpc_wallet
+            and self._rpc_wallet_watch not in wallets
+        ):
+            self._log.debug(
+                f'{self.ticker()} watchonly wallet: "{self._rpc_wallet_watch}" not active, attempting to load.'
+            )
+            try:
+                self.rpc(
+                    "loadwallet",
+                    [
+                        self._rpc_wallet_watch,
+                    ],
+                )
+                wallets = self.rpc("listwallets")
+            except Exception as e:
+                self._log.debug(
+                    f'Error loading {self.ticker()} watchonly wallet "{self._rpc_wallet_watch}": {e}.'
+                )
+
         # Wallet name is "" for some LTC and PART installs on older cores
         if self._rpc_wallet not in wallets and len(wallets) > 0:
-            self._log.warning(f"Changing {self.ticker()} wallet name.")
-            for wallet_name in wallets:
-                # Skip over other expected wallets
-                if wallet_name in ("mweb",):
-                    continue
-
-                change_watchonly_wallet: bool = (
-                    self._rpc_wallet_watch == self._rpc_wallet
+            if "" in wallets:
+                self._log.warning(
+                    f"Nameless {self.ticker()} wallet found."
+                    + '\nPlease set the "wallet_name" coin setting to "" or recreate the wallet'
                 )
+                # backupwallet and restorewallet with name should work.
 
-                self._rpc_wallet = wallet_name
-                self._log.info(
-                    f"Switched {self.ticker()} wallet name to {self._rpc_wallet}."
-                )
-                self.rpc_wallet = make_rpc_func(
-                    self._rpcport,
-                    self._rpcauth,
-                    host=self._rpc_host,
-                    wallet=self._rpc_wallet,
-                )
-                if change_watchonly_wallet:
-                    self.rpc_wallet_watch = self.rpc_wallet
-                break
-
+        if self._rpc_wallet not in wallets:
+            raise RuntimeError(
+                f'{self.ticker()} wallet "{self._rpc_wallet}" not active'
+            )
+        if self._rpc_wallet_watch not in wallets:
+            raise RuntimeError(
+                f'{self.ticker()} watchonly wallet "{self._rpc_wallet_watch}" not active'
+            )
         return len(wallets)
 
     def testDaemonRPC(self, with_wallet=True) -> None:


### PR DESCRIPTION
Stop BSX from selecting a wallet if the set wallet isn't able to be loaded.

Affected users can set "wallet_name": "" in the relevant coin settings section in their basicswap.json config file.