### PR TITLE
startup: skip checkAndNotifyBalanceChange while system is locked

### DIFF
--- a/basicswap/basicswap.py
+++ b/basicswap/basicswap.py
@@ -191,6 +191,9 @@ def checkAndNotifyBalanceChange(
     if not swap_client.ws_server:
         return
 
+    if swap_client._is_locked is True:
+        return
+
     try:
         blockchain_info = ci.getBlockchainInfo()
         verification_progress = blockchain_info.get("verificationprogress", 1.0)


### PR DESCRIPTION
fixes issue: When wallets are locked, balances are still attempted to be checked.
```
2026-06-29 11:36:00 DEBUG : New block header notification: height=955928
2026-06-29 11:36:00 DEBUG : Header subscription updated height to 955928
2026-06-29 11:36:00 DEBUG : New XMR block at height: 3706634
2026-06-29 11:36:05 DEBUG : checkAndNotifyBalanceChange XMR: balance check failed: Wallet RPC error {'code': -1, 'message': 'Failed to open wallet : Invalid password.'}
2026-06-29 11:36:05 INFO : BasicSwap is up to date (v0.16.6)
2026-06-29 11:36:10 DEBUG : New WOW block at height: 851923
2026-06-29 11:36:10 DEBUG : New BTC electrum block at height: 955928
2026-06-29 11:36:10 DEBUG : BTC balance cache updated silently (trigger: electrum_poll)
2026-06-29 11:36:18 DEBUG : checkAndNotifyBalanceChange WOW: balance check failed: Wallet RPC error {'code': -1, 'message': 'Failed to open wallet : Invalid password.'}
2026-06-29 11:36:23 DEBUG : New PART block at height: 2191726
2026-06-29 11:36:23 INFO : unlockWallet - PART
2026-06-29 11:36:23 DEBUG : PART balance cache updated silently (trigger: block)
2026-06-29 11:36:23 INFO : unlockWallet - BTC
2026-06-29 11:36:23 INFO : unlockWallet - LTC
```
