### PR TITLE
Fix: Wallet balance overwrite on WebSocket updates.

### DIFF
--- a/basicswap/js_server.py
+++ b/basicswap/js_server.py
@@ -192,6 +192,28 @@ def js_walletbalances(self, url_split, post_string, is_json) -> bytes:
                     coin_entry["electrum_synced"] = sync_status.get("synced", False)
                     coin_entry["electrum_height"] = sync_status.get("height", 0)
 
+                if k in wallets:
+                    w = wallets[k]
+                    if "error" not in w and "no_data" not in w:
+                        if k == Coins.PART:
+                            for field in ("blind_balance", "anon_balance"):
+                                if field in w:
+                                    raw = w[field]
+                                    if isinstance(raw, float):
+                                        coin_entry[field] = (
+                                            f"{raw:.8f}".rstrip("0").rstrip(".")
+                                        )
+                                    elif isinstance(raw, int):
+                                        coin_entry[field] = str(raw)
+                                    else:
+                                        coin_entry[field] = raw
+                        elif k == Coins.LTC:
+                            if "mweb_balance" in w:
+                                coin_entry["mweb_balance"] = w["mweb_balance"]
+                        elif k == Coins.FIRO:
+                            if "spark_balance" in w:
+                                coin_entry["spark_balance"] = w["spark_balance"]
+
                 coins_with_balances.append(coin_entry)
 
                 if k == Coins.PART:

--- a/basicswap/js_server.py
+++ b/basicswap/js_server.py
@@ -200,9 +200,9 @@ def js_walletbalances(self, url_split, post_string, is_json) -> bytes:
                                 if field in w:
                                     raw = w[field]
                                     if isinstance(raw, float):
-                                        coin_entry[field] = (
-                                            f"{raw:.8f}".rstrip("0").rstrip(".")
-                                        )
+                                        coin_entry[field] = f"{raw:.8f}".rstrip(
+                                            "0"
+                                        ).rstrip(".")
                                     elif isinstance(raw, int):
                                         coin_entry[field] = str(raw)
                                     else:

