### PR TITLE
swaps: only enforce secret hash if both coins are same type

### DIFF
--- a/basicswap/static/js/pages/amm-tables.js
+++ b/basicswap/static/js/pages/amm-tables.js
@@ -6,7 +6,7 @@ const AmmTablesManager = (function() {
 
     let refreshTimer = null;
     let stateData = null;
-    let coinData = {};
+    const coinData = {};
 
     const offersTab = document.getElementById('offers-tab');
     const bidsTab = document.getElementById('bids-tab');
@@ -2178,8 +2178,7 @@ const AmmTablesManager = (function() {
         }
     }
 
-    const adaptor_sig_only_coins = ['6', 'Monero', '7', 'Particl Blind', '8', 'Particl Anon', '9', 'Wownero', '13', 'Firo', '16', 'Zano', '17', 'Bitcoin Cash', '18', 'Dogecoin'];
-    const secret_hash_only_coins = ['11', 'PIVX', '12', 'Dash'];
+    const coins_without_segwit = ['11', 'PIVX', '12', 'Dash'];
 
     function updateSwapTypeOptions(coinFromValue, coinToValue, swapTypeSelect) {
         if (!swapTypeSelect) return;
@@ -2189,15 +2188,12 @@ const AmmTablesManager = (function() {
 
         let disableSelect = false;
 
-        if (adaptor_sig_only_coins.includes(coinFromValue) || adaptor_sig_only_coins.includes(coinToValue)) {
-            swapTypeSelect.value = 'adaptor_sig';
-            disableSelect = true;
-        } else if (secret_hash_only_coins.includes(coinFromValue) || secret_hash_only_coins.includes(coinToValue)) {
+        if (coins_without_segwit.includes(coinFromValue) && coins_without_segwit.includes(coinToValue)) {
             swapTypeSelect.value = 'seller_first';
             disableSelect = true;
         } else {
             swapTypeSelect.value = 'adaptor_sig';
-            disableSelect = false;
+            disableSelect = true;
         }
 
         swapTypeSelect.disabled = disableSelect;
@@ -2226,7 +2222,7 @@ const AmmTablesManager = (function() {
             if (!select) return;
 
             if (select.style.display === 'none' && select.parentNode.querySelector('.relative')) {
-                return; 
+                return;
             }
 
             const wrapper = document.createElement('div');
@@ -2329,9 +2325,9 @@ const AmmTablesManager = (function() {
 
             let showBalance = false;
             if (modalType === 'offer' && select.id.includes('coin-from')) {
-                showBalance = true; 
+                showBalance = true;
             } else if (modalType === 'bid' && select.id.includes('coin-to')) {
-                showBalance = true; 
+                showBalance = true;
             }
 
             createSimpleDropdown(select, showBalance);
@@ -2466,7 +2462,7 @@ const AmmTablesManager = (function() {
                         console.error('CoinGecko error:', response.coingecko_error);
                         rateInput.value = originalValue || '';
 
-                        let userMessage = 'Unable to get current market rate from CoinGecko.';
+                        const userMessage = 'Unable to get current market rate from CoinGecko.';
                         let details = '';
 
                         if (typeof response.coingecko_error === 'number') {
@@ -2515,7 +2511,7 @@ const AmmTablesManager = (function() {
             } else {
                 console.error('Error fetching rate data:', xhr.status, xhr.statusText);
                 rateInput.value = originalValue || '';
-                let errorMessage = 'Unable to retrieve rate information from the server.';
+                const errorMessage = 'Unable to retrieve rate information from the server.';
                 let details = '';
 
                 switch(xhr.status) {
@@ -2633,7 +2629,7 @@ const AmmTablesManager = (function() {
                             icon.classList.remove('animate-spin');
                         }
                         refreshButton.disabled = false;
-                    }, 500); 
+                    }, 500);
                 }
             });
         }

--- a/basicswap/static/js/pages/offer-new-page.js
+++ b/basicswap/static/js/pages/offer-new-page.js
@@ -328,8 +328,7 @@ function getRateInferred(event) {
 }
 
 const SwapTypeManager = {
-    adaptor_sig_only_coins: ['6', '9', '8', '7', '13', '18', '17'],
-    secret_hash_only_coins: ['11', '12'],
+    coins_without_segwit: ['11', '12'],
 
     setSwapTypeEnabled: (coinFrom, coinTo, swapTypeElement) => {
         if (!swapTypeElement) return;
@@ -338,24 +337,19 @@ const SwapTypeManager = {
         coinFrom = String(coinFrom);
         coinTo = String(coinTo);
 
-        if (SwapTypeManager.adaptor_sig_only_coins.includes(coinFrom) ||
-            SwapTypeManager.adaptor_sig_only_coins.includes(coinTo)) {
-            swapTypeElement.disabled = true;
-            swapTypeElement.value = 'xmr_swap';
-            makeHidden = true;
-            swapTypeElement.classList.add('select-disabled');
-        } else if (SwapTypeManager.secret_hash_only_coins.includes(coinFrom) ||
-                  SwapTypeManager.secret_hash_only_coins.includes(coinTo)) {
+        if (
+            SwapTypeManager.coins_without_segwit.includes(coinFrom) &&
+            SwapTypeManager.coins_without_segwit.includes(coinTo)
+        ) {
             swapTypeElement.disabled = true;
             swapTypeElement.value = 'seller_first';
             makeHidden = true;
             swapTypeElement.classList.add('select-disabled');
         } else {
-            swapTypeElement.disabled = false;
-            swapTypeElement.classList.remove('select-disabled');
-            if (['xmr_swap', 'seller_first'].includes(swapTypeElement.value) == false) {
-                swapTypeElement.value = 'xmr_swap';
-            }
+            swapTypeElement.disabled = true;
+            swapTypeElement.value = 'xmr_swap';
+            makeHidden = true;
+            swapTypeElement.classList.add('select-disabled');
         }
 
         let swapTypeHidden = DOM.get('swap_type_hidden');

--- a/tests/basicswap/test_other.py
+++ b/tests/basicswap/test_other.py
@@ -823,8 +823,8 @@ class Test(unittest.TestCase):
             (Coins.XMR, Coins.BTC, SwapTypes.XMR_SWAP),
             (Coins.BTC, Coins.FIRO, SwapTypes.XMR_SWAP),
             (Coins.FIRO, Coins.BTC, SwapTypes.XMR_SWAP),
-            (Coins.PIVX, Coins.BTC, SwapTypes.SELLER_FIRST),
-            (Coins.BTC, Coins.PIVX, SwapTypes.SELLER_FIRST),
+            (Coins.PIVX, Coins.BTC, SwapTypes.XMR_SWAP),
+            (Coins.BTC, Coins.PIVX, SwapTypes.XMR_SWAP),
             (Coins.DASH, Coins.PIVX, SwapTypes.SELLER_FIRST),
             (Coins.PIVX, Coins.DASH, SwapTypes.SELLER_FIRST),
         ]


### PR DESCRIPTION
It appears that no-segwit coins (pivx and dash) can behave as scriptless via reverse adaptor sig swaps when they are the maker, and i assume this means that they only require secret hash mode when both coins are "secret hash only" (renamed to coins_without_segwit to match basicswap.py) coins, ie dash<->pivx

this pr ~~sets gui~~ enforces use of adaptor sigs _except_ in the case that both coins are "secret hash only"

~~i have not tested these swaps myself.~~
tested both directions for ads swaps between part/pivx, and they work.

note: The misc changes here are from eslint

Edit:
regarding the gui changes, and the "place new offer" screen correctly changes the swap type, but the amm gui "add offer" does not. I think the amm gui has always had that issue though.
