### PR TITLE
refactor: ease validateFeeRate limits

### DIFF
--- a/basicswap/basicswap.py
+++ b/basicswap/basicswap.py
@@ -4136,8 +4136,8 @@ class BasicSwap(BaseApp, BSXNetwork, UIApp):
                 msg_buf.fee_rate_to = ci_to.make_int(fee_rate)
 
             if swap_type == SwapTypes.XMR_SWAP:
-                ci_from.validateFeeRate(msg_buf.fee_rate_from)
-                ci_to.validateFeeRate(msg_buf.fee_rate_to)
+                ci_from.validateFeeRate(msg_buf.fee_rate_from, Concepts.OFFER)
+                ci_to.validateFeeRate(msg_buf.fee_rate_to, Concepts.OFFER)
 
                 xmr_offer = XmrOffer()
 
@@ -6094,8 +6094,8 @@ class BasicSwap(BaseApp, BSXNetwork, UIApp):
 
             self.checkCoinsReady(coin_from, coin_to)
 
-            ci_from.validateFeeRate(xmr_offer.a_fee_rate)
-            ci_to.validateFeeRate(xmr_offer.b_fee_rate)
+            ci_from.validateFeeRate(xmr_offer.a_fee_rate, Concepts.BID)
+            ci_to.validateFeeRate(xmr_offer.b_fee_rate, Concepts.BID)
 
             bid_created_at: int = self.getTime()
             valid_for_seconds: int = extra_options.get("valid_for_seconds", 60 * 10)
@@ -6113,7 +6113,7 @@ class BasicSwap(BaseApp, BSXNetwork, UIApp):
                     ci_to.validatePrefundedTxAmounts(prefunded_tx_data)
                 )
                 self.log.debug(f"Using prefunded tx: {self.log.id(prefunded_txid)}")
-                ci_to.validateFeeRate(prefunded_tx_fee_rate)
+                ci_to.validateFeeRate(prefunded_tx_fee_rate, Concepts.BID)
             else:
                 amount, amount_to, bid_rate = self.setBidAmounts(
                     amount, offer, extra_options, ci_from
@@ -10364,8 +10364,8 @@ class BasicSwap(BaseApp, BSXNetwork, UIApp):
             ensure(len(offer_data.pkhash_seller) == 0, "Unexpected data")
             ensure(len(offer_data.secret_hash) == 0, "Unexpected data")
 
-            ci_from.validateFeeRate(offer_data.fee_rate_from)
-            ci_to.validateFeeRate(offer_data.fee_rate_to)
+            ci_from.validateFeeRate(offer_data.fee_rate_from, Concepts.OFFER)
+            ci_to.validateFeeRate(offer_data.fee_rate_to, Concepts.OFFER)
 
         else:
             raise ValueError("Unknown swap type {}.".format(offer_data.swap_type))

--- a/basicswap/basicswap.py
+++ b/basicswap/basicswap.py
@@ -6072,6 +6072,10 @@ class BasicSwap(BaseApp, BSXNetwork, UIApp):
         # Send MSG1L F -> L or MSG0F L -> F
         self.log.debug(f"postXmrBid {self.logIDO(offer_id)}")
 
+        bypass_fee_validation: bool = extra_options.get("bypass_fee_validation", False)
+        if bypass_fee_validation:
+            self.log.warning("Post bid: Bypassing fee checks!")
+
         try:
             cursor = self.openDB()
             offer, xmr_offer = self.getXmrOffer(offer_id, cursor=cursor)
@@ -6094,8 +6098,12 @@ class BasicSwap(BaseApp, BSXNetwork, UIApp):
 
             self.checkCoinsReady(coin_from, coin_to)
 
-            ci_from.validateFeeRate(xmr_offer.a_fee_rate, Concepts.BID)
-            ci_to.validateFeeRate(xmr_offer.b_fee_rate, Concepts.BID)
+            ci_from.validateFeeRate(
+                xmr_offer.a_fee_rate, Concepts.BID, bypass_fee_validation
+            )
+            ci_to.validateFeeRate(
+                xmr_offer.b_fee_rate, Concepts.BID, bypass_fee_validation
+            )
 
             bid_created_at: int = self.getTime()
             valid_for_seconds: int = extra_options.get("valid_for_seconds", 60 * 10)
@@ -6113,7 +6121,9 @@ class BasicSwap(BaseApp, BSXNetwork, UIApp):
                     ci_to.validatePrefundedTxAmounts(prefunded_tx_data)
                 )
                 self.log.debug(f"Using prefunded tx: {self.log.id(prefunded_txid)}")
