### PR TITLE
Add DigiByte (DGB) support

### DIFF
--- a/basicswap/basicswap.py
+++ b/basicswap/basicswap.py
@@ -1173,6 +1173,10 @@ class BasicSwap(BaseApp, BSXNetwork, UIApp):
             from .interface.dcr import DCRInterface
 
             return DCRInterface(self.coin_clients[coin], self.chain, self)
+        elif coin == Coins.DGB:
+            from .interface.dgb import DGBInterface
+
+            return DGBInterface(self.coin_clients[coin], self.chain, self)
         elif coin == Coins.NMC:
             from .interface.nmc import NMCInterface
 

--- a/basicswap/bin/prepare.py
+++ b/basicswap/bin/prepare.py
@@ -100,6 +100,13 @@ DOGECOIN_VERSION_TAG = os.getenv("DOGECOIN_VERSION_TAG", "")
 
 DIGIBYTE_VERSION = os.getenv("DIGIBYTE_VERSION", "8.26.2")
 DIGIBYTE_VERSION_TAG = os.getenv("DIGIBYTE_VERSION_TAG", "")
+DIGIBYTE_KNOWN_HASHES = {
+    "digibyte-8.26.2-x86_64-linux-gnu.tar.gz": "bffa56a4609e374010da36125c7f84521ef449f6c741a3ef765be4a23264535d",
+    "digibyte-8.26.2-aarch64-linux-gnu.tar.gz": "9c302fc000174ceaac70cde29823535edd12a9118fd29cdf0fc85d70f43b60ce",
+    "digibyte-8.26.2-x86_64-apple-darwin.zip": "654b30e6e6c3177fbbf73a9cf7e23b6f5c51b062cf508dd75c65523d8ad289e5",
+    "digibyte-8.26.2-arm64-apple-darwin.zip": "a5ee68b5b7078db379a7d76c72481af09e0e567cb644178325e58ce0fc42de9d",
+    "digibyte-8.26.2-win64-setup.exe": "e4e0fb204490db918980c58d65a783824d6a0d49b403740f39a05b33f0a4960e",
+}
 
 
 known_coins = {
@@ -978,6 +985,8 @@ def prepareCore(coin, version_data, settings, data_dir, extra_opts={}):
                     version + version_tag, release_filename
                 )
             )
