### PR TITLE
Prevent receive-address reuse and fix gap limit derivation.

### DIFF
--- a/basicswap/db.py
+++ b/basicswap/db.py
@@ -12,8 +12,8 @@ import time
 from enum import IntEnum, auto
 from typing import Optional
 
-CURRENT_DB_VERSION = 34
-CURRENT_DB_DATA_VERSION = 8
+CURRENT_DB_VERSION = 35
+CURRENT_DB_DATA_VERSION = 9
 
 
 class Concepts(IntEnum):

--- a/basicswap/db.py
+++ b/basicswap/db.py
@@ -13,7 +13,7 @@ from enum import IntEnum, auto
 from typing import Optional
 
 CURRENT_DB_VERSION = 35
-CURRENT_DB_DATA_VERSION = 9
+CURRENT_DB_DATA_VERSION = 8
 
 
 class Concepts(IntEnum):

--- a/basicswap/db.py
+++ b/basicswap/db.py
@@ -13,7 +13,7 @@ from enum import IntEnum, auto
 from typing import Optional
 
 CURRENT_DB_VERSION = 35
-CURRENT_DB_DATA_VERSION = 8
+CURRENT_DB_DATA_VERSION = 9
 
 
 class Concepts(IntEnum):

--- a/basicswap/db_upgrades.py
+++ b/basicswap/db_upgrades.py
@@ -154,6 +154,17 @@ def upgradeDatabaseData(self, data_version):
             ):
                 addBidState(self, state, now, cursor)
 
+        if data_version > 0 and data_version < 9:
+            cursor.execute(
+                "UPDATE wallet_addresses SET ever_used = 1"
+                " WHERE is_funded = 1"
+                " OR (cached_balance IS NOT NULL AND cached_balance > 0)"
+                " OR first_seen_height IS NOT NULL"
+            )
+            cursor.execute(
+                "UPDATE wallet_addresses SET ever_used = 0 WHERE ever_used IS NULL"
+            )
+
         self.db_data_version = CURRENT_DB_DATA_VERSION
         self.setIntKV("db_data_version", self.db_data_version, cursor)
         self.commitDB()

--- a/basicswap/db_wallet.py
+++ b/basicswap/db_wallet.py
@@ -21,6 +21,7 @@ class WalletAddress(Table):
     scripthash = Column("string")
     pubkey = Column("blob")
     is_funded = Column("bool")
+    ever_used = Column("bool")
     cached_balance = Column("integer")
     cached_balance_time = Column("integer")
     first_seen_height = Column("integer")

--- a/basicswap/wallet_manager.py
+++ b/basicswap/wallet_manager.py
@@ -154,6 +154,7 @@ class WalletManager:
         query = (
             "SELECT derivation_index, address FROM wallet_addresses"
             " WHERE coin_type = ? AND is_internal = ? AND is_funded = 0"
+            " AND ever_used = 0"
             " ORDER BY derivation_index ASC LIMIT 1"
         )
         cursor.execute(query, (int(coin_type), internal))
@@ -161,6 +162,22 @@ class WalletManager:
         if row:
             return row[0], row[1]
         return None, None
