### PR TITLE
interface/bch: use lock_time_1 for the lock-refund-tx input nSequence

### DIFF
--- a/basicswap/interface/bch/bch.py
+++ b/basicswap/interface/bch/bch.py
@@ -547,7 +547,11 @@ class BCHInterface(BTCInterface):
         tx.vin.append(
             CTxIn(
                 COutPoint(tx_lock_id_int, locked_n),
-                nSequence=kwargs["timelock"] if "timelock" in kwargs else lock1_value,
+                # Refund input spends the lock tx's refund branch (CSV = lock_time_1), and
+                # verifySCLockRefundTx checks nSequence == lock_time_1 (prevout_seq). The old
+                # kwargs["timelock"] (= lock_time_2) only matched when the two timelocks were
+                # equal; lock_time_2 is carried separately on the refund output. Match btc.py.
+                nSequence=lock1_value,
                 scriptSig=self.getScriptScriptSig(script_lock, None),
             )
         )

--- a/tests/basicswap/test_bch_xmr.py
+++ b/tests/basicswap/test_bch_xmr.py
@@ -20,6 +20,7 @@ from basicswap.basicswap import (
 from basicswap.bin.run import startDaemon
 from basicswap.util.crypto import sha256
 from tests.basicswap.test_btc_xmr import BasicSwapTest
+from tests.basicswap.extended.test_dcr import run_test_ads_both_refund
 from tests.basicswap.common import (
     callrpc_cli,
     make_rpc_func,
@@ -993,3 +994,11 @@ class TestBCH(BasicSwapTest):
     def test_08_insufficient_funds_rev(self):
         self.prepare_balance(Coins.BCH, 100.0, 1801, 1800)
         super().test_08_insufficient_funds_rev()
+
+    def test_14_ads_bch_xmr_both_refund(self):
+        # Regression for the createSCLockRefundTx refund-input nSequence bug: the builder
+        # set nSequence to kwargs["timelock"] (= lock_time_2) while verifySCLockRefundTx
+        # requires lock_time_1 (prevout_seq); the two match only when the timelocks are equal
+        # (the default). run_test_ads_both_refund sets OFFER_LOCK_2_VALUE_INC so they differ,
+        # making acceptBid -> verifySCLockRefundTx raise "Bad input nSequence" without the fix.
+        run_test_ads_both_refund(self, Coins.BCH, Coins.XMR, lock_value=20)


### PR DESCRIPTION
`createSCLockRefundTx` set the refund input's `nSequence` to `kwargs["timelock"]`
(= `lock_time_2`), but that input spends the lock tx's refund branch whose CSV is
`lock_time_1`, and `verifySCLockRefundTx` requires `nSequence == lock_time_1`
(`prevout_seq`). The values agree only when the two swap timelocks are equal - the
default - so the mismatch was masked; the upstream BCH<>XMR suite never exercises
non-equal timelocks (only `test_dcr.py` sets `OFFER_LOCK_2_VALUE_INC`). With
non-equal timelocks the offerer rejects the bidder's lock-refund tx at `acceptBid`
("Bad input nSequence"), breaking the refund path.

Fix: use `lock1_value`, matching `btc.py`'s `createSCLockRefundTx`. `lock_time_2` is
carried separately on the refund output (unchanged); the happy path is unaffected
(the emitted value is identical when the timelocks are equal).

Adds `tests/basicswap/test_bch_xmr.py::TestBCH::test_14_ads_bch_xmr_both_refund`,
which forces non-equal timelocks via `OFFER_LOCK_2_VALUE_INC` (the same debug flag
`test_dcr.py` already uses); it fails on the old code at `acceptBid` and passes with
the fix.

Honest scope: a latent builder/verifier inconsistency in the refund path,
reproducible from the project's own debug flag - not a live loss-of-funds bug, since
the two timelocks are equal by default and real swaps today are unaffected.
