### PR TITLE
xmr: add "input stream error" to corrupt wallet errors

### DIFF
--- a/basicswap/interface/xmr.py
+++ b/basicswap/interface/xmr.py
@@ -228,6 +228,7 @@ class XMRInterface(CoinInterface):
                     "invalid signature",
                     "std::bad_alloc",
                     "basic_string::_M_replace_aux",
+                    "input stream error",
                 )
             ):
                 self._log.error(f"{self.coin_name()} wallet is corrupt.")


### PR DESCRIPTION
Tested.

Had this happen today after a system crash
wallet_stdout.log showed `failed to deserialize`