### PR TITLE
amm: dont autostart amm while the system is locked

### DIFF
--- a/basicswap/basicswap.py
+++ b/basicswap/basicswap.py
@@ -498,6 +498,7 @@ class BasicSwap(BaseApp, BSXNetwork, UIApp):
         self._notifications_cache = {}
         self._is_encrypted = None
         self._is_locked = None
+        self._amm_autostart_pending = False
         self._tx_cache = {}
         self._price_cache = {}
         self._volume_cache = {}
@@ -1460,53 +1461,15 @@ class BasicSwap(BaseApp, BSXNetwork, UIApp):
         autostart_setting = self.settings.get("amm_autostart", False)
         self.log.info(f"Checking AMM autostart setting: {autostart_setting}")
 
-        if autostart_setting:
-            self.log.info("AMM autostart is enabled, starting AMM process...")
-            try:
-                from basicswap.ui.page_amm import (
-                    start_amm_process,
-                    start_amm_process_force,
-                    check_existing_amm_processes,
-                )
-
-                self.log.info("Waiting 2 seconds for BasicSwap to fully initialize...")
-                time.sleep(2)
-
-                amm_host = self.settings.get("htmlhost", "127.0.0.1")
-                amm_port = self.settings.get("htmlport", 12700)
-                amm_debug = False
-
-                self.log.info(
-                    f"Starting AMM with host={amm_host}, port={amm_port}, debug={amm_debug}"
-                )
-
-                existing_pids = check_existing_amm_processes()
-                if existing_pids:
-                    self.log.warning(
-                        f"Found existing AMM processes: {existing_pids}. Using force start to clean up..."
-                    )
-                    success, msg = start_amm_process_force(
-                        self, amm_host, amm_port, debug=amm_debug
-                    )
-                    if success:
-                        self.log.info(f"AMM autostart force successful: {msg}")
-                    else:
-                        self.log.warning(f"AMM autostart force failed: {msg}")
-                else:
-                    success, msg = start_amm_process(
-                        self, amm_host, amm_port, debug=amm_debug
-                    )
-                    if success:
-                        self.log.info(f"AMM autostart successful: {msg}")
-                    else:
-                        self.log.warning(f"AMM autostart failed: {msg}")
-            except Exception as e:
-                self.log.error(f"AMM autostart error: {str(e)}")
-                import traceback
-
-                self.log.error(traceback.format_exc())
-        else:
+        if not autostart_setting:
             self.log.info("AMM autostart is disabled")
+        elif not self.isSystemUnlocked():
+            self.log.info(
+                "AMM autostart is enabled but the system is locked, deferring AMM start until unlock"
+            )
+            self._amm_autostart_pending = True
+        else:
+            self._autostartAMM()
 
         if self.settings.get("fetchpricesthread", True):
             self._price_fetch_running = True
@@ -1693,6 +1656,53 @@ class BasicSwap(BaseApp, BSXNetwork, UIApp):
                     )
                 )
 
+    def _autostartAMM(self) -> None:
+        self.log.info("AMM autostart is enabled, starting AMM process...")
+        self._amm_autostart_pending = False
+        try:
+            from basicswap.ui.page_amm import (
+                start_amm_process,
+                start_amm_process_force,
+                check_existing_amm_processes,
+            )
+
+            self.log.info("Waiting 2 seconds for BasicSwap to fully initialize...")
+            time.sleep(2)
+
+            amm_host = self.settings.get("htmlhost", "127.0.0.1")
+            amm_port = self.settings.get("htmlport", 12700)
+            amm_debug = False
+
+            self.log.info(
+                f"Starting AMM with host={amm_host}, port={amm_port}, debug={amm_debug}"
+            )
+
+            existing_pids = check_existing_amm_processes()
+            if existing_pids:
+                self.log.warning(
+                    f"Found existing AMM processes: {existing_pids}. Using force start to clean up..."
+                )
+                success, msg = start_amm_process_force(
+                    self, amm_host, amm_port, debug=amm_debug
+                )
+                if success:
+                    self.log.info(f"AMM autostart force successful: {msg}")
+                else:
+                    self.log.warning(f"AMM autostart force failed: {msg}")
+            else:
+                success, msg = start_amm_process(
+                    self, amm_host, amm_port, debug=amm_debug
+                )
+                if success:
+                    self.log.info(f"AMM autostart successful: {msg}")
+                else:
+                    self.log.warning(f"AMM autostart failed: {msg}")
+        except Exception as e:
+            self.log.error(f"AMM autostart error: {str(e)}")
+            import traceback
+
+            self.log.error(traceback.format_exc())
+
     def isSystemUnlocked(self) -> bool:
         # TODO - Check all active coins
         ci = self.ci(Coins.PART)
@@ -1862,6 +1872,9 @@ class BasicSwap(BaseApp, BSXNetwork, UIApp):
 
         finally:
             self._read_zmq_queue = True
+
+        if self._amm_autostart_pending and coin is None:
+            self._autostartAMM()
 
     def _initializeElectrumWallets(self) -> None:
         try:


### PR DESCRIPTION
fixes issue: amm autostarts before systems unlocked, which sends repeated rejected queries. Spams the log as below. Instead, we defer the amm autostart until after the system is unlocked

```
2026-07-02 19:49:01 INFO : AMM autostart successful: AMM process started with PID 68207                                                                                                 
2026-07-02 19:49:01 INFO : Background price fetching started                                                                                                                            
2026-07-02 19:49:01 INFO : Starting HTTP server at http://127.0.0.1:12705                                                                                                               
2026-07-02 19:49:02 INFO : HTTP server initialized with threading support                                                                                                               
2026-07-02 19:49:02 INFO : Starting WebSocket server at ws://127.0.0.1:11705  
2026-07-02 19:49:02 INFO : Exit with Ctrl + c.                                
2026-07-02 19:49:02 INFO : AMM: API connection successful.                  
2026-07-02 19:49:02 WARNING : Wallet locked: Particl wallet must be unlocked                                                                                                            
2026-07-02 19:49:02 WARNING : Wallet locked: Particl wallet must be unlocked                                                                                                            
2026-07-02 19:49:02 WARNING : Wallet locked: Particl wallet must be unlocked
2026-07-02 19:49:02 WARNING : Wallet locked: Particl wallet must be unlocked
2026-07-02 19:49:02 WARNING : Wallet locked: Particl wallet must be unlocked
2026-07-02 19:49:02 WARNING : Wallet locked: Particl wallet must be unlocked  
```