### PR TITLE
Fix ensureWalletCanSend: use actual fee for validation and error message

### DIFF
--- a/basicswap/basicswap.py
+++ b/basicswap/basicswap.py
@@ -3970,7 +3970,13 @@ class BasicSwap(BaseApp, BSXNetwork, UIApp):
         return ci.isValidAddressHash(dest)
 
     def ensureWalletCanSend(
-        self, ci, swap_type, ensure_balance: int, estimated_fee: int, for_offer=True
+        self,
+        ci,
+        swap_type,
+        ensure_balance: int,
+        estimated_fee: int,
+        for_offer=True,
+        fee_rate: int = None,
     ) -> None:
         balance_msg: str = (
             f"{ci.format_amount(ensure_balance)} {ci.coin_name()} with estimated fee {ci.format_amount(estimated_fee)}"
@@ -3988,7 +3994,12 @@ class BasicSwap(BaseApp, BSXNetwork, UIApp):
                 pi = self.pi(swap_type)
                 current_balance: int = ci.getSpendableBalance()
                 mock_addr = pi.getMockAddrTo(ci)
-                max_amount: int = ci.getMaxFundable(mock_addr, current_balance)
+                self.log.debug(
+                    f"getMaxFundable: balance={current_balance}, fee_rate={fee_rate}"
+                )
+                max_amount: int = ci.getMaxFundable(
+                    mock_addr, current_balance, fee_rate
+                )
                 if max_amount < ensure_balance:
                     actual_fee: int = current_balance - max_amount
                     ticker: str = ci.ticker()
@@ -4003,9 +4014,7 @@ class BasicSwap(BaseApp, BSXNetwork, UIApp):
         except Exception as e:
             type_str = "offer" if for_offer else "bid"
             self.log.error(f"ensureWalletCanSend failed {e}")
-            err_msg = (
-                f"Insufficient funds for {type_str} of {balance_msg}."
-            )
+            err_msg = f"Insufficient funds for {type_str} of {balance_msg}."
             self.log.error(err_msg)
             raise ValueError(err_msg)
 
@@ -4171,11 +4180,16 @@ class BasicSwap(BaseApp, BSXNetwork, UIApp):
 
             # If a prefunded txn is not used, check that the wallet balance can cover the tx fee.
             if "prefunded_itx" not in extra_options:
-                # TODO: Better tx size estimate, xmr_swap_b_lock_tx_vsize could be larger than xmr_swap_b_lock_spend_tx_vsize
                 estimated_fee: int = (
                     msg_buf.fee_rate_from * ci_from.est_lock_tx_vsize() // 1000
                 )
-                self.ensureWalletCanSend(ci_from, swap_type, int(amount), estimated_fee)
+                self.ensureWalletCanSend(
+                    ci_from,
+                    swap_type,
+                    int(amount),
+                    estimated_fee,
+                    fee_rate=msg_buf.fee_rate_from,
+                )
 
             # TODO: Send proof of funds with offer
             # proof_of_funds_hash = getOfferProofOfFundsHash(msg_buf, offer_addr)
@@ -6039,12 +6053,18 @@ class BasicSwap(BaseApp, BSXNetwork, UIApp):
 
             self.checkCoinsReady(coin_from, coin_to)
 
-            # TODO: Better tx size estimate
-            fee_rate, fee_src = self.getFeeRateForCoin(coin_to, conf_target=2)
-            fee_rate_to = ci_to.make_int(fee_rate)
-            estimated_fee: int = fee_rate_to * ci_to.est_lock_tx_vsize() // 1000
+            reverse_bid: bool = self.is_reverse_ads_bid(coin_from, coin_to)
+            lock_tx_fee_rate: int = (
+                xmr_offer.b_fee_rate if reverse_bid else xmr_offer.a_fee_rate
+            )
+            estimated_fee: int = lock_tx_fee_rate * ci_to.est_lock_tx_vsize() // 1000
             self.ensureWalletCanSend(
-                ci_to, offer.swap_type, int(amount_to), estimated_fee, for_offer=False
+                ci_to,
+                offer.swap_type,
+                int(amount_to),
+                estimated_fee,
+                for_offer=False,
+                fee_rate=lock_tx_fee_rate,
             )
 
             bid_addr: str = self.prepareSMSGAddress(

--- a/basicswap/basicswap.py
+++ b/basicswap/basicswap.py
@@ -3986,17 +3986,26 @@ class BasicSwap(BaseApp, BSXNetwork, UIApp):
                 pass
             else:
                 pi = self.pi(swap_type)
-                _ = pi.getFundedInitiateTxTemplate(ci, ensure_balance, False)
-                # TODO: Save the prefunded tx so the fee can't change, complicates multiple offers at the same time.
+                current_balance: int = ci.getSpendableBalance()
+                mock_addr = pi.getMockAddrTo(ci)
+                max_amount: int = ci.getMaxFundable(mock_addr, current_balance)
+                if max_amount < ensure_balance:
+                    actual_fee: int = current_balance - max_amount
+                    ticker: str = ci.ticker()
+                    raise ValueError(
+                        f"Insufficient funds for {'offer' if for_offer else 'bid'} of "
+                        f"{ci.format_amount(ensure_balance)} {ticker}. "
+                        f"Transaction fee: {ci.format_amount(actual_fee)} {ticker}, "
+                        f"maximum amount: {ci.format_amount(max_amount)} {ticker}."
+                    )
+        except ValueError:
+            raise
         except Exception as e:
             type_str = "offer" if for_offer else "bid"
-            err_msg = f"Insufficient funds for {type_str} of {balance_msg}."
-            if self.debug:
-                self.log.error(f"ensureWalletCanSend failed {e}")
-                current_balance: int = ci.getSpendableBalance()
-                err_msg += (
-                    f" Debug: Spendable balance: {ci.format_amount(current_balance)}."
-                )
+            self.log.error(f"ensureWalletCanSend failed {e}")
+            err_msg = (
+                f"Insufficient funds for {type_str} of {balance_msg}."
+            )
             self.log.error(err_msg)
             raise ValueError(err_msg)
 

--- a/basicswap/interface/btc.py
+++ b/basicswap/interface/btc.py
@@ -3500,16 +3500,18 @@ class BTCInterface(Secp256k1Interface):
 
         return funded_tx.hex()
 
-    def getMaxFundable(self, addr_to: str, amount: int) -> int:
-        """Return max output value by dry-running fundrawtransaction with subtractFeeFromOutputs."""
+    def getMaxFundable(self, addr_to: str, amount: int, fee_rate: int = None) -> int:
         txn = self.rpc(
             "createrawtransaction", [[], {addr_to: self.format_amount(amount)}]
         )
         options = {
             "lockUnspents": False,
-            "conf_target": self._conf_target,
             "subtractFeeFromOutputs": [0],
         }
+        if fee_rate:
+            options["feeRate"] = self.format_amount(fee_rate)
+        else:
+            options["conf_target"] = self._conf_target
         result = self.rpc_wallet("fundrawtransaction", [txn, options])
         return amount - self.make_int(result["fee"])
 

--- a/basicswap/interface/btc.py
+++ b/basicswap/interface/btc.py
@@ -3500,6 +3500,19 @@ class BTCInterface(Secp256k1Interface):
 
         return funded_tx.hex()
 
+    def getMaxFundable(self, addr_to: str, amount: int) -> int:
+        """Return max output value by dry-running fundrawtransaction with subtractFeeFromOutputs."""
+        txn = self.rpc(
+            "createrawtransaction", [[], {addr_to: self.format_amount(amount)}]
+        )
+        options = {
+            "lockUnspents": False,
+            "conf_target": self._conf_target,
+            "subtractFeeFromOutputs": [0],
+        }
+        result = self.rpc_wallet("fundrawtransaction", [txn, options])
+        return amount - self.make_int(result["fee"])
+
     def createRawSignedTransaction(self, addr_to, amount) -> str:
         txn_funded = self.createRawFundedTransaction(addr_to, amount)
 


### PR DESCRIPTION
## Summary

- Fix false "Insufficient funds" rejections when bid amount is close to wallet balance
- Show actionable error message with actual tx fee and maximum sendable amount

## Problem

`ensureWalletCanSend` validates bids by calling `fundrawtransaction` with `conf_target`, which uses `estimatesmartfee` internally. The actual swap later uses the offer's explicit `feeRate`. When these diverge, valid bids get rejected. Additionally, when the fee margin falls in the dust gap (above dust threshold but below fee-with-change), Bitcoin Core can't construct the transaction at all.

The error message was misleading — showing a fee estimate from a 110-vbyte approximation that didn't match the actual rejection cause. Users saw numbers that added up, yet the bid was rejected.

**Before:**
```
Insufficient funds for bid of 0.00194250 Bitcoin with estimated fee 0.00000248. Debug: Spendable balance: 0.00194532.
```

**After:**
```
Insufficient funds for bid of 0.00194531 BTC. Transaction fee: 0.00000427 BTC, maximum amount: 0.00194105 BTC.
```

## Changes

- Add `BTCInterface.getMaxFundable()` — dry-runs `fundrawtransaction` with `subtractFeeFromOutputs` to discover the real maximum output value
- Rewrite `ensureWalletCanSend` for UTXO coins: validate using actual max fundable amount instead of the `conf_target`-based `fundrawtransaction` that hits the dust gap
- Error message now shows: bid amount, actual transaction fee, and maximum sendable amount

Relates to #246.

Assisted-by: 🤖 Claude Opus/Sonnet 4.6