-                ci_to.validateFeeRate(prefunded_tx_fee_rate, Concepts.BID)
+                ci_to.validateFeeRate(
+                    prefunded_tx_fee_rate, Concepts.BID, bypass_fee_validation
+                )
             else:
                 amount, amount_to, bid_rate = self.setBidAmounts(
                     amount, offer, extra_options, ci_from

--- a/basicswap/interface/utils.py
+++ b/basicswap/interface/utils.py
@@ -5,12 +5,21 @@
 # file LICENSE or http://www.opensource.org/licenses/mit-license.php.
 
 from basicswap.contrib.test_framework.messages import COIN
+from basicswap.db import (
+    Concepts,
+    strConcepts,
+)
+from basicswap.util import toBool as make_boolean
 
 
 class FeeValidator:
     @staticmethod
     def defaultMaxFeeRate() -> int:
         return COIN // 10
+
+    def __init__(self, **kwargs):
+        self.updateFeeValidationSettings(kwargs.get("network"))
+        super().__init__(**kwargs)
 
     def makeIntFromSetting(
         self, settings: dict, setting_name: str, default: int
@@ -20,11 +29,13 @@ class FeeValidator:
             return self.make_int(settings[setting_name])
         return default
 
-    def __init__(self, **kwargs):
+    def updateFeeValidationSettings(self, network: str) -> None:
         default_low_fee_conf_target: int = 24
         default_low_fee_rate: int = 0
+        default_low_estimated_feerate_multiplier: float = 0.8
         default_high_estimated_feerate_multiplier: float = 4.0
         default_high_fee_rate: int = self.defaultMaxFeeRate()
+        default_allow_highfee_offers_when_minfee_src: bool = True
         if self._sc:
             chain_client_settings = self._sc.getChainClientSettings(
                 self.coin_type()
@@ -36,6 +47,12 @@ class FeeValidator:
             default_low_fee_rate = self.makeIntFromSetting(
                 settings, "low_feerate", default_low_fee_rate
             )
+            default_low_estimated_feerate_multiplier = float(
+                settings.get(
+                    "low_estimated_feerate_multiplier",
+                    default_low_estimated_feerate_multiplier,
+                )
+            )
             default_high_estimated_feerate_multiplier = float(
                 settings.get(
                     "high_estimated_feerate_multiplier",
@@ -45,8 +62,14 @@ class FeeValidator:
             default_high_fee_rate = self.makeIntFromSetting(
                 settings, "high_feerate", default_high_fee_rate
             )
+            default_allow_highfee_offers_when_minfee_src = make_boolean(
+                settings.get(
+                    "allow_highfee_offers_when_minfee_src",
+                    default_allow_highfee_offers_when_minfee_src,
+                )
+            )
         else:
-            if kwargs.get("network") != "regtest":
+            if network != "regtest":
                 raise ValueError("swapclient unset")
             chain_client_settings = {}
 
@@ -55,9 +78,19 @@ class FeeValidator:
                 "low_fee_conf_target", default_low_fee_conf_target
             )
         )
+
         self._low_feerate = self.makeIntFromSetting(
             chain_client_settings, "low_feerate", default_low_fee_rate
         )
+
+        self._low_estimated_feerate_multiplier = float(
+            chain_client_settings.get(
+                "low_estimated_feerate_multiplier",
+                default_low_estimated_feerate_multiplier,
+            )
+        )
+        if self._low_estimated_feerate_multiplier < 0.0:
+            raise ValueError("low_estimated_feerate_multiplier can't be negative")
 
         # Set below 1.0 to disable estimating the max feerate and use max_feerate
         self._high_estimated_feerate_multiplier = float(
@@ -66,19 +99,64 @@ class FeeValidator:
                 default_high_estimated_feerate_multiplier,
             )
         )
+        if self._high_estimated_feerate_multiplier < 0.0:
+            raise ValueError("high_estimated_feerate_multiplier can't be negative")
+
         self._high_feerate = self.makeIntFromSetting(
             chain_client_settings, "high_feerate", default_high_fee_rate
         )
 
-        super().__init__(**kwargs)
+        self._allow_highfee_offers_when_minfee = make_boolean(
+            chain_client_settings.get(
+                "allow_highfee_offers_when_minfee_src",
+                default_allow_highfee_offers_when_minfee_src,
+            )
+        )
 
-    def validateFeeRate(self, feerate: int) -> None:
+    def getHardMinFee(self):  # -> (float, str) | (None, None):
+        chain_client_settings = self._sc.getChainClientSettings(
+            self.coin_type()
+        )  # basicswap.json
+        override_feerate = chain_client_settings.get("override_feerate", None)
+        if override_feerate:
+            self._log.debug(
+                f"Fee rate override used for {self.coin_name()}: {override_feerate}"
+            )
+            return override_feerate, "override_feerate"
+        if "min_relay_fee" in chain_client_settings:
+            return chain_client_settings["min_relay_fee"], "min_relay_fee_setting"
+
+        if self._connection_type == "rpc":
+            networkinfo = self.rpc("getnetworkinfo")
+            if "relayfee" in networkinfo:
+                return networkinfo["relayfee"], "relayfee_rpc"
+        return None, None
+
+    def validateFeeRate(self, feerate: int, concept_type: int) -> None:
         if self._low_feerate > 0:
-            min_feerate_src = "set_value"
-            min_feerate = self._low_feerate
+            min_feerate, min_feerate_src = (self._low_feerate, "set_value")
+            hard_min_feerate, hard_min_feerate_src = (None, None)
         else:
-            min_feerate, min_feerate_src = self.get_fee_rate(self._low_fee_conf_target)
-            min_feerate = self.make_int(min_feerate)
+            min_feerate_float, min_feerate_src = self.get_fee_rate(
+                self._low_fee_conf_target
+            )
+            min_feerate = self.make_int(min_feerate_float)
+            hard_min_feerate_float, hard_min_feerate_src = self.getHardMinFee()
+            hard_min_feerate = (
+                None
+                if hard_min_feerate_float is None
+                else self.make_int(hard_min_feerate_float)
+            )
+
+        # If the hard minfeerate is known reduce the minfeerate
+        if hard_min_feerate is not None and min_feerate_src in (
+            "estimatesmartfee",
+            "electrum",
+        ):
+            min_feerate = max(
+                hard_min_feerate,
+                int(min_feerate * self._low_estimated_feerate_multiplier),
+            )
 
         if self._high_estimated_feerate_multiplier >= 1.0:
             max_feerate, max_feerate_src = self.get_fee_rate()
@@ -94,8 +172,13 @@ class FeeValidator:
                 max_feerate_src = "clamped_to_set_value"
                 max_feerate = self._high_feerate
 
+        concept_name: str = strConcepts(concept_type)
+        min_fee_rate_desc: str = f"min {min_feerate} {min_feerate_src}"
+        if hard_min_feerate is not None and hard_min_feerate != min_feerate:
+            min_fee_rate_desc += f" (hardmin {hard_min_feerate} {hard_min_feerate_src})"
+
         self._log.debug(
-            f"Verify {self.ticker()} fee rate {feerate}, min {min_feerate} {min_feerate_src}, max {max_feerate} {max_feerate_src}"
+            f"Verify {self.ticker()} fee rate {feerate} for {concept_name}, {min_fee_rate_desc}, max {max_feerate} {max_feerate_src}"
         )
         if feerate < min_feerate:
             err_msg: str = (
@@ -103,7 +186,17 @@ class FeeValidator:
             )
             self._log.error(err_msg)
             raise ValueError(err_msg)
+
         if feerate > max_feerate:
+            # If validating for an offer, allow high fees if estimate source is relayfee
+            # Fee will be validated again on sending bid
+            if concept_type == Concepts.OFFER and self._allow_highfee_offers_when_minfee:
+                if max_feerate_src in ("relayfee", "min_relay_fee"):
+                    self._log.debug(
+                        "Allowing offer through as max feerate source is minfee"
+                    )
+                    return
+
             err_msg: str = (
                 f"Fee rate too high, {feerate} > {max_feerate}, {max_feerate_src}"
             )

--- a/basicswap/interface/utils.py
+++ b/basicswap/interface/utils.py
@@ -132,7 +132,9 @@ class FeeValidator:
                 return networkinfo["relayfee"], "relayfee_rpc"
         return None, None
 
-    def validateFeeRate(self, feerate: int, concept_type: int) -> None:
+    def validateFeeRate(
+        self, feerate: int, concept_type: int, force_bypass: bool = False
+    ) -> None:
         if self._low_feerate > 0:
             min_feerate, min_feerate_src = (self._low_feerate, "set_value")
             hard_min_feerate, hard_min_feerate_src = (None, None)
@@ -184,13 +186,25 @@ class FeeValidator:
             err_msg: str = (
                 f"Fee rate too low, {feerate} < {min_feerate}, {min_feerate_src}"
             )
-            self._log.error(err_msg)
-            raise ValueError(err_msg)
+            if force_bypass:
+                self._log.warning(f"Forced bypass: {err_msg}")
+            else:
+                self._log.error(err_msg)
+                raise ValueError(err_msg)
 
         if feerate > max_feerate:
+            err_msg: str = (
+                f"Fee rate too high, {feerate} > {max_feerate}, {max_feerate_src}"
+            )
+            if force_bypass:
+                self._log.warning(f"Forced bypass: {err_msg}")
+                return
             # If validating for an offer, allow high fees if estimate source is relayfee
             # Fee will be validated again on sending bid
-            if concept_type == Concepts.OFFER and self._allow_highfee_offers_when_minfee:
+            if (
+                concept_type == Concepts.OFFER
+                and self._allow_highfee_offers_when_minfee
+            ):
                 if max_feerate_src in ("relayfee", "min_relay_fee"):
                     self._log.debug(
                         "Allowing offer through as max feerate source is minfee"

--- a/basicswap/interface/xmr.py
+++ b/basicswap/interface/xmr.py
@@ -875,5 +875,5 @@ class XMRInterface(CoinInterface):
             self._log.error(f"listWalletTransactions failed: {e}")
             return []
 
-    def validateFeeRate(self, fee_rate: int) -> None:
+    def validateFeeRate(self, fee_rate: int, concept_type: int) -> None:
         pass  # Fee rate isn't used

--- a/basicswap/interface/xmr.py
+++ b/basicswap/interface/xmr.py
@@ -875,5 +875,7 @@ class XMRInterface(CoinInterface):
             self._log.error(f"listWalletTransactions failed: {e}")
             return []
 
-    def validateFeeRate(self, fee_rate: int, concept_type: int) -> None:
+    def validateFeeRate(
+        self, fee_rate: int, concept_type: int, force_bypass: bool = False
+    ) -> None:
         pass  # Fee rate isn't used

--- a/basicswap/templates/offer.html
+++ b/basicswap/templates/offer.html
@@ -548,6 +548,14 @@
          <input type="number" class="bg-gray-50 text-gray-900 appearance-none pr-10 dark:bg-gray-500 dark:text-white border border-gray-300 dark:border-gray-400 dark:text-gray-50 dark:placeholder-gray-50 text-sm rounded-lg outline-none focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5 focus:ring-0" name="validmins" min="10" max="1440" value="{{ data.nb_validmins }}">
         </td>
        </tr>
+       {% if data.xmr_type == true %}
+       <tr class="opacity-100 text-gray-500 dark:text-gray-100 hover:bg-coolGray-200 dark:hover:bg-gray-600">
+        <td class="py-3 px-6 bold">Bypass Fee Checks</td>
+        <td class="py-3 px-6">
+          <input type="checkbox" name="bypass_fee_checks" id="bypass_fee_checks" value="bypass_fee_checks"/>
+        </td>
+       </tr>
+       {% endif %}
        {% if data.debug_ui == true %}
        <tr class="opacity-100 text-gray-500 dark:text-gray-100 hover:bg-coolGray-200 dark:hover:bg-gray-600">
         <td class="py-3 px-6 bold">Debug Option:</td>

--- a/basicswap/ui/page_offers.py
+++ b/basicswap/ui/page_offers.py
@@ -679,6 +679,8 @@ def page_offer(self, url_split: List[str], post_string: str) -> bytes:
                     extra_options["prefunded_tx"] = bytes.fromhex(
                         get_data_entry(form_data, "prefunded_bid_tx")
                     )
+                if have_data_entry(form_data, "bypass_fee_checks"):
+                    extra_options["bypass_fee_validation"] = True
 
                 sent_bid_id = swap_client.postBid(
                     offer_id,

--- a/tests/basicswap/util.py
+++ b/tests/basicswap/util.py
@@ -10,6 +10,7 @@ import logging
 import os
 import urllib
 from urllib.request import urlopen
+from basicswap.util import toBool as make_boolean  # noqa: F401
 
 PORT_OFS = int(os.getenv("PORT_OFS", 1))
 UI_PORT = 12700 + PORT_OFS
@@ -20,14 +21,6 @@ REQUIRED_SETTINGS = {
     "use_segwit": True,
     "connection_type": "rpc",
 }
-
-
-def make_boolean(s) -> bool:
-    if isinstance(s, bool):
-        return s
-    if isinstance(s, int):
-        return False if s == 0 else True
-    return s.lower() in ["1", "true"]
 
 
 def post_json_req(url, json_data):


### PR DESCRIPTION
- If the low feerate value is not a hard limit (estimatesmartfee) allow 20% under.
- If the high feerate value is relayfee allow offers through.
  - Feerate will be validated again when trying to send a bid (hopefully estimatesmartfee is active by then)
- Add skip fee checks checkbox when placing bids.