### PR TITLE
amm: add contract lock time to gui and script

### DIFF
--- a/basicswap/static/js/pages/amm-tables.js
+++ b/basicswap/static/js/pages/amm-tables.js
@@ -1269,6 +1269,7 @@ const AmmTablesManager = (function() {
             document.getElementById('add-offer-address').value = 'auto';
             document.getElementById('add-offer-min-swap-amount').value = '0.001';
             document.getElementById('add-offer-amount-step').value = '0.001';
+            document.getElementById('add-offer-lock-hours').value = '24';
 
             const coinFrom = document.getElementById('add-amm-coin-from');
             const coinTo = document.getElementById('add-amm-coin-to');
@@ -1392,6 +1393,7 @@ const AmmTablesManager = (function() {
                 newItem.ratetweakpercent = parseFloat(document.getElementById('add-offer-ratetweakpercent').value || '0');
                 newItem.adjust_rates_based_on_market = document.getElementById('add-offer-adjust-rates').value;
                 newItem.swap_type = document.getElementById('add-offer-swap-type').value || 'adaptor_sig';
+                newItem.lock_hours = parseInt(document.getElementById('add-offer-lock-hours').value) || 24;
                 const automationStrategyElement = document.getElementById('add-offer-automation-strategy');
                 newItem.automation_strategy = automationStrategyElement ? automationStrategyElement.value : 'accept_all';
 
@@ -1712,6 +1714,7 @@ const AmmTablesManager = (function() {
                 editSwapTypeEl.dispatchEvent(new Event('change'));
                 document.getElementById('edit-offer-min-swap-amount').value = item.min_swap_amount || '0.001';
                 document.getElementById('edit-offer-amount-step').value = item.amount_step || '0.001';
+                document.getElementById('edit-offer-lock-hours').value = item.lock_hours || '24';
                 const editAutomationStrategyElement = document.getElementById('edit-offer-automation-strategy');
                 if (editAutomationStrategyElement) {
                     editAutomationStrategyElement.value = item.automation_strategy || 'accept_all';
@@ -1863,6 +1866,7 @@ const AmmTablesManager = (function() {
                 updatedItem.ratetweakpercent = parseFloat(document.getElementById('edit-offer-ratetweakpercent').value || '0');
                 updatedItem.adjust_rates_based_on_market = document.getElementById('edit-offer-adjust-rates').value;
                 updatedItem.swap_type = document.getElementById('edit-offer-swap-type').value || 'adaptor_sig';
+                updatedItem.lock_hours = parseInt(document.getElementById('edit-offer-lock-hours').value) || 24;
                 const editAutomationStrategyElement = document.getElementById('edit-offer-automation-strategy');
                 updatedItem.automation_strategy = editAutomationStrategyElement ? editAutomationStrategyElement.value : 'accept_all';
 

--- a/basicswap/templates/amm.html
+++ b/basicswap/templates/amm.html
@@ -892,12 +892,28 @@
                     </div>
 
                     <div>
-                      <label for="add-offer-min-swap-amount" class="block text-sm font-medium text-gray-700 dark:text-gray-300">Min Swap Amount</label>
-                      <input type="text" id="add-offer-min-swap-amount" pattern="[0-9]*\.?[0-9]*" class="bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500" value="0.001" placeholder="0.001">
+                      <label for="add-offer-lock-hours" class="block text-sm font-medium text-gray-700 dark:text-gray-300">Contract Lock Period</label>
+                      <div class="relative">
+                        <svg class="absolute top-1/2 right-3 transform -translate-y-1/2 w-4 h-4 text-gray-400 pointer-events-none" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+                        </svg>
+                        <select id="add-offer-lock-hours" class="bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500 appearance-none">
+                          <option value="2">2 hours</option>
+                          <option value="4">4 hours</option>
+                          <option value="8">8 hours</option>
+                          <option value="12">12 hours</option>
+                          <option value="24" selected>24 hours (default)</option>
+                        </select>
+                      </div>
                     </div>
                   </div>
 
                   <div class="grid grid-cols-2 gap-4">
+                    <div>
+                      <label for="add-offer-min-swap-amount" class="block text-sm font-medium text-gray-700 dark:text-gray-300">Min Swap Amount</label>
+                      <input type="text" id="add-offer-min-swap-amount" pattern="[0-9]*\.?[0-9]*" class="bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500" value="0.001" placeholder="0.001">
+                    </div>
+
                     <div>
                       <label for="add-offer-amount-step" class="block text-sm font-medium text-gray-700 dark:text-gray-300">Offer Size Increment <span class="text-red-500">*</span></label>
                       <input type="text" id="add-offer-amount-step" pattern="[0-9]*\.?[0-9]*" class="bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500" placeholder="e.g., 5.0" required>
@@ -905,8 +921,10 @@
                         How much to adjust offer size when partially filled. Must be between 0.001 and your offer amount.
                       </small>
                     </div>
+                  </div>
 
-                    {% if debug_ui_mode %}
+                  {% if debug_ui_mode %}
+                  <div class="grid grid-cols-2 gap-4">
                     <div>
                       <label for="add-offer-automation-strategy" class="block text-sm font-medium text-gray-700 dark:text-gray-300">Auto Accept Bids</label>
                       <div class="relative">
@@ -920,8 +938,8 @@
                         </select>
                       </div>
                     </div>
-                    {% endif %}
                   </div>
+                  {% endif %}
 
                   <div>
                     <label for="add-offer-adjust-rates" class="block text-sm font-medium text-gray-700 dark:text-gray-300">Adjust Rates Based on Market</label>
@@ -1178,12 +1196,28 @@
                     </div>
 
                     <div>
-                      <label for="edit-offer-min-swap-amount" class="block text-sm font-medium text-gray-700 dark:text-gray-300">Minimum Swap Amount</label>
-                      <input type="text" id="edit-offer-min-swap-amount" pattern="[0-9]*\.?[0-9]*" class="bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500" placeholder="0.001">
+                      <label for="edit-offer-lock-hours" class="block text-sm font-medium text-gray-700 dark:text-gray-300">Contract Lock Period</label>
+                      <div class="relative">
+                        <svg class="absolute top-1/2 right-3 transform -translate-y-1/2 w-4 h-4 text-gray-400 pointer-events-none" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+                        </svg>
+                        <select id="edit-offer-lock-hours" class="bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500 appearance-none">
+                          <option value="2">2 hours</option>
+                          <option value="4">4 hours</option>
+                          <option value="8">8 hours</option>
+                          <option value="12">12 hours</option>
+                          <option value="24">24 hours (default)</option>
+                        </select>
+                      </div>
                     </div>
                   </div>
 
                   <div class="grid grid-cols-2 gap-4">
+                    <div>
+                      <label for="edit-offer-min-swap-amount" class="block text-sm font-medium text-gray-700 dark:text-gray-300">Minimum Swap Amount</label>
+                      <input type="text" id="edit-offer-min-swap-amount" pattern="[0-9]*\.?[0-9]*" class="bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500" placeholder="0.001">
+                    </div>
+
                     <div>
                       <label for="edit-offer-amount-step" class="block text-sm font-medium text-gray-700 dark:text-gray-300">Offer Size Increment <span class="text-red-500">*</span></label>
                       <input type="text" id="edit-offer-amount-step" pattern="[0-9]*\.?[0-9]*" class="bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500" placeholder="e.g., 5.0" required>
@@ -1191,8 +1225,10 @@
                         How much to adjust offer size when partially filled. Must be between 0.001 and your offer amount.
                       </small>
                     </div>
+                  </div>
 
-                    {% if debug_ui_mode %}
+                  {% if debug_ui_mode %}
+                  <div class="grid grid-cols-2 gap-4">
                     <div>
                       <label for="edit-offer-automation-strategy" class="block text-sm font-medium text-gray-700 dark:text-gray-300">Auto Accept Bids</label>
                       <div class="relative">
@@ -1206,8 +1242,8 @@
                         </select>
                       </div>
                     </div>
-                    {% endif %}
                   </div>
+                  {% endif %}
 
                   <div>
                     <label for="edit-offer-adjust-rates" class="block text-sm font-medium text-gray-700 dark:text-gray-300">Adjust Rates Based on Market</label>

--- a/scripts/createoffers.py
+++ b/scripts/createoffers.py
@@ -41,6 +41,7 @@ Create offers
             # Optional
             "enabled": Set to false to ignore offer template.
             "swap_type": Type of swap, defaults to "adaptor_sig"
+            "lock_hours": Contract lock period in hours. One of 4, 8, 12 or 24 (default: 24).
             "min_swap_amount": Sets "amt_bid_min" on the offer, minimum purchase quantity when offer amount is variable.
         },
         ...
@@ -94,6 +95,10 @@ read_json_api_wallet = None
 
 DEFAULT_CONFIG_FILE: str = "createoffers.json"
 DEFAULT_STATE_FILE: str = "createoffers_state.json"
+
+# Contract lock period options offered in the AMM GUI, in hours.
+VALID_LOCK_HOURS: tuple = (4, 8, 12, 24)
+DEFAULT_LOCK_HOURS: int = 24
 
 
 def post_req(url: str, json_data=None, auth_header_val=None):
@@ -358,6 +363,16 @@ def readConfig(args, known_coins):
         if "amount_variable" not in offer_template:
             print("Setting amount_variable to True for offer", offer_template["name"])
             offer_template["amount_variable"] = True
+            num_changes += 1
+        if (
+            "lock_hours" not in offer_template
+            or int(offer_template["lock_hours"]) not in VALID_LOCK_HOURS
+        ):
+            print(
+                f"Setting lock_hours to {DEFAULT_LOCK_HOURS} for offer",
+                offer_template["name"],
+            )
+            offer_template["lock_hours"] = DEFAULT_LOCK_HOURS
             num_changes += 1
 
         if offer_template.get("enabled", True) is False:
@@ -1233,7 +1248,7 @@ def process_offers(args, config, script_state) -> None:
             ),
             "rate": use_rate,
             "swap_type": offer_template.get("swap_type", "adaptor_sig"),
-            "lockhrs": "24",
+            "lockhrs": offer_template.get("lock_hours", DEFAULT_LOCK_HOURS),
             "automation_strat_id": automation_strat_id,
         }
 


### PR DESCRIPTION
Adds the ability to set the contract lock time to the  AMM gui

tested working on ADS swaps.
not sure if this also works for HTLC?

the larger changes in the amm.html template are due to reordering the fields so that swap type is next to lock time, and getting rid of a blank space.

I initially had 2hrs as an option, but removed it. Options now are 4, 8, 12, and 24 hours, defaulting to 24.