### PR TITLE
startup: extend getnetworkinfo timeout to avoid slow daemons from stopping bsx

### DIFF
--- a/basicswap/interface/btc.py
+++ b/basicswap/interface/btc.py
@@ -485,7 +485,7 @@ class BTCInterface(FeeValidator, Secp256k1Interface):
                 except Exception:
                     self._core_version = "electrum"
             else:
-                self._core_version = self.rpc("getnetworkinfo")["version"]
+                self._core_version = self.rpc("getnetworkinfo", timeout=30)["version"]
         return self._core_version
 
     def getElectrumServer(self) -> str:


### PR DESCRIPTION
just a bandaid, could use a proper fix

Main coin of issue that i see, is LTC. If the node is not fully synced, it times out here and causes startup to abort