### PR TITLE
startup: require all wallets to unlock before unlocking the system

### DIFF
--- a/basicswap/basicswap.py
+++ b/basicswap/basicswap.py
@@ -1834,10 +1834,10 @@ class BasicSwap(BaseApp, BSXNetwork, UIApp):
                     self.ci(c).unlockWallet(password)
                 except Exception as e:  # noqa: F841
                     self.log.warning(f"Failed to unlock wallet {getCoinName(c)}")
-                    if coin is not None or c == Coins.PART:
-                        raise
-                if c == Coins.PART:
-                    self._is_locked = False
+                    raise
+
+            if coin is None or coin == Coins.PART:
+                self._is_locked = False
 
             self.loadFromDB()
 


### PR DESCRIPTION
fixes issue: the system unlocks with only part being unlocked. If a subsequent unlock fails, the system loads in a half-broken state (system unlocked, some wallets still locked, cannot unlock still-locked wallets)

```
2026-06-25 06:30:03 DEBUG : checkAndNotifyBalanceChange LTC: getBlockchainInfo failed: RPC server error: timed out, method: getblockchaininfo
2026-06-25 06:30:07 DEBUG : Refreshing Monero wallet
2026-06-25 06:30:10 INFO : Expired 2 / 327 messages.
2026-06-25 06:30:10 DEBUG : Log file bytes: 100884169.
2026-06-25 06:30:11 DEBUG : Expired 0 bids and 1 offer
2026-06-25 06:30:13 DEBUG : Refreshing Monero wallet
2026-06-25 06:30:13 DEBUG : XMR balance cache updated silently (trigger: block)
2026-06-25 06:30:17 DEBUG : Refreshing Wownero wallet
2026-06-25 06:30:17 DEBUG : WOW balance cache updated silently (trigger: block)
2026-06-25 06:30:33 DEBUG : New LTC block at height: 3130950
2026-06-25 06:30:50 WARNING : Failed to unlock wallet Litecoin MWEB
2026-06-25 06:30:50 INFO : Loading data from db
2026-06-25 06:31:10 INFO : Expired 1 / 326 messages.
```
only mark the sys as unlocked once all coins have been unlocked.