### PR TITLE
dash: bump to 23.1.4 [mandatory]

### DIFF
--- a/basicswap/bin/prepare.py
+++ b/basicswap/bin/prepare.py
@@ -83,7 +83,7 @@ WOW_SITE_COMMIT = (
 PIVX_VERSION = os.getenv("PIVX_VERSION", "5.6.1")
 PIVX_VERSION_TAG = os.getenv("PIVX_VERSION_TAG", "")
 
-DASH_VERSION = os.getenv("DASH_VERSION", "23.1.2")
+DASH_VERSION = os.getenv("DASH_VERSION", "23.1.4")
 DASH_VERSION_TAG = os.getenv("DASH_VERSION_TAG", "")
 
 FIRO_VERSION = os.getenv("FIRO_VERSION", "0.14.16.1")


### PR DESCRIPTION
from [release notes](https://github.com/dashpay/dash/releases/tag/v23.1.4):

> This version does not include breaking changes. This release is mandatory for all nodes as it fixes an important DoS vulnerability.

note: PastaPastaPasta's attestation not yet available:
https://github.com/dashpay/guix.sigs/tree/master/23.1.4


