### PR TITLE
xmr: only open_wallet when a wallet change is expected

### DIFF
--- a/basicswap/interface/xmr/xmr.py
+++ b/basicswap/interface/xmr/xmr.py
@@ -120,6 +120,7 @@ class XMRInterface(CoinInterface):
         self._wallet_password = None
         self._have_checked_seed = False
         self._wallet_filename = coin_settings.get("wallet_name", "swap_wallet")
+        self._cached_main_wallet_address = None
 
         daemon_login = None
         if coin_settings.get("rpcuser", "") != "":
@@ -217,6 +218,28 @@ class XMRInterface(CoinInterface):
             raise ValueError("generate_from_keys failed")
 
     def openWallet(self, filename):
+        is_default: bool = filename == self._wallet_filename
+        if is_default and self._cached_main_wallet_address is not None:
+            try:
+                if (
+                    self.rpc_wallet("get_address")["address"]
+                    == self._cached_main_wallet_address
+                ):
+                    return
+            except Exception:
+                pass
+
+        self._openWallet(filename)
+
+        if is_default:
+            try:
+                self._cached_main_wallet_address = self.rpc_wallet("get_address")[
+                    "address"
+                ]
+            except Exception:
+                pass
+
+    def _openWallet(self, filename):
         params = {"filename": filename}
         if self._wallet_password is not None:
             params["password"] = self._wallet_password

--- a/basicswap/interface/xmr/xmr.py
+++ b/basicswap/interface/xmr/xmr.py
@@ -582,6 +582,14 @@ class XMRInterface(CoinInterface):
                 current_height = None  # If the transfer is available it will be deep enough
                 #   and (current_height is None or current_height - transfer['block_height'] > cb_block_confirmed):
             """
+            try:
+                open_wallet_addr = self.rpc_wallet("get_address")["address"]
+            except Exception:
+                open_wallet_addr = "UNKNOWN"
+            if open_wallet_addr != address_b58:
+                raise TemporaryError(
+                    f"findTxB open wallet {open_wallet_addr} does not match swap shared wallet {address_b58}; refusing to check coin B lock amount"
+                )
             params = {"transfer_type": "available"}
             transfers = self.rpc_wallet("incoming_transfers", params)
             rv = None
@@ -694,6 +702,14 @@ class XMRInterface(CoinInterface):
             self.rpc_wallet("refresh")
             self._log.debug(f"Refreshing {self.coin_name()} wallet")
             rv = self.rpc_wallet("get_balance")
+            try:
+                open_wallet_addr = self.rpc_wallet("get_address")["address"]
+            except Exception:
+                open_wallet_addr = "UNKNOWN"
+            if open_wallet_addr != address_b58:
+                raise TemporaryError(
+                    f"spendBLockTx open wallet {open_wallet_addr} does not match swap shared wallet {address_b58}; refusing to spend coin B lock"
+                )
             if rv["balance"] < cb_swap_value:
                 self._log.warning("Balance is too low, checking for existing spend.")
                 txns = self.rpc_wallet("get_transfers", {"out": True})
@@ -857,11 +873,12 @@ class XMRInterface(CoinInterface):
         if old_password != "":
             self._wallet_password = old_password
         try:
-            self.openWallet(self._wallet_filename)
-            self.rpc_wallet(
-                "change_wallet_password",
-                {"old_password": old_password, "new_password": new_password},
-            )
+            with self._mx_wallet:
+                self.openWallet(self._wallet_filename)
+                self.rpc_wallet(
+                    "change_wallet_password",
+                    {"old_password": old_password, "new_password": new_password},
+                )
         except Exception as e:  # noqa: F841
             self._wallet_password = orig_password
             raise
@@ -879,11 +896,12 @@ class XMRInterface(CoinInterface):
 
     def isAddressMine(self, address: str) -> bool:
         try:
-            self.openWallet(self._wallet_filename)
-            self.rpc_wallet(
-                "get_address_index",
-                {"address": address},
-            )
+            with self._mx_wallet:
+                self.openWallet(self._wallet_filename)
+                self.rpc_wallet(
+                    "get_address_index",
+                    {"address": address},
+                )
             return True
         except Exception as e:  # noqa: F841
             pass


### PR DESCRIPTION
2nd commit guards against wrong wallet reads by adding mutex to isAddressMine (and one other place where it was missing) and skipping spends/checks when the incorrect wallet is loaded.

Previously, the wallet was always opened during the tx checks (which acquired lock), but post optimization, the wallet already being opened meant that another process could change the active wallet.