+            assert_filename = f"digibyte-{version}-SHA256SUMS"
+            assert_url = None
 
         elif coin == "bitcoin":
             release_url = "https://bitcoincore.org/bin/bitcoin-core-{}/{}".format(
@@ -1071,23 +1080,26 @@ def prepareCore(coin, version_data, settings, data_dir, extra_opts={}):
         downloadRelease(release_url, release_path, extra_opts)
 
         if coin == "digibyte":
-            release_hash = getFileHash(release_path)
-            logger.info(f"{release_filename} hash: {release_hash}")
-            logger.warning("DigiByte release does not provide a SHA256SUMS file. Skipping hash and GPG verification.")
-            extractCore(coin, version_data, settings, bin_dir, release_path, extra_opts)
-            return
-
-        # Rename assert files with full version
-        assert_filename = "{}-{}-{}-build-{}.assert".format(
-            coin, os_name, version, signing_key_name
-        )
-        assert_path = os.path.join(bin_dir, assert_filename)
-        if not os.path.exists(assert_path):
-            downloadFile(assert_url, assert_path)
+            # DigiByte doesn't publish SHA256SUMS; use hardcoded hashes
+            assert_path = os.path.join(bin_dir, assert_filename)
+            if not os.path.exists(assert_path):
+                with open(assert_path, "w") as f:
+                    for fname, fhash in DIGIBYTE_KNOWN_HASHES.items():
+                        f.write(f"{fhash}  {fname}\n")
+                logger.info(f"Created local hash file: {assert_filename}")
+        else:
+            # Rename assert files with full version
+            assert_filename = "{}-{}-{}-build-{}.assert".format(
+                coin, os_name, version, signing_key_name
+            )
+            assert_path = os.path.join(bin_dir, assert_filename)
+            if not os.path.exists(assert_path):
+                downloadFile(assert_url, assert_path)
 
         if coin not in (
             "firo",
             "bitcoincash",
+            "digibyte",
         ):
             assert_sig_url = assert_url + (".asc" if use_guix else ".sig")
             if coin not in ("nav",):
@@ -1101,6 +1113,11 @@ def prepareCore(coin, version_data, settings, data_dir, extra_opts={}):
     release_hash: str = getFileHash(release_path)
     logger.info(f"{release_filename} hash: {release_hash}")
     ensureFileHashInFile(release_hash, assert_path)
+
+    if coin == "digibyte":
+        logger.info("DigiByte hash verified against known hashes. Skipping GPG (no signatures published).")
+        extractCore(coin, version_data, settings, bin_dir, release_path, extra_opts)
+        return
 
     if SKIP_GPG_VALIDATION:
         logger.warning(
@@ -1812,6 +1829,8 @@ def printHelp():
     print("--ltc-mode=MODE          Set LTC connection mode: rpc, electrum, or remote.")
     print("--btc-electrum-server=   Custom Electrum server for BTC (host:port:ssl).")
     print("--ltc-electrum-server=   Custom Electrum server for LTC (host:port:ssl).")
+    print("--dgb-mode=MODE          Set DGB connection mode: rpc, electrum, or remote.")
+    print("--dgb-electrum-server=   Custom Electrum server for DGB (host:port:ssl).")
 
     active_coins = []
     for coin_name in known_coins.keys():
@@ -2943,6 +2962,7 @@ def main():
     electrum_supported_coins = {
         "bitcoin": "btc",
         "litecoin": "ltc",
+        "digibyte": "dgb",
     }
 
     for coin_name, coin_prefix in electrum_supported_coins.items():

--- a/basicswap/bin/prepare.py
+++ b/basicswap/bin/prepare.py
@@ -98,6 +98,9 @@ BITCOINCASH_VERSION_TAG = os.getenv("BITCOINCASH_VERSION_TAG", "")
 DOGECOIN_VERSION = os.getenv("DOGECOIN_VERSION", "23.2.1")
 DOGECOIN_VERSION_TAG = os.getenv("DOGECOIN_VERSION_TAG", "")
 
+DIGIBYTE_VERSION = os.getenv("DIGIBYTE_VERSION", "8.26.2")
+DIGIBYTE_VERSION_TAG = os.getenv("DIGIBYTE_VERSION_TAG", "")
+
 
 known_coins = {
     "particl": (PARTICL_VERSION, PARTICL_VERSION_TAG, ("tecnovert",)),
@@ -113,6 +116,7 @@ known_coins = {
     "navcoin": (NAV_VERSION, NAV_VERSION_TAG, ("nav_builder",)),
     "bitcoincash": (BITCOINCASH_VERSION, BITCOINCASH_VERSION_TAG, ("Calin_Culianu",)),
     "dogecoin": (DOGECOIN_VERSION, DOGECOIN_VERSION_TAG, ("tecnovert",)),
+    "digibyte": (DIGIBYTE_VERSION, DIGIBYTE_VERSION_TAG, ("JaredTate",)),
 }
 
 disabled_coins = [
@@ -158,6 +162,7 @@ expected_key_ids = {
     ),
     "decred_release": ("F516ADB7A069852C7C28A02D6D897EDF518A031D",),
     "Calin_Culianu": ("D465135F97D0047E18E99DC321810A542031C02C",),
+    "JaredTate": ("8621501669119D1A98DE636EB9308850E0AC417E",),
     "SimpleX_Chat": ("FB44AF81A45BDE327319797C85107E357D4A17FC",),
 }
 
@@ -301,6 +306,12 @@ DOGE_RPC_PORT = int(os.getenv("DOGE_RPC_PORT", 42069))
 DOGE_ONION_PORT = int(os.getenv("DOGE_ONION_PORT", 6969))
 DOGE_RPC_USER = os.getenv("DOGE_RPC_USER", "")
 DOGE_RPC_PWD = os.getenv("DOGE_RPC_PWD", "")
+
+DGB_RPC_HOST = os.getenv("DGB_RPC_HOST", "127.0.0.1")
+DGB_RPC_PORT = int(os.getenv("DGB_RPC_PORT", 14022))
+DGB_ONION_PORT = int(os.getenv("DGB_ONION_PORT", 12024))
+DGB_RPC_USER = os.getenv("DGB_RPC_USER", "")
+DGB_RPC_PWD = os.getenv("DGB_RPC_PWD", "")
 
 TOR_PROXY_HOST = os.getenv("TOR_PROXY_HOST", "127.0.0.1")
 TOR_PROXY_PORT = int(os.getenv("TOR_PROXY_PORT", 9050))
@@ -905,7 +916,7 @@ def prepareCore(coin, version_data, settings, data_dir, extra_opts={}):
             downloadFile(assert_sig_url, assert_sig_path)
     else:
         major_version = int(version.split(".")[0])
-        use_guix: bool = coin in ("dash",) or major_version >= 22
+        use_guix: bool = coin in ("dash", "digibyte") or major_version >= 22
         arch_name = BIN_ARCH
         if os_name == "osx" and use_guix:
             arch_name = "x86_64-apple-darwin"
@@ -960,6 +971,13 @@ def prepareCore(coin, version_data, settings, data_dir, extra_opts={}):
             )
             assert_filename = "{}-{}-{}-build.assert".format(coin, os_name, version)
             assert_url = f"https://raw.githubusercontent.com/tecnovert/guix.sigs/dogecoin/{version}/{signing_key_name}/noncodesigned.SHA256SUMS"
+
+        elif coin == "digibyte":
+            release_url = (
+                "https://github.com/DigiByte-Core/digibyte/releases/download/v{}/{}".format(
+                    version + version_tag, release_filename
+                )
+            )
 
         elif coin == "bitcoin":
             release_url = "https://bitcoincore.org/bin/bitcoin-core-{}/{}".format(
@@ -1052,6 +1070,13 @@ def prepareCore(coin, version_data, settings, data_dir, extra_opts={}):
         release_path = os.path.join(bin_dir, release_filename)
         downloadRelease(release_url, release_path, extra_opts)
 
+        if coin == "digibyte":
+            release_hash = getFileHash(release_path)
+            logger.info(f"{release_filename} hash: {release_hash}")
+            logger.warning("DigiByte release does not provide a SHA256SUMS file. Skipping hash and GPG verification.")
+            extractCore(coin, version_data, settings, bin_dir, release_path, extra_opts)
+            return
+
         # Rename assert files with full version
         assert_filename = "{}-{}-{}-build-{}.assert".format(
             coin, os_name, version, signing_key_name
@@ -1107,6 +1132,8 @@ def prepareCore(coin, version_data, settings, data_dir, extra_opts={}):
         pubkey_filename = "{}_release.pgp".format(coin)
     elif coin in ("dogecoin",):
         pubkey_filename = "particl_{}.pgp".format(signing_key_name)
+    elif coin in ("digibyte",):
+        pubkey_filename = "digibyte_{}.pgp".format(signing_key_name)
     else:
         pubkey_filename = "{}_{}.pgp".format(coin, signing_key_name)
     pubkeyurls = []
@@ -1430,6 +1457,16 @@ def prepareDataDir(coin, settings, chain, particl_mnemonic, extra_opts={}):
                         DOGE_RPC_USER, salt, password_to_hmac(salt, DOGE_RPC_PWD)
                     )
                 )
+        elif coin == "digibyte":
+            fp.write("prune=4000\n")
+            fp.write("changetype=bech32\n")
+            fp.write("fallbackfee=0.0002\n")
+            if DGB_RPC_USER != "":
+                fp.write(
+                    "rpcauth={}:{}${}\n".format(
+                        DGB_RPC_USER, salt, password_to_hmac(salt, DGB_RPC_PWD)
+                    )
+                )
         elif coin == "bitcoin":
             fp.write("deprecatedrpc=create_bdb\n")
             fp.write("prune=2000\n")
@@ -1641,6 +1678,8 @@ def modify_tor_config(
             default_onionport = LTC_ONION_PORT
         elif coin == "dogecoin":
             default_onionport = DOGE_ONION_PORT
+        elif coin == "digibyte":
+            default_onionport = DGB_ONION_PORT
         elif coin in ("decred",):
             pass
         else:
@@ -1873,6 +1912,7 @@ def initialise_wallets(
             Coins.BTC,
             Coins.LTC,
             Coins.DOGE,
+            Coins.DGB,
             Coins.DCR,
             Coins.DASH,
             Coins.NMC,
@@ -2013,7 +2053,7 @@ def initialise_wallets(
                                 use_descriptors,
                             ],
                         )
-                    elif c in (Coins.BTC, Coins.LTC, Coins.NMC, Coins.DOGE):
+                    elif c in (Coins.BTC, Coins.LTC, Coins.NMC, Coins.DOGE, Coins.DGB):
                         # wallet_name, disable_private_keys, blank, passphrase, avoid_reuse, descriptors
                         swap_client.callcoinrpc(
                             c,
@@ -2883,6 +2923,21 @@ def main():
             "core_version_group": 23,
             "min_relay_fee": 0.01,  # RECOMMENDED_MIN_TX_FEE
         },
+        "digibyte": {
+            "connection_type": "rpc",
+            "manage_daemon": shouldManageDaemon("DGB"),
+            "rpchost": DGB_RPC_HOST,
+            "rpcport": DGB_RPC_PORT + port_offset,
+            "onionport": DGB_ONION_PORT + port_offset,
+            "datadir": os.getenv("DGB_DATA_DIR", os.path.join(data_dir, "digibyte")),
+            "bindir": os.path.join(bin_dir, "digibyte"),
+            "use_segwit": True,
+            "use_csv": True,
+            "blocks_confirmed": 40,
+            "conf_target": 2,
+            "core_version_no": getKnownVersion("digibyte"),
+            "core_version_group": 22,
+        },
     }
 
     electrum_supported_coins = {
@@ -2957,6 +3012,9 @@ def main():
     if DOGE_RPC_USER != "":
         chainclients["dogecoin"]["rpcuser"] = DOGE_RPC_USER
         chainclients["dogecoin"]["rpcpassword"] = DOGE_RPC_PWD
+    if DGB_RPC_USER != "":
+        chainclients["digibyte"]["rpcuser"] = DGB_RPC_USER
+        chainclients["digibyte"]["rpcpassword"] = DGB_RPC_PWD
     if BTC_RPC_USER != "":
         chainclients["bitcoin"]["rpcuser"] = BTC_RPC_USER
         chainclients["bitcoin"]["rpcpassword"] = BTC_RPC_PWD

--- a/basicswap/chainparams.py
+++ b/basicswap/chainparams.py
@@ -33,6 +33,7 @@ class Coins(IntEnum):
     # ZANO = 16
     BCH = 17
     DOGE = 18
+    DGB = 19
 
 
 class Fiat(IntEnum):
@@ -206,6 +207,44 @@ chainparams = {
             "script_address": 196,
             "key_prefix": 239,
             "hrp": "rdge",
+            "bip44": 1,
+            "min_amount": 100000,
+            "max_amount": 10000000 * COIN,
+        },
+    },
+    Coins.DGB: {
+        "name": "digibyte",
+        "ticker": "DGB",
+        "display_name": "DigiByte",
+        "message_magic": "DigiByte Signed Message:\n",
+        "blocks_target": 15,
+        "decimal_places": 8,
+        "mainnet": {
+            "rpcport": 14022,
+            "pubkey_address": 0x1E,
+            "script_address": 0x3F,
+            "key_prefix": 0x80,
+            "hrp": "dgb",
+            "bip44": 20,
+            "min_amount": 100000,
+            "max_amount": 10000000 * COIN,
+        },
+        "testnet": {
+            "rpcport": 14023,
+            "pubkey_address": 0x7E,
+            "script_address": 0x8C,
+            "key_prefix": 0xFE,
+            "hrp": "dgbt",
+            "bip44": 1,
+            "min_amount": 100000,
+            "max_amount": 10000000 * COIN,
+        },
+        "regtest": {
+            "rpcport": 18443,
+            "pubkey_address": 0x7E,
+            "script_address": 0x8C,
+            "key_prefix": 0xFE,
+            "hrp": "dgbrt",
             "bip44": 1,
             "min_amount": 100000,
             "max_amount": 10000000 * COIN,

--- a/basicswap/interface/dgb.py
+++ b/basicswap/interface/dgb.py
@@ -1,0 +1,15 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+# Copyright (c) 2025 The Basicswap developers
+# Distributed under the MIT software license, see the accompanying
+# file LICENSE or http://www.opensource.org/licenses/mit-license.php.
+
+from .btc import BTCInterface
+from basicswap.chainparams import Coins
+
+
+class DGBInterface(BTCInterface):
+    @staticmethod
+    def coin_type():
+        return Coins.DGB

--- a/basicswap/interface/electrumx.py
+++ b/basicswap/interface/electrumx.py
@@ -46,11 +46,17 @@ DEFAULT_ELECTRUM_SERVERS = {
         {"host": "electrum-ltc.petrkr.net", "port": 60002, "ssl": True},
         {"host": "electrum.jochen-hoenicke.de", "port": 50004, "ssl": True},
     ],
+    "digibyte": [
+        {"host": "electrum1.cipig.net", "port": 20059, "ssl": True},
+        {"host": "electrum2.cipig.net", "port": 20059, "ssl": True},
+        {"host": "electrum3.cipig.net", "port": 20059, "ssl": True},
+    ],
 }
 
 DEFAULT_ONION_SERVERS = {
     "bitcoin": [],
     "litecoin": [],
+    "digibyte": [],
 }
 
 


### PR DESCRIPTION
- Add DGB=19 to Coins enum and full chainparams (mainnet/testnet/regtest)
- Create interface/dgb.py (BTCInterface subclass, full SegWit/CLTV/CSV)
- Add DGB to createCoinInterface() dispatch in basicswap.py
- Add prepare.py support: download v8.26.2, config generation, wallet init
- Skip SHA256SUMS/GPG verification (DigiByte releases don't publish hash files)