--- a/basicswap/static/js/pages/wallet-page.js
+++ b/basicswap/static/js/pages/wallet-page.js
@@ -351,16 +351,19 @@
       );
 
       matchingCoins.forEach(coinData => {
-        const balanceElements = document.querySelectorAll('.coinname-value[data-coinname]');
+        const balanceElements = document.querySelectorAll('.coinname-value[data-coinname][data-balance-type]');
         balanceElements.forEach(element => {
           const elementCoinName = element.getAttribute('data-coinname');
           if (elementCoinName === coinData.name) {
-            const currentText = element.textContent;
-            const ticker = coinData.ticker || coinId.toUpperCase();
-            const newBalance = `${coinData.balance} ${ticker}`;
-            if (currentText !== newBalance) {
-              element.textContent = newBalance;
-              console.log(`Updated balance: ${coinData.name} -> ${newBalance}`);
+            const balanceType = element.getAttribute('data-balance-type');
+            const value = coinData[balanceType];
+            if (value !== undefined) {
+              const ticker = coinData.ticker || coinId.toUpperCase();
+              const newBalance = balanceType === 'est_fee' ? value : `${value} ${ticker}`;
+              if (element.textContent !== newBalance) {
+                element.textContent = newBalance;
+                console.log(`Updated ${balanceType}: ${coinData.name} -> ${newBalance}`);
+              }
             }
           }
         });

--- a/basicswap/static/js/pages/wallets-page.js
+++ b/basicswap/static/js/pages/wallets-page.js
@@ -75,8 +75,27 @@
         if (coinData.pending && parseFloat(coinData.pending) > 0) {
           this.updatePendingBalance('Particl', 'Blind Balance:', coinData.pending, coinData.ticker || 'PART', 'Blind Unconfirmed:', coinData);
         }
+      } else if (coinData.name === 'Litecoin MWEB') {
+        this.updateSpecificBalance('Litecoin', 'MWEB Balance:', coinData.balance, coinData.ticker || 'LTC');
+        this.removePendingBalance('Litecoin', 'MWEB Balance:');
+        if (coinData.pending && parseFloat(coinData.pending) > 0) {
+          this.updatePendingBalance('Litecoin', 'MWEB Balance:', coinData.pending, coinData.ticker || 'LTC', 'MWEB Pending:', coinData);
+        }
       } else {
         this.updateSpecificBalance(coinData.name, 'Balance:', coinData.balance, coinData.ticker || coinData.name);
+
+        if (coinData.mweb_balance !== undefined) {
+          this.updateSpecificBalance(coinData.name, 'MWEB Balance:', coinData.mweb_balance, coinData.ticker || coinData.name);
+        }
+        if (coinData.spark_balance !== undefined) {
+          this.updateSpecificBalance(coinData.name, 'Spark Balance:', coinData.spark_balance, coinData.ticker || coinData.name);
+        }
+        if (coinData.blind_balance !== undefined) {
+          this.updateSpecificBalance(coinData.name, 'Blind Balance:', coinData.blind_balance, coinData.ticker || coinData.name);
+        }
+        if (coinData.anon_balance !== undefined) {
+          this.updateSpecificBalance(coinData.name, 'Anon Balance:', coinData.anon_balance, coinData.ticker || coinData.name);
+        }
 
         if (coinData.name !== 'Particl Anon' && coinData.name !== 'Particl Blind' && coinData.name !== 'Litecoin MWEB') {
           if (coinData.pending && parseFloat(coinData.pending) > 0) {

--- a/basicswap/templates/wallet.html
+++ b/basicswap/templates/wallet.html
@@ -138,7 +138,7 @@
                         <tr class="opacity-100 text-gray-500 dark:text-gray-100 hover:bg-coolGray-200 dark:hover:bg-gray-600">
                           <td class="py-3 px-6 bold"> <span class="inline-flex align-middle items-center justify-center w-9 h-10 bg-white-50 rounded"> <img class="h-7" src="/static/images/coins/{{ w.name }}.png" alt="{{ w.name }}"> </span>Balance: </td>
                           <td class="py-3 px-6 bold">
-                            <span class="coinname-value" data-coinname="{{ w.name }}">{{ w.balance }} {{ w.ticker }}</span>
+                            <span class="coinname-value" data-coinname="{{ w.name }}" data-balance-type="balance">{{ w.balance }} {{ w.ticker }}</span>
                             (<span class="usd-value"></span>)
                             {% if w.pending %}
                               <span class="inline-block py-1 px-2 rounded-full bg-green-100 text-green-500 dark:bg-gray-500 dark:text-green-500">Pending: +{{ w.pending }} {{ w.ticker }} </span>
@@ -152,7 +152,7 @@
                         <tr class="opacity-100 text-gray-500 dark:text-gray-100 hover:bg-coolGray-200 dark:hover:bg-gray-600">
                           <td class="py-3 px-6 bold"> <span class="inline-flex align-middle items-center justify-center w-9 h-10 bg-white-50 rounded"> <img class="h-7" src="/static/images/coins/{{ w.name }}.png" alt="{{ w.name }} Blind"> </span>Blind Balance: </td>
                           <td class="py-3 px-6 bold">
-                            <span class="coinname-value" data-coinname="{{ w.name }}">{{ w.blind_balance }} {{ w.ticker }}</span>
+                            <span class="coinname-value" data-coinname="{{ w.name }}" data-balance-type="blind_balance">{{ w.blind_balance }} {{ w.ticker }}</span>
                             (<span class="usd-value"></span>)
                             {% if w.blind_unconfirmed %}
                               <span class="inline-block py-1 px-2 rounded-full bg-green-100 text-green-500 dark:bg-gray-500 dark:text-green-500">Unconfirmed: +{{ w.blind_unconfirmed }} {{ w.ticker }}</span>
@@ -162,7 +162,7 @@
                         <tr class="opacity-100 text-gray-500 dark:text-gray-100 hover:bg-coolGray-200 dark:hover:bg-gray-600">
                           <td class="py-3 px-6 bold"> <span class="inline-flex align-middle items-center justify-center w-9 h-10 bg-white-50 rounded"> <img class="h-7" src="/static/images/coins/{{ w.name }}.png" alt="{{ w.name }} Anon"> </span>Anon Balance: </td>
                           <td class="py-3 px-6 bold">
-                            <span class="coinname-value" data-coinname="{{ w.name }}">{{ w.anon_balance }} {{ w.ticker }}</span>
+                            <span class="coinname-value" data-coinname="{{ w.name }}" data-balance-type="anon_balance">{{ w.anon_balance }} {{ w.ticker }}</span>
                             (<span class="usd-value"></span>)
                             {% if w.anon_pending %}
                               <span class="inline-block py-1 px-2 rounded-full bg-green-100 text-green-500 dark:bg-gray-500 dark:text-green-500">Pending: +{{ w.anon_pending }} {{ w.ticker }}</span>
@@ -177,7 +177,7 @@
                             {% if is_electrum_mode %}
                             <span class="text-gray-400 dark:text-gray-300">Not available in light mode</span>
                             {% else %}
-                            <span class="coinname-value" data-coinname="{{ w.name }}">{{ w.mweb_balance }} {{ w.ticker }}</span>
+                            <span class="coinname-value" data-coinname="{{ w.name }}" data-balance-type="mweb_balance">{{ w.mweb_balance }} {{ w.ticker }}</span>
                             (<span class="usd-value"></span>)
                             {% if w.mweb_pending %}
                               <span class="inline-block py-1 px-2 rounded-full bg-green-100 text-green-500 dark:bg-gray-500 dark:text-green-500">Pending: +{{ w.mweb_pending }} {{ w.ticker }} </span>
@@ -200,7 +200,7 @@
                         <tr class="opacity-100 text-gray-500 dark:text-gray-100 hover:bg-coolGray-200 dark:hover:bg-gray-600">
                           <td class="py-3 px-6 bold"> <span class="inline-flex align-middle items-center justify-center w-9 h-10 bg-white-50 rounded"> <img class="h-7" src="/static/images/coins/{{ w.name }}.png" alt="{{ w.name }} Spark"> </span>Spark Balance: </td>
                           <td class="py-3 px-6 bold">
-                            <span class="coinname-value" data-coinname="{{ w.name }}">{{ w.spark_balance }} {{ w.ticker }}</span>
+                            <span class="coinname-value" data-coinname="{{ w.name }}" data-balance-type="spark_balance">{{ w.spark_balance }} {{ w.ticker }}</span>
                             (<span class="usd-value"></span>)
                             {% if w.spark_pending %}
                               <span class="inline-block py-1 px-2 rounded-full bg-green-100 text-green-500 dark:bg-gray-500 dark:text-green-500">Pending: +{{ w.spark_pending }} {{ w.ticker }} </span>
@@ -211,7 +211,7 @@
                         <tr class="opacity-100 text-gray-500 dark:text-gray-100 hover:bg-coolGray-200 dark:hover:bg-gray-600">
                           <td class="py-3 px-6 bold"> <span class="inline-flex align-middle items-center justify-center w-9 h-10 bg-white-50 rounded"> <img class="h-7" src="/static/images/coins/{{ w.name }}.png" alt="{{ w.name }} Spark"> </span>Spark Balance: </td>
                           <td class="py-3 px-6 bold">
-                            <span class="coinname-value" data-coinname="{{ w.name }}">{{ w.spark_balance }} {{ w.ticker }}</span>
+                            <span class="coinname-value" data-coinname="{{ w.name }}" data-balance-type="spark_balance">{{ w.spark_balance }} {{ w.ticker }}</span>
                             (<span class="usd-value"></span>)
                             {% if w.spark_pending %}
                               <span class="inline-block py-1 px-2 rounded-full bg-green-100 text-green-500 dark:bg-gray-500 dark:text-green-500">Pending: +{{ w.spark_pending }} {{ w.ticker }} </span>
@@ -348,16 +348,7 @@
                           <td class="py-3 px-6">{{ w.expected_seed }}</td>
                         </tr>
                         {% endif %}
-                        {% if w.account_key %}
-                        <tr class="opacity-100 text-gray-500 dark:text-gray-100 hover:bg-coolGray-200 dark:hover:bg-gray-600">
-                          <td class="py-3 px-6 bold">Extended Private Key:</td>
-                          <td class="py-3 px-6">
-                            <span id="account-key-hidden" class="font-mono text-sm">••••••••••••••••</span>
-                            <span id="account-key-value" class="font-mono text-sm hidden break-all">{{ w.account_key }}</span>
-                            <button type="button" id="toggle-account-key" onclick="var h=document.getElementById('account-key-hidden'),v=document.getElementById('account-key-value');if(v.classList.contains('hidden')){v.classList.remove('hidden');h.classList.add('hidden');this.textContent='Hide';}else{v.classList.add('hidden');h.classList.remove('hidden');this.textContent='Show';}" class="ml-2 px-2 py-1 text-xs bg-blue-500 hover:bg-blue-600 text-white rounded">Show</button>
-                          </td>
-                        </tr>
-                        {% endif %}
+
                       </table>
                     </div>
                   </div>
@@ -556,7 +547,7 @@
           <tr class="opacity-100 text-gray-500 dark:text-gray-100">
            <td class="py-4 pl-6 bold"> <span class="inline-flex align-middle items-center justify-center w-9 h-10 bg-white-50 rounded"> <img class="h-7" src="/static/images/coins/{{ w.name }}.png" alt="{{ w.name }}"> </span>Balance: </td>
            <td class="py-3 px-6">
-            <span class="coinname-value" data-coinname="{{ w.name }}">{{ w.balance }} {{ w.ticker }}</span>
+            <span class="coinname-value" data-coinname="{{ w.name }}" data-balance-type="balance">{{ w.balance }} {{ w.ticker }}</span>
             (<span class="usd-value"></span>)
            </td>
           </tr>
@@ -568,7 +559,7 @@
             {% if is_electrum_mode %}
             <span class="text-gray-400 dark:text-gray-300">Not available in light mode</span>
             {% else %}
-            <span class="coinname-value" data-coinname="{{ w.name }}">{{ w.mweb_balance }} {{ w.ticker }}</span>
+            <span class="coinname-value" data-coinname="{{ w.name }}" data-balance-type="mweb_balance">{{ w.mweb_balance }} {{ w.ticker }}</span>
             (<span class="usd-value"></span>)
             {% endif %}
            </td>
@@ -578,7 +569,7 @@
           <tr class="opacity-100 text-gray-500 dark:text-gray-100">
            <td class="py-4 pl-6 bold w-1/4"> <span class="inline-flex align-middle items-center justify-center w-9 h-10 bg-white-50 rounded"> <img class="h-7" src="/static/images/coins/{{ w.name }}.png" alt="{{ w.name }}"> </span>Spark Balance: </td>
            <td class="py-3 px-6">
-            <span class="coinname-value" data-coinname="{{ w.name }}">{{ w.spark_balance }} {{ w.ticker }}</span>
+            <span class="coinname-value" data-coinname="{{ w.name }}" data-balance-type="spark_balance">{{ w.spark_balance }} {{ w.ticker }}</span>
             (<span class="usd-value"></span>)
            </td>
           </tr>
@@ -587,7 +578,7 @@
           <tr class="opacity-100 text-gray-500 dark:text-gray-100">
            <td class="py-4 pl-6 bold w-1/4"> <span class="inline-flex align-middle items-center justify-center w-9 h-10 bg-white-50 rounded"> <img class="h-7" src="/static/images/coins/{{ w.name }}.png" alt="{{ w.name }}"> </span>Spark Balance: </td>
            <td class="py-3 px-6">
-            <span class="coinname-value" data-coinname="{{ w.name }}">{{ w.spark_balance }} {{ w.ticker }}</span>
+            <span class="coinname-value" data-coinname="{{ w.name }}" data-balance-type="spark_balance">{{ w.spark_balance }} {{ w.ticker }}</span>
             (<span class="usd-value"></span>)
            </td>
           </tr>
@@ -596,14 +587,14 @@
           <tr class="opacity-100 text-gray-500 dark:text-gray-100">
            <td class="py-4 pl-6 bold"> <span class="inline-flex align-middle items-center justify-center w-9 h-10 bg-white-50 rounded"> <img class="h-7" src="/static/images/coins/{{ w.name }}.png" alt="{{ w.name }}"> </span>Blind Balance: </td>
            <td class="py-3 px-6">
-            <span class="coinname-value" data-coinname="{{ w.name }}">{{ w.blind_balance }} {{ w.ticker }}</span>
+            <span class="coinname-value" data-coinname="{{ w.name }}" data-balance-type="blind_balance">{{ w.blind_balance }} {{ w.ticker }}</span>
             (<span class="usd-value"></span>)
            </td>
           </tr>
           <tr class="opacity-100 text-gray-500 dark:text-gray-100">
            <td class="py-4 pl-6 bold"> <span class="inline-flex align-middle items-center justify-center w-9 h-10 bg-white-50 rounded"> <img class="h-7" src="/static/images/coins/{{ w.name }}.png" alt="{{ w.name }}"> </span>Anon Balance: </td>
            <td class="py-3 px-6">
-            <span class="coinname-value" data-coinname="{{ w.name }}">{{ w.anon_balance }} {{ w.ticker }}</span>
+            <span class="coinname-value" data-coinname="{{ w.name }}" data-balance-type="anon_balance">{{ w.anon_balance }} {{ w.ticker }}</span>
             (<span class="usd-value"></span>)
            </td>
           </tr>
@@ -778,7 +769,7 @@
            <tr class="opacity-100 text-gray-500 dark:text-gray-100">
            <td class="py-3 px-6 bold">Fee Estimate:</td>
            <td class="py-3 px-6">
-           <span class="coinname-value" data-coinname="{{ w.name }}">{{ w.est_fee }}</span>
+           <span class="coinname-value" data-coinname="{{ w.name }}" data-balance-type="est_fee">{{ w.est_fee }}</span>
           (<span class="usd-value fee-estimate-usd" data-decimals="8"></span>)
           </td>
           </tr>

--- a/basicswap/templates/wallets.html
+++ b/basicswap/templates/wallets.html
@@ -65,7 +65,7 @@
       <div class="p-6 bg-coolGray-100 dark:bg-gray-600">
           <div class="flex mb-2 justify-between items-center">
               <h4 class="text-xs font-medium dark:text-white">Balance:</h4>
-              <div class="bold inline-block py-1 px-2 rounded-full bg-blue-100 text-xs text-black-500 dark:bg-gray-500 dark:text-gray-200 coinname-value" data-coinname="{{ w.name }}">{{ w.balance }} {{ w.ticker }}</div>
+              <div class="bold inline-block py-1 px-2 rounded-full bg-blue-100 text-xs text-black-500 dark:bg-gray-500 dark:text-gray-200 coinname-value" data-coinname="{{ w.name }}" data-balance-type="balance">{{ w.balance }} {{ w.ticker }}</div>
           </div>
           <div class="flex mb-2 justify-between items-center">
               <h4 class="text-xs font-medium dark:text-white ">{{ w.ticker }} USD value:</h4>
@@ -90,7 +90,7 @@
        {% if w.cid == '1' %} {# PART #}
        <div class="flex mb-2 justify-between items-center">
         <h4 class="text-xs font-medium dark:text-white">Blind Balance:</h4>
-        <span class="bold inline-block py-1 px-2 rounded-full bg-blue-100 text-xs text-black-500 dark:bg-gray-500 dark:text-gray-200 coinname-value" data-coinname="{{ w.name }}">{{ w.blind_balance }} {{ w.ticker }}</span>
+        <span class="bold inline-block py-1 px-2 rounded-full bg-blue-100 text-xs text-black-500 dark:bg-gray-500 dark:text-gray-200 coinname-value" data-coinname="{{ w.name }}" data-balance-type="blind_balance">{{ w.blind_balance }} {{ w.ticker }}</span>
        </div>
         <div class="flex mb-2 justify-between items-center">
           <h4 class="text-xs font-medium dark:text-white">Blind USD value:</h4>
@@ -108,7 +108,7 @@
        {% endif %}
        <div class="flex mb-2 justify-between items-center">
         <h4 class="text-xs font-medium dark:text-white">Anon Balance:</h4>
-        <span class="bold inline-block py-1 px-2 rounded-full bg-blue-100 text-xs text-black-500 dark:bg-gray-500 dark:text-gray-200 coinname-value"  data-coinname="{{ w.name }}">{{ w.anon_balance }} {{ w.ticker }}</span>
+        <span class="bold inline-block py-1 px-2 rounded-full bg-blue-100 text-xs text-black-500 dark:bg-gray-500 dark:text-gray-200 coinname-value"  data-coinname="{{ w.name }}" data-balance-type="anon_balance">{{ w.anon_balance }} {{ w.ticker }}</span>
        </div>
         <div class="flex mb-2 justify-between items-center">
           <h4 class="text-xs font-medium dark:text-white">Anon USD value:</h4>
@@ -129,7 +129,7 @@
        {% if w.cid == '3' and w.connection_type != 'electrum' %} {# LTC - MWEB not available in electrum mode #}
        <div class="flex mb-2 justify-between items-center">
         <h4 class="text-xs font-medium dark:text-white">MWEB Balance:</h4>
-        <span class="bold inline-block py-1 px-2 rounded-full bg-blue-100 text-xs text-black-500 dark:bg-gray-500 dark:text-gray-200 coinname-value" data-coinname="{{ w.name }}">{{ w.mweb_balance }} {{ w.ticker }}</span>
+        <span class="bold inline-block py-1 px-2 rounded-full bg-blue-100 text-xs text-black-500 dark:bg-gray-500 dark:text-gray-200 coinname-value" data-coinname="{{ w.name }}" data-balance-type="mweb_balance">{{ w.mweb_balance }} {{ w.ticker }}</span>
        </div>
         <div class="flex mb-2 justify-between items-center">
           <h4 class="text-xs font-medium dark:text-white">MWEB USD value:</h4>
@@ -151,7 +151,7 @@
        {% if w.cid == '13' %} {# FIRO #}
        <div class="flex mb-2 justify-between items-center">
         <h4 class="text-xs font-medium dark:text-white">Spark Balance:</h4>
-        <span class="bold inline-block py-1 px-2 rounded-full bg-blue-100 text-xs text-black-500 dark:bg-gray-500 dark:text-gray-200 coinname-value" data-coinname="{{ w.name }}">{{ w.spark_balance }} {{ w.ticker }}</span>
+        <span class="bold inline-block py-1 px-2 rounded-full bg-blue-100 text-xs text-black-500 dark:bg-gray-500 dark:text-gray-200 coinname-value" data-coinname="{{ w.name }}" data-balance-type="spark_balance">{{ w.spark_balance }} {{ w.ticker }}</span>
        </div>
         <div class="flex mb-2 justify-between items-center">
           <h4 class="text-xs font-medium dark:text-white">Spark USD value:</h4>


### PR DESCRIPTION
- js_server.py: Add blind_balance, anon_balance, mweb_balance, spark_balance fields to main coin entry in js_walletbalances.
- wallet-page.js: Update handleBalanceUpdate to use data-balance-type attribute for selective updates instead of overwriting all matching spans.
- wallets-page.js: Add Litecoin MWEB variant handling andupdate sub-balances (MWEB, Spark, Blind, Anon) from main coin entry.
- wallet.html / wallets.html: Add data-balance-type attribute to all coinname-value spans
- Various small fixes.

