### PR TITLE
fix: use main address for XMR & WOW

### DIFF
--- a/basicswap/basicswap.py
+++ b/basicswap/basicswap.py
@@ -11896,7 +11896,7 @@ class BasicSwap(BaseApp, BSXNetwork, UIApp):
             )
             vkbs = ci_to.sumKeys(kbsl, kbsf)
 
-            if coin_to == (Coins.XMR, Coins.WOW):
+            if coin_to in (Coins.XMR, Coins.WOW):
                 address_to = self.getCachedMainWalletAddress(ci_to, cursor)
             elif coin_to in (Coins.PART_BLIND, Coins.PART_ANON):
                 address_to = self.getCachedStealthAddressForCoin(coin_to, cursor)


### PR DESCRIPTION
```python
if coin_to == (Coins.XMR, Coins.WOW):  # always False
```

XMR/WOW redemption falls through to `getReceiveAddressFromPool`, which creates a new sub-address per swap instead of using the cached main-wallet address.