### PR TITLE
Fixes: PIVX/FIRO and test_pivx.py

### DIFF
--- a/basicswap/interface/btc.py
+++ b/basicswap/interface/btc.py
@@ -1083,8 +1083,8 @@ class BTCInterface(Secp256k1Interface):
         return self.encode_p2wsh(script)
 
     def getDestForAddress(self, address: str) -> bytes:
-        bech32_prefix = self.chainparams_network()["hrp"]
-        if address.startswith(bech32_prefix + "1"):
+        bech32_prefix: str | None = self.chainparams_network().get("hrp", None)
+        if bech32_prefix and address.startswith(bech32_prefix + "1"):
             _, witprog = segwit_addr.decode(bech32_prefix, address)
             return CScript([OP_0, bytes(witprog)])
 

--- a/basicswap/interface/firo.py
+++ b/basicswap/interface/firo.py
@@ -361,7 +361,7 @@ class FIROInterface(BTCInterface):
         )
         return pay_fee
 
-    def signTxWithKey(self, tx: bytes, key: bytes) -> bytes:
+    def signTxWithKey(self, tx: bytes, key: bytes, prev_amount=None) -> bytes:
         key_wif = self.encodeKey(key)
         rv = self.rpc(
             "signrawtransaction",

--- a/basicswap/interface/pivx.py
+++ b/basicswap/interface/pivx.py
@@ -12,7 +12,7 @@ from .btc import BTCInterface
 from basicswap.rpc import make_rpc_func
 from basicswap.chainparams import Coins
 from basicswap.util.address import decodeAddress
-from .contrib.pivx_test_framework.messages import CBlock, ToHex, FromHex, CTransaction
+from .contrib.pivx_test_framework.messages import CTransaction
 from basicswap.contrib.test_framework.script import (
     CScript,
     OP_DUP,
@@ -100,29 +100,13 @@ class PIVXInterface(BTCInterface):
         return decodeAddress(address)[1:]
 
     def getBlockWithTxns(self, block_hash):
-        # TODO: Bypass decoderawtransaction and getblockheader
-        block = self.rpc("getblock", [block_hash, False])
-        block_header = self.rpc("getblockheader", [block_hash])
-        decoded_block = CBlock()
-        decoded_block = FromHex(decoded_block, block)
-
+        block = self.rpc("getblock", [block_hash, True])
         tx_rv = []
-        for tx in decoded_block.vtx:
-            tx_dec = self.rpc("decoderawtransaction", [ToHex(tx)])
+        for txid_str in block["tx"]:
+            tx_dec = self.rpc("getrawtransaction", [txid_str, True])
             tx_rv.append(tx_dec)
-
-        block_rv = {
-            "hash": block_hash,
-            "previousblockhash": block_header["previousblockhash"],
-            "tx": tx_rv,
-            "confirmations": block_header["confirmations"],
-            "height": block_header["height"],
-            "time": block_header["time"],
-            "version": block_header["version"],
-            "merkleroot": block_header["merkleroot"],
-        }
-
-        return block_rv
+        block["tx"] = tx_rv
+        return block
 
     def withdrawCoin(self, value, addr_to, subfee):
         params = [addr_to, value, "", "", subfee]
@@ -150,7 +134,7 @@ class PIVXInterface(BTCInterface):
         )
         return pay_fee
 
-    def signTxWithKey(self, tx: bytes, key: bytes) -> bytes:
+    def signTxWithKey(self, tx: bytes, key: bytes, prev_amount=None) -> bytes:
         key_wif = self.encodeKey(key)
         rv = self.rpc(
             "signrawtransaction",

--- a/tests/basicswap/extended/test_pivx.py
+++ b/tests/basicswap/extended/test_pivx.py
@@ -182,6 +182,7 @@ def prepareDir(datadir, nodeId, network_key, network_pubkey):
                 "datadir": node_dir,
                 "bindir": cfg.PARTICL_BINDIR,
                 "blocks_confirmed": 2,  # Faster testing
+                "wallet_name": "bsx_wallet",
             },
             "pivx": {
                 "connection_type": "rpc",
@@ -191,6 +192,7 @@ def prepareDir(datadir, nodeId, network_key, network_pubkey):
                 "bindir": PIVX_BINDIR,
                 "use_csv": False,
                 "use_segwit": False,
+                "wallet_name": "",
             },
             "bitcoin": {
                 "connection_type": "rpc",
@@ -199,6 +201,7 @@ def prepareDir(datadir, nodeId, network_key, network_pubkey):
                 "datadir": btcdatadir,
                 "bindir": cfg.BITCOIN_BINDIR,
                 "use_segwit": True,
+                "wallet_name": "bsx_wallet",
             },
         },
         "check_progress_seconds": 2,
@@ -760,7 +763,17 @@ class Test(unittest.TestCase):
         rtx = pivxRpc(f'getrawtransaction "{txid}" true')
         assert rtx["version"] == 3
 
-        block_hash = pivxRpc(f'generatetoaddress 1 "{generate_addr}"')[0]
+        block_hash = None
+        for i in range(15):
+            rtx = pivxRpc(f'getrawtransaction "{txid}" true')
+            if "blockhash" in rtx:
+                block_hash = rtx["blockhash"]
+                logging.info(f"Shielded tx confirmed in block {block_hash} after {i}s")
+                break
+            if i == 5:
+                pivxRpc(f'generatetoaddress 1 "{generate_addr}"')
+            delay_event.wait(1)
+        assert block_hash is not None, "Shielded tx was not confirmed"
 
         ci = self.swap_clients[0].ci(Coins.PIVX)
         block = ci.getBlockWithTxns(block_hash)
@@ -837,7 +850,11 @@ class Test(unittest.TestCase):
         swap_value = ci_from.make_int(swap_value)
         assert swap_value > ci_from.make_int(9)
 
-        itx = pi.getFundedInitiateTxTemplate(ci_from, swap_value, True)
+        addr_to = pi.getMockAddrTo(ci_from)
+        funded_tx = ci_from.createRawFundedTransaction(
+            addr_to, swap_value, True, lock_unspents=True
+        )
+        itx = bytes.fromhex(funded_tx)
         itx_decoded = ci_from.describeTx(itx.hex())
 
         n = pi.findMockVout(ci_from, itx_decoded)


### PR DESCRIPTION
- btc.py: Safe Bech32 prefix lookup using .get("hrp", None).
- firo.py: add prev_amount=None to signTxWithKey.
- pivx.py: add prev_amount=None to signTxWithKey.
- pivx.py: Replace CBlock deserialization in getBlockWithTxns with native RPC decoding.
- pivx.py: Clean up unused imports.
- test_pivx.py: Fix wallet_name settings for test nodes.
- test_pivx.py: fix test_09 shielded tx race condition with background mining.
- test_pivx_py: fix test_10 prefunded ITX UTXO spending race by locking inputs.

