### PR TITLE
startup: don't treat RPC timeout as missing seed during unlock

### DIFF
--- a/basicswap/interface/btc.py
+++ b/basicswap/interface/btc.py
@@ -4391,16 +4391,33 @@ class BTCInterface(FeeValidator, Secp256k1Interface):
                     else:
                         raise
 
-            try:
-                seed_id = self.getWalletSeedID()
-                needs_seed_init = seed_id == "Not found"
-            except Exception as e:
-                self._log.debug(f"getWalletSeedID failed: {e}")
-                needs_seed_init = True
+            seed_id = None
+            last_seed_err = None
+            max_attempts = 5
+            for _attempt in range(max_attempts):
+                try:
+                    seed_id = self.getWalletSeedID()
+                    last_seed_err = None
+                    break
+                except Exception as e:
+                    last_seed_err = e
+                    self._log.debug(
+                        f"getWalletSeedID failed (attempt {_attempt + 1}/{max_attempts}): {e}"
+                    )
+                    if _attempt < max_attempts - 1:
+                        time.sleep(2**_attempt)  # exponential backoff
+            if last_seed_err is not None:
+                raise last_seed_err
+            needs_seed_init = seed_id == "Not found"
             if needs_seed_init:
                 self._log.info(f"Initializing HD seed for {self.coin_name()}.")
+                if password and self.isWalletEncrypted():
+                    # sethdseed requires the passphrase to be entered first
+                    self.rpc_wallet(
+                        "walletpassphrase", [password, 100000000], timeout=120
+                    )
                 self._sc.initialiseWallet(self.coin_type())
-                if password:
+                if password and not self.isWalletEncrypted():
                     self._log.info(f"Encrypting {self.coin_name()} wallet.")
                     try:
                         self.rpc_wallet("encryptwallet", [password], timeout=120)


### PR DESCRIPTION
fixes issue: sethdseed and encryptwallet is run on a preexisting wallet after a timeout during unlock process

```
2026-06-25 06:28:00 INFO : unlockWallet - LTC
2026-06-25 06:28:20 DEBUG : getWalletSeedID failed: RPC server error: timed out, method: getwalletinfo
2026-06-25 06:28:20 INFO : Initializing HD seed for Litecoin.
2026-06-25 06:28:20 INFO : Initialising Litecoin wallet.
2026-06-25 06:28:22 INFO : Expired 463 / 773 messages.
2026-06-25 06:28:22 DEBUG : New LTC block at height: 3130914
2026-06-25 06:28:22 DEBUG : sethdseed failed: RPC error {'code': -13, 'message': 'Error: Please enter the wallet passphrase with walletpassphrase first.'}
2026-06-25 06:28:22 ERROR : initialiseWallet failed: RPC error {'code': -13, 'message': 'Error: Please enter the wallet passphrase with walletpassphrase first.'}
2026-06-25 06:28:24 ERROR : Traceback (most recent call last):
  File "/home/nahuhh/coinswaps/venv/lib/python3.14/site-packages/basicswap/http_server.py", line 946, in handle_http
    return page_offers(self, url_split, post_string)
  File "/home/nahuhh/coinswaps/venv/lib/python3.14/site-packages/basicswap/ui/page_offers.py", line 923, in page_offers
    swap_client.checkSystemStatus()
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^
  File "/home/nahuhh/coinswaps/venv/lib/python3.14/site-packages/basicswap/basicswap.py", line 1702, in checkSystemStatus
    raise LockedCoinError(Coins.PART)
basicswap.util.LockedCoinError: must be unlocked: 1

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/nahuhh/coinswaps/venv/lib/python3.14/site-packages/basicswap/basicswap.py", line 3256, in initialiseWallet
    ci.initialiseWallet(root_key, restore_time)
    ~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/nahuhh/coinswaps/venv/lib/python3.14/site-packages/basicswap/interface/btc.py", line 710, in initialiseWallet
    self.rpc_wallet("sethdseed", [True, key_wif])
    ~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/nahuhh/coinswaps/venv/lib/python3.14/site-packages/basicswap/rpc.py", line 269, in rpc_func
    return callrpc(
        port,
    ...<5 lines>...
        timeout=timeout,
    )
  File "/home/nahuhh/coinswaps/venv/lib/python3.14/site-packages/basicswap/rpc.py", line 159, in callrpc
    return callrpc_pooled(rpc_port, auth, method, params, wallet, host, timeout)
  File "/home/nahuhh/coinswaps/venv/lib/python3.14/site-packages/basicswap/rpc.py", line 218, in callrpc_pooled
    raise ValueError("RPC error " + str(r["error"]))
ValueError: RPC error {'code': -13, 'message': 'Error: Please enter the wallet passphrase with walletpassphrase first.'}

2026-06-25 06:28:24 INFO : Encrypting Litecoin wallet.
2026-06-25 06:28:28 DEBUG : encryptwallet returned: RPC error {'code': -15, 'message': 'Error: running with an encrypted wallet, but encryptwallet was called.'}
```