+
+    def _trailingUnusedGap(
+        self, coin_type: Coins, internal: bool, next_index: int, cursor
+    ) -> int:
+        cursor.execute(
+            "SELECT derivation_index, ever_used FROM wallet_addresses"
+            " WHERE coin_type = ? AND is_internal = ? AND derivation_index < ?"
+            " ORDER BY derivation_index DESC",
+            (int(coin_type), internal, next_index),
+        )
+        gap = 0
+        for _, ever_used in cursor.fetchall():
+            if ever_used:
+                break
+            gap += 1
+        return gap
 
     def getNewAddress(
         self, coin_type: Coins, internal: bool = False, label: str = "", cursor=None
@@ -195,7 +212,10 @@ class WalletManager:
                 else:
                     next_index = (state.last_external_index or 0) + 1
 
-            if next_index >= self.ELECTRUM_GAP_LIMIT:
+            trailing_gap = self._trailingUnusedGap(
+                coin_type, internal, next_index, use_cursor
+            )
+            if trailing_gap + 1 >= self.ELECTRUM_GAP_LIMIT:
                 reuse_index, reuse_addr = self._findReusableAddress(
                     coin_type, internal, use_cursor
                 )
@@ -203,7 +223,14 @@ class WalletManager:
                     self._log.debug(
                         f"Reusing unfunded address at index {reuse_index}"
                         f" (next would be {next_index},"
+                        f" trailing unused gap {trailing_gap},"
                         f" electrum gap limit {self.ELECTRUM_GAP_LIMIT})"
+                    )
+                    use_cursor.execute(
+                        "UPDATE wallet_addresses SET ever_used = 1"
+                        " WHERE coin_type = ? AND derivation_index = ?"
+                        " AND is_internal = ?",
+                        (int(coin_type), reuse_index, internal),
                     )
                     self._swap_client.commitDB()
                     return reuse_addr
@@ -220,6 +247,12 @@ class WalletManager:
 
             if existing:
                 address = existing.address
+                use_cursor.execute(
+                    "UPDATE wallet_addresses SET ever_used = 1"
+                    " WHERE coin_type = ? AND derivation_index = ?"
+                    " AND is_internal = ?",
+                    (int(coin_type), next_index, internal),
+                )
                 if state:
                     if internal:
                         state.last_internal_index = next_index
@@ -248,6 +281,7 @@ class WalletManager:
                     scripthash=scripthash,
                     pubkey=pubkey,
                     is_funded=False,
+                    ever_used=True,
                     cached_balance=0,
                     created_at=now,
                 ),
@@ -359,6 +393,7 @@ class WalletManager:
                     scripthash=scripthash,
                     pubkey=pubkey,
                     is_funded=True,
+                    ever_used=True,
                     cached_balance=0,
                     created_at=now,
                 ),
@@ -490,6 +525,7 @@ class WalletManager:
                     scripthash=scripthash,
                     pubkey=pubkey,
                     is_funded=False,
+                    ever_used=True,
                     created_at=now,
                 ),
                 cursor,
@@ -662,6 +698,8 @@ class WalletManager:
                             record.is_funded = balance > 0
                             if record_type == "wallet":
                                 record.cached_balance_time = now
+                                if balance > 0:
+                                    record.ever_used = True
                             self._swap_client.updateDB(
                                 record, cursor, constraints=["coin_type", "address"]
                             )
@@ -1116,6 +1154,7 @@ class WalletManager:
                             scripthash=addr_data["scripthash"],
                             pubkey=addr_data["pubkey"],
                             is_funded=False,
+                            ever_used=False,
                             cached_balance=0,
                             created_at=now,
                         ),
@@ -1287,6 +1326,7 @@ class WalletManager:
                             scripthash=scripthash,
                             pubkey=pubkey,
                             is_funded=False,
+                            ever_used=False,
                             cached_balance=0,
                             created_at=now,
                         ),
@@ -1416,6 +1456,7 @@ class WalletManager:
                             scripthash=scripthash,
                             pubkey=pubkey,
                             is_funded=False,
+                            ever_used=False,
                             created_at=now,
                         )
                         self._swap_client.add(record, cursor)


### PR DESCRIPTION
Prevents reused receive addresses and fixes the gap-limit calculation in the Electrum HD wallet.

Previously an address could be handed out again even after it had already been used, and the gap-limit check looked at the total derivation index instead of the run of trailing unused addresses, so address reuse could trigger at the wrong time.

This adds an ever_used flag to wallet addresses (with a DB migration for existing wallets), only recycles addresses that were never used, and bases the gap-limit decision on the number of unused addresses at the end of the chain. Addresses are marked used when they're handed out or first receive funds.