### PR TITLE
Small UI fixes for the offer/bid flow

### DIFF
--- a/basicswap/static/js/pages/offer-new-page.js
+++ b/basicswap/static/js/pages/offer-new-page.js
@@ -579,7 +579,12 @@ function initializeApp() {
         });
 
         DOM.addEvent(id, 'input', function() {
-            RateManager.setRate(id);
+            // When rate is locked, suppress as-you-type recalc; the 'change'
+            // (blur) handler recalculates once the full value is entered.
+            const rateLock = document.getElementById('rate_lock');
+            if (rateLock && !rateLock.checked) {
+                RateManager.setRate(id);
+            }
         });
     });
 

--- a/basicswap/static/js/pages/offer-page.js
+++ b/basicswap/static/js/pages/offer-page.js
@@ -261,7 +261,9 @@
 
       const validMins = validMinsInput ? validMinsInput.value : '60';
 
-      const addrFrom = addrFromSelect ? addrFromSelect.value : '';
+      const addrFrom = addrFromSelect && addrFromSelect.selectedIndex >= 0
+        ? addrFromSelect.options[addrFromSelect.selectedIndex].text
+        : '';
 
       const modalAmtReceive = document.getElementById('modal-amt-receive');
       const modalReceiveCurrency = document.getElementById('modal-receive-currency');

--- a/basicswap/templates/bid.html
+++ b/basicswap/templates/bid.html
@@ -647,7 +647,12 @@ document.addEventListener('DOMContentLoaded', function() {
   }
 
   window.confirmPopup = function(action = 'Abandon') {
-    triggerElement = document.activeElement;
+    // Guard: overrideButtonConfirm sets triggerElement = this before calling here.
+    // e.preventDefault() in the click handler may prevent the button from becoming
+    // document.activeElement, so only fall back to activeElement if not already set.
+    if (!triggerElement) {
+      triggerElement = document.activeElement;
+    }
     const title = `Confirm ${action} Bid`;
     const showBidDetails = action.toLowerCase() === 'accept';
 


### PR DESCRIPTION
A few minor front-end improvements to the offer creation and bid confirmation pages. No backend/protocol changes.

## 1. Bid accept confirmation button could be unresponsive
`overrideButtonConfirm` sets `triggerElement = this` before calling `confirmPopup`, but `confirmPopup` unconditionally overwrote it with `document.activeElement`. Since the click handler calls `e.preventDefault()`, the button may not become `activeElement`, leaving `triggerElement.form` null so `form.submit()` did nothing. Guard the assignment to only fall back to `activeElement` when `triggerElement` isn't already set.

## 2. Confirm bid dialog shows "-1" for Send From Address
The dialog displayed the raw `<select name="addr_from">` value, which is `-1` for the default "New Address" option. Show the selected option's text instead, so it reads "New Address" (or the address + label).

## 3. Rate field not updating when entering amounts with lock rate checked
With "lock rate" checked (default), the rate is auto-populated from the two amounts. The per-keystroke `input` handler recalculated on partial input: typing "0.002" sent the leading "0" first, the server returned a rate of 0, and the field stayed there. Only recalc from `input` when lock rate is unchecked; when checked, the `change` (blur) handler computes the rate once from the complete amounts. Unchecked behavior is unchanged.
