### PR TITLE
AMM: Fixes.

### DIFF
--- a/basicswap/__init__.py
+++ b/basicswap/__init__.py
@@ -2,4 +2,4 @@ name = "basicswap"
 
 __version__ = "0.17.0"
 GUI_VERSION = "4.0.0"
-AMM_VERSION = "0.5.0"
+AMM_VERSION = "0.5.1"

--- a/basicswap/basicswap.py
+++ b/basicswap/basicswap.py
@@ -15354,6 +15354,9 @@ class BasicSwap(BaseApp, BSXNetwork, UIApp):
         if "addressnote" in filters:
             query_str += " AND note LIKE :note "
             query_data["note"] = "%" + filters["addressnote"] + "%"
+        if "search" in filters:
+            query_str += " AND (addr LIKE :search OR note LIKE :search) "
+            query_data["search"] = "%" + filters["search"] + "%"
         if "addr_type" in filters and filters["addr_type"] > -1:
             query_str += " AND use_type = :addr_type "
             query_data["addr_type"] = filters["addr_type"]

--- a/basicswap/js_server.py
+++ b/basicswap/js_server.py
@@ -20,6 +20,7 @@ from .util.network import (
     is_url_scheme_allowed,
 )
 from .basicswap_util import (
+    AddressTypes,
     fiatFromTicker,
     strBidState,
     strTxState,
@@ -917,6 +918,24 @@ def js_smsgaddresses(self, url_split, post_string, is_json) -> bytes:
     filters = {
         "exclude_inactive": post_data.get("exclude_inactive", True),
     }
+    use_type_map = {
+        "offer_send_from": AddressTypes.OFFER,
+        "offer_send_to": AddressTypes.SEND_OFFER,
+        "bid": AddressTypes.BID,
+    }
+    if have_data_entry(post_data, "use_type"):
+        use_type_str = get_data_entry(post_data, "use_type")
+        if use_type_str not in use_type_map:
+            raise ValueError("Unknown address type")
+        filters["addr_type"] = int(use_type_map[use_type_str])
+    if have_data_entry(post_data, "search"):
+        search_str = get_data_entry(post_data, "search").strip()
+        if search_str:
+            filters["search"] = search_str
+    if have_data_entry(post_data, "limit"):
+        limit = int(get_data_entry(post_data, "limit"))
+        ensure(0 < limit <= 200, "Invalid limit")
+        filters["limit"] = limit
     return bytes(json.dumps(swap_client.listAllSMSGAddresses(filters)), "UTF-8")
 
 

--- a/basicswap/static/js/modules/amm-template-validation.js
+++ b/basicswap/static/js/modules/amm-template-validation.js
@@ -50,9 +50,10 @@
             errors.push('Invalid offer mode.');
         }
 
-        if (mode === 'standing') {
-            if (!isPositiveNumber(offer.min_coin_from_amt)) {
-                errors.push('Standing offers require a Minimum Balance greater than 0 to act as a wallet floor.');
+        if (mode === 'standing' && offer.min_coin_from_amt !== undefined && offer.min_coin_from_amt !== null && offer.min_coin_from_amt !== '') {
+            const floor = parseFloat(offer.min_coin_from_amt);
+            if (isNaN(floor) || floor < 0) {
+                errors.push('Minimum Balance must be zero or greater.');
             }
         }
 

--- a/basicswap/static/js/pages/amm-page.js
+++ b/basicswap/static/js/pages/amm-page.js
@@ -295,8 +295,12 @@
       const enabledOffers = offers.filter(o => o.enabled);
 
       for (const offer of enabledOffers) {
-        if (!offer.min_coin_from_amt || parseFloat(offer.min_coin_from_amt) <= 0) {
-          return { success: false, error: `Offer "${offer.name}" needs a minimum coin amount to protect your wallet balance.` };
+        const mode = offer.offer_mode || 'standing';
+        if (mode !== 'standing') continue;
+        if (offer.min_coin_from_amt === undefined || offer.min_coin_from_amt === null || offer.min_coin_from_amt === '') continue;
+        const floor = parseFloat(offer.min_coin_from_amt);
+        if (isNaN(floor) || floor < 0) {
+          return { success: false, error: `Offer "${offer.name}" has an invalid minimum balance.` };
         }
       }
 

--- a/basicswap/static/js/pages/amm-tables.js
+++ b/basicswap/static/js/pages/amm-tables.js
@@ -786,6 +786,17 @@ const AmmTablesManager = (function() {
         });
     }
 
+    function setConfigTextarea(configTextarea, text) {
+        const wasReadonly = configTextarea.hasAttribute('readonly');
+        if (wasReadonly) {
+            configTextarea.removeAttribute('readonly');
+        }
+        configTextarea.value = text;
+        if (wasReadonly) {
+            configTextarea.setAttribute('readonly', '');
+        }
+    }
+
     function refreshAfterSave() {
         if (window.AmmCounterManager && window.AmmCounterManager.fetchAmmStatus) {
             window.AmmCounterManager.fetchAmmStatus();
@@ -1860,6 +1871,16 @@ const AmmTablesManager = (function() {
                 }
             }
 
+            const existingList = type === 'offer' ? config.offers : config.bids;
+            if (Array.isArray(existingList) && existingList.some(item => item && item.name === name)) {
+                if (window.showErrorModal) {
+                    window.showErrorModal('Validation Error', `A ${type} template named "${name}" already exists.`);
+                } else {
+                    alert(`A ${type} template named "${name}" already exists.`);
+                }
+                return;
+            }
+
             if (type === 'offer') {
                 if (!Array.isArray(config.offers)) {
                     config.offers = [];
@@ -1879,16 +1900,8 @@ const AmmTablesManager = (function() {
                 return;
             }
 
-            const wasReadonly = configTextarea.hasAttribute('readonly');
-            if (wasReadonly) {
-                configTextarea.removeAttribute('readonly');
-            }
-
-            configTextarea.value = JSON.stringify(config, null, 4);
-
-            if (wasReadonly) {
-                configTextarea.setAttribute('readonly', '');
-            }
+            const previousConfigText = configTextarea.value;
+            setConfigTextarea(configTextarea, JSON.stringify(config, null, 4));
 
             persistConfig(config).then(function(data) {
                 if (data && data.success) {
@@ -1900,10 +1913,12 @@ const AmmTablesManager = (function() {
                     refreshAfterSave();
                     notify(`${type.charAt(0).toUpperCase() + type.slice(1)} "${name}" added.`, 'success');
                 } else {
+                    setConfigTextarea(configTextarea, previousConfigText);
                     const errMsg = (data && data.error) || 'Failed to save the configuration.';
                     notify(errMsg, 'error');
                 }
             }).catch(function(error) {
+                setConfigTextarea(configTextarea, previousConfigText);
                 notify(`Failed to save the configuration: ${error.message}`, 'error');
             });
         } catch (error) {
@@ -2191,6 +2206,16 @@ const AmmTablesManager = (function() {
                 );
             }
 
+            const targetList = type === 'offer' ? config.offers : config.bids;
+            if (Array.isArray(targetList) && targetList.some(item => item && item !== originalItem && item.name === name)) {
+                if (window.showErrorModal) {
+                    window.showErrorModal('Validation Error', `A ${type} template named "${name}" already exists.`);
+                } else {
+                    alert(`A ${type} template named "${name}" already exists.`);
+                }
+                return;
+            }
+
             const updatedItem = Object.assign({}, originalItem || {}, {
                 name: name,
                 enabled: document.getElementById('edit-amm-enabled').checked,
@@ -2415,16 +2440,8 @@ const AmmTablesManager = (function() {
                 return;
             }
 
-            const wasReadonly = configTextarea.hasAttribute('readonly');
-            if (wasReadonly) {
-                configTextarea.removeAttribute('readonly');
-            }
-
-            configTextarea.value = JSON.stringify(config, null, 4);
-
-            if (wasReadonly) {
-                configTextarea.setAttribute('readonly', '');
-            }
+            const previousConfigText = configTextarea.value;
+            setConfigTextarea(configTextarea, JSON.stringify(config, null, 4));
 
             persistConfig(config).then(function(data) {
                 if (data && data.success) {
@@ -2436,10 +2453,12 @@ const AmmTablesManager = (function() {
                     refreshAfterSave();
                     notify('Configuration updated.', 'success');
                 } else {
+                    setConfigTextarea(configTextarea, previousConfigText);
                     const errMsg = (data && data.error) || 'Failed to save the configuration.';
                     notify(errMsg, 'error');
                 }
             }).catch(function(error) {
+                setConfigTextarea(configTextarea, previousConfigText);
                 notify(`Failed to save the configuration: ${error.message}`, 'error');
             });
         } catch (error) {
@@ -2481,10 +2500,8 @@ const AmmTablesManager = (function() {
 
         list[index].enabled = newEnabled;
 
-        const wasReadonly = configTextarea.hasAttribute('readonly');
-        if (wasReadonly) configTextarea.removeAttribute('readonly');
-        configTextarea.value = JSON.stringify(config, null, 4);
-        if (wasReadonly) configTextarea.setAttribute('readonly', '');
+        const previousConfigText = configTextarea.value;
+        setConfigTextarea(configTextarea, JSON.stringify(config, null, 4));
 
         persistConfig(config).then(function(data) {
             if (data && data.success) {
@@ -2495,10 +2512,12 @@ const AmmTablesManager = (function() {
                 updateTables();
                 refreshAfterSave();
             } else {
+                setConfigTextarea(configTextarea, previousConfigText);
                 if (toggleEl) toggleEl.checked = !newEnabled;
                 notify((data && data.error) || 'Failed to save the configuration.', 'error');
             }
         }).catch(function(error) {
+            setConfigTextarea(configTextarea, previousConfigText);
             if (toggleEl) toggleEl.checked = !newEnabled;
             notify(`Failed to save the configuration: ${error.message}`, 'error');
         });
@@ -2551,16 +2570,8 @@ const AmmTablesManager = (function() {
                 return;
             }
 
-            const wasReadonly = configTextarea.hasAttribute('readonly');
-            if (wasReadonly) {
-                configTextarea.removeAttribute('readonly');
-            }
-
-            configTextarea.value = JSON.stringify(config, null, 4);
-
-            if (wasReadonly) {
-                configTextarea.setAttribute('readonly', '');
-            }
+            const previousConfigText = configTextarea.value;
+            setConfigTextarea(configTextarea, JSON.stringify(config, null, 4));
 
             persistConfig(config).then(function(data) {
                 if (data && data.success) {
@@ -2571,10 +2582,12 @@ const AmmTablesManager = (function() {
                     refreshAfterSave();
                     notify(`${type.charAt(0).toUpperCase() + type.slice(1)} "${name || 'Unnamed'}" deleted.`, 'success');
                 } else {
+                    setConfigTextarea(configTextarea, previousConfigText);
                     const errMsg = (data && data.error) || 'Failed to save the configuration.';
                     notify(errMsg, 'error');
                 }
             }).catch(function(error) {
+                setConfigTextarea(configTextarea, previousConfigText);
                 notify(`Failed to save the configuration: ${error.message}`, 'error');
             });
         } catch (error) {

--- a/basicswap/static/js/pages/amm-tables.js
+++ b/basicswap/static/js/pages/amm-tables.js
@@ -1508,7 +1508,7 @@ const AmmTablesManager = (function() {
 
         document.getElementById('add-amm-type').value = type;
 
-        document.getElementById('add-amm-name').value = 'Unnamed Offer';
+        document.getElementById('add-amm-name').value = '';
         document.getElementById('add-amm-enabled').checked = true;
 
         const coinFromSelect = document.getElementById('add-amm-coin-from');
@@ -1691,14 +1691,26 @@ const AmmTablesManager = (function() {
                 const automationStrategyElement = document.getElementById('add-offer-automation-strategy');
                 newItem.automation_strategy = automationStrategyElement ? automationStrategyElement.value : 'accept_all';
 
-                const minCoinFromAmt = document.getElementById('add-offer-min-coin-from-amt').value;
-                if (minCoinFromAmt) {
-                    newItem.min_coin_from_amt = parseFloat(minCoinFromAmt);
-                }
-
                 const offerModeEl = document.getElementById('add-offer-mode');
                 const offerMode = offerModeEl ? (offerModeEl.value || 'standing') : 'standing';
                 newItem.offer_mode = offerMode;
+
+                const minCoinFromAmt = document.getElementById('add-offer-min-coin-from-amt').value;
+                if (minCoinFromAmt !== '' && minCoinFromAmt !== null) {
+                    const minCoinFromAmtValue = parseFloat(minCoinFromAmt);
+                    if (isNaN(minCoinFromAmtValue) || minCoinFromAmtValue < 0) {
+                        if (window.showErrorModal) {
+                            window.showErrorModal('Validation Error', 'Minimum Balance must be zero or greater.');
+                        } else {
+                            alert('Minimum Balance must be zero or greater.');
+                        }
+                        return;
+                    }
+                    newItem.min_coin_from_amt = minCoinFromAmtValue;
+                } else if (offerMode === 'standing' || offerMode === 'legacy') {
+                    newItem.min_coin_from_amt = 0;
+                }
+
                 const offerAmountForMode = parseFloat(document.getElementById('add-amm-amount').value);
                 if (offerMode === 'fixed_total') {
                     const totalToSell = parseFloat(document.getElementById('add-offer-total-to-sell').value);
@@ -1711,15 +1723,6 @@ const AmmTablesManager = (function() {
                         return;
                     }
                     newItem.total_to_sell = totalToSell;
-                } else if (offerMode === 'standing') {
-                    if (!newItem.min_coin_from_amt || newItem.min_coin_from_amt <= 0) {
-                        if (window.showErrorModal) {
-                            window.showErrorModal('Validation Error', 'Standing offers require a Minimum Balance greater than 0 to act as a wallet floor.');
-                        } else {
-                            alert('Standing offers require a Minimum Balance greater than 0 to act as a wallet floor.');
-                        }
-                        return;
-                    }
                 }
 
                 const validSeconds = document.getElementById('add-offer-valid-seconds').value;
@@ -2030,7 +2033,10 @@ const AmmTablesManager = (function() {
                 AmmEditOfferModeToggle.init();
 
                 document.getElementById('edit-offer-ratetweakpercent').value = item.ratetweakpercent || '0';
-                document.getElementById('edit-offer-min-coin-from-amt').value = item.min_coin_from_amt || '';
+                document.getElementById('edit-offer-min-coin-from-amt').value =
+                    (item.min_coin_from_amt !== undefined && item.min_coin_from_amt !== null)
+                        ? String(item.min_coin_from_amt)
+                        : '';
                 document.getElementById('edit-offer-valid-seconds').value = item.offer_valid_seconds || '3600';
                 document.getElementById('edit-offer-address').value = item.address || 'auto';
                 document.getElementById('edit-offer-adjust-rates').value = item.adjust_rates_based_on_market || 'false';
@@ -2174,14 +2180,25 @@ const AmmTablesManager = (function() {
                 return;
             }
 
-            const updatedItem = {
+            let originalItem = null;
+            if (type === 'offer' && Array.isArray(config.offers)) {
+                originalItem = config.offers.find(item =>
+                    (id && item.id === id) || (!id && item.name === originalName)
+                );
+            } else if (type === 'bid' && Array.isArray(config.bids)) {
+                originalItem = config.bids.find(item =>
+                    (id && item.id === id) || (!id && item.name === originalName)
+                );
+            }
+
+            const updatedItem = Object.assign({}, originalItem || {}, {
                 name: name,
                 enabled: document.getElementById('edit-amm-enabled').checked,
                 coin_from: document.getElementById('edit-amm-coin-from').value,
                 coin_to: document.getElementById('edit-amm-coin-to').value,
                 amount: parseFloat(document.getElementById('edit-amm-amount').value),
                 amount_variable: true
-            };
+            });
 
             if (id) {
                 updatedItem.id = id;
@@ -2196,14 +2213,26 @@ const AmmTablesManager = (function() {
                 const editAutomationStrategyElement = document.getElementById('edit-offer-automation-strategy');
                 updatedItem.automation_strategy = editAutomationStrategyElement ? editAutomationStrategyElement.value : 'accept_all';
 
-                const minCoinFromAmt = document.getElementById('edit-offer-min-coin-from-amt').value;
-                if (minCoinFromAmt) {
-                    updatedItem.min_coin_from_amt = parseFloat(minCoinFromAmt);
-                }
-
                 const editOfferModeEl = document.getElementById('edit-offer-mode');
                 const editOfferMode = editOfferModeEl ? (editOfferModeEl.value || 'standing') : 'standing';
                 updatedItem.offer_mode = editOfferMode;
+
+                const minCoinFromAmt = document.getElementById('edit-offer-min-coin-from-amt').value;
+                if (minCoinFromAmt !== '' && minCoinFromAmt !== null) {
+                    const minCoinFromAmtValue = parseFloat(minCoinFromAmt);
+                    if (isNaN(minCoinFromAmtValue) || minCoinFromAmtValue < 0) {
+                        if (window.showErrorModal) {
+                            window.showErrorModal('Validation Error', 'Minimum Balance must be zero or greater.');
+                        } else {
+                            alert('Minimum Balance must be zero or greater.');
+                        }
+                        return;
+                    }
+                    updatedItem.min_coin_from_amt = minCoinFromAmtValue;
+                } else if (editOfferMode === 'standing' || editOfferMode === 'legacy') {
+                    updatedItem.min_coin_from_amt = 0;
+                }
+
                 const editOfferAmountForMode = parseFloat(document.getElementById('edit-amm-amount').value);
                 if (editOfferMode === 'fixed_total') {
                     const editTotalToSell = parseFloat(document.getElementById('edit-offer-total-to-sell').value);
@@ -2216,15 +2245,6 @@ const AmmTablesManager = (function() {
                         return;
                     }
                     updatedItem.total_to_sell = editTotalToSell;
-                } else if (editOfferMode === 'standing') {
-                    if (!updatedItem.min_coin_from_amt || updatedItem.min_coin_from_amt <= 0) {
-                        if (window.showErrorModal) {
-                            window.showErrorModal('Validation Error', 'Standing offers require a Minimum Balance greater than 0 to act as a wallet floor.');
-                        } else {
-                            alert('Standing offers require a Minimum Balance greater than 0 to act as a wallet floor.');
-                        }
-                        return;
-                    }
                 }
 
                 const validSeconds = document.getElementById('edit-offer-valid-seconds').value;

--- a/basicswap/static/js/pages/offer-new-page.js
+++ b/basicswap/static/js/pages/offer-new-page.js
@@ -177,6 +177,66 @@ function handleNewOfferAddress() {
     }
 }
 
+const AddrFromSearch = {
+    initialOptions: null,
+    debounceTimer: null,
+    requestSeq: 0,
+    init: function() {
+        const input = DOM.get('addr_from_search');
+        const select = DOM.get('addr_from');
+        if (!input || !select) return;
+        this.initialOptions = Array.from(select.options).map(o => ({ value: o.value, text: o.text }));
+        input.addEventListener('input', () => {
+            clearTimeout(this.debounceTimer);
+            this.debounceTimer = setTimeout(() => this.search(input.value.trim()), 300);
+        });
+    },
+    search: function(query) {
+        const select = DOM.get('addr_from');
+        if (!select) return;
+        if (!query) {
+            this.render(select, this.initialOptions);
+            return;
+        }
+        const seq = ++this.requestSeq;
+        const params = 'use_type=offer_send_from&limit=50&search=' + encodeURIComponent(query);
+        Ajax.post('/json/smsgaddresses', params, (resp) => {
+            if (seq !== this.requestSeq) return;
+            let results = [];
+            try {
+                const list = (typeof resp === 'string') ? JSON.parse(resp) : resp;
+                if (Array.isArray(list)) {
+                    results = list.map(a => ({ value: a.addr, text: a.addr + (a.note ? ' ' + a.note : '') }));
+                }
+            } catch (e) {
+                results = [];
+            }
+            const options = [{ value: '-1', text: 'New Address' }].concat(results);
+            this.render(select, options);
+        });
+    },
+    render: function(select, options) {
+        const current = select.value;
+        select.innerHTML = '';
+        let hasCurrent = false;
+        options.forEach(o => {
+            const opt = document.createElement('option');
+            opt.value = o.value;
+            opt.text = o.text;
+            select.appendChild(opt);
+            if (o.value === current) hasCurrent = true;
+        });
+        if (!hasCurrent && current && current !== '-1') {
+            const opt = document.createElement('option');
+            opt.value = current;
+            opt.text = current;
+            select.insertBefore(opt, select.options[1] || null);
+            hasCurrent = true;
+        }
+        select.value = hasCurrent ? current : '-1';
+    }
+};
+
 const AddrFromHint = {
     update: function() {
         const hint = DOM.get('addr-from-hint');
@@ -1126,6 +1186,7 @@ const UIEnhancer = {
 
 function initializeApp() {
     handleNewOfferAddress();
+    AddrFromSearch.init();
 
     CoinPicker.init();
 

--- a/basicswap/templates/amm.html
+++ b/basicswap/templates/amm.html
@@ -581,7 +581,7 @@
                     <li>• If <strong>offer_mode</strong> is not set, templates default to <strong>"standing"</strong></li>
                     <li>• Tracking state (amount filled, fills completed) is persisted per-offer and is self-correcting: a failed or cancelled bid simply drops out of the in-flight total</li>
                     <li>• <strong>total_to_sell</strong> is only read when <strong>offer_mode</strong> is "fixed_total", and must be greater than or equal to <strong>amount</strong></li>
-                    <li>• For "standing" offers, <strong>min_coin_from_amt</strong> doubles as the minimum wallet reserve used to decide when to stop reposting</li>
+                    <li>• For "standing" offers, <strong>min_coin_from_amt</strong> doubles as the minimum wallet reserve used to decide when to stop reposting. A value of 0 means no reserve floor (sell until the wallet is empty)</li>
                   </ul>
                 </div>
               </div>
@@ -931,7 +931,7 @@
                           <option value="standing" selected>Standing — repeat until a wallet floor</option>
                         </select>
                       </div>
-                      <small class="text-xs text-gray-500 dark:text-gray-400 mt-1 block">One-time posts a single offer and stops once it is filled. Fixed total keeps reposting until the cumulative sold amount reaches Total to Sell. Standing repeats indefinitely, skipping new offers when the wallet balance would drop below the Minimum Balance floor.</small>
+                      <small class="text-xs text-gray-500 dark:text-gray-400 mt-1 block">One-time posts a single offer and stops once it is filled. Fixed total keeps reposting until the cumulative sold amount reaches Total to Sell. Standing repeats indefinitely, skipping new offers when the wallet balance would drop below the Minimum Balance floor (0 = no floor, sell everything).</small>
                     </div>
 
                     <div id="add-offer-total-to-sell-wrap" class="hidden">
@@ -1258,7 +1258,7 @@
                           <option value="standing">Standing — repeat until a wallet floor</option>
                         </select>
                       </div>
-                      <small class="text-xs text-gray-500 dark:text-gray-400 mt-1 block">One-time posts a single offer and stops once it is filled. Fixed total keeps reposting until the cumulative sold amount reaches Total to Sell. Standing repeats indefinitely, skipping new offers when the wallet balance would drop below the Minimum Balance floor.</small>
+                      <small class="text-xs text-gray-500 dark:text-gray-400 mt-1 block">One-time posts a single offer and stops once it is filled. Fixed total keeps reposting until the cumulative sold amount reaches Total to Sell. Standing repeats indefinitely, skipping new offers when the wallet balance would drop below the Minimum Balance floor (0 = no floor, sell everything).</small>
                     </div>
 
                     <div id="edit-offer-total-to-sell-wrap" class="hidden">

--- a/basicswap/templates/offer_new_1.html
+++ b/basicswap/templates/offer_new_1.html
@@ -162,6 +162,7 @@
               </div>
               <div>
                 <label class="block mb-1.5 text-sm font-medium text-coolGray-800 dark:text-white">Send-from address</label>
+                <input type="text" id="addr_from_search" autocomplete="off" placeholder="Search addresses or labels..." class="hover:border-blue-500 bg-gray-50 text-gray-900 dark:bg-gray-500 dark:text-white border border-gray-300 dark:border-gray-400 dark:text-gray-50 dark:placeholder-gray-300 text-sm rounded-lg outline-none focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5 mb-2 focus:ring-0">
                 <div class="relative">
                   {{ input_down_arrow_offer_svg | safe }}
                   <div class="flex absolute inset-y-0 left-0 items-center pl-3 pointer-events-none">{{ select_address_svg | safe }}</div>
@@ -172,7 +173,7 @@
                     {% endfor %}
                   </select>
                 </div>
-                <p class="text-xs text-gray-500 dark:text-gray-300 mt-2">The address that will hold and lock the coins you send during the swap.</p>
+                <p class="text-xs text-gray-500 dark:text-gray-300 mt-2">The address that will hold and lock the coins you send during the swap. Showing the most recent addresses; type above to search all.</p>
                 <p id="addr-from-hint" class="text-xs mt-1"></p>
               </div>
             </div>

--- a/basicswap/ui/page_amm.py
+++ b/basicswap/ui/page_amm.py
@@ -984,11 +984,11 @@ def page_amm(self, _, post_string):
                             )
                             raise ValueError("total_to_sell < amount")
                     elif offer_mode == "standing":
-                        if new_offer.get("min_coin_from_amt", 0) <= 0:
+                        if new_offer.get("min_coin_from_amt", 0) < 0:
                             err_messages.append(
-                                "Standing offers require a minimum wallet reserve (min coin from amount) greater than 0"
+                                "Minimum wallet reserve (min coin from amount) cannot be negative"
                             )
-                            raise ValueError("standing without wallet floor")
+                            raise ValueError("negative wallet floor")
 
                     if form_data.get("offer_valid_seconds", [""])[0]:
                         try:
@@ -1412,10 +1412,8 @@ def validate_amm_config(config_data):
 
         if offer_mode == "standing":
             try:
-                if float(offer.get("min_coin_from_amt", 0)) <= 0:
-                    errors.append(
-                        f"{label}: standing offers require min_coin_from_amt > 0"
-                    )
+                if float(offer.get("min_coin_from_amt", 0)) < 0:
+                    errors.append(f"{label}: min_coin_from_amt cannot be negative")
             except (TypeError, ValueError):
                 errors.append(f"{label}: min_coin_from_amt must be a number")
 
@@ -1693,7 +1691,7 @@ def amm_config_api(swap_client, post_string, params=None):
         if validation_errors:
             return {
                 "success": False,
-                "error": validation_errors[0],
+                "error": "; ".join(validation_errors),
                 "errors": validation_errors,
             }
 

--- a/basicswap/ui/page_amm.py
+++ b/basicswap/ui/page_amm.py
@@ -898,19 +898,24 @@ def page_amm(self, _, post_string):
                 config_content = form_data.get("config_content", [""])[0]
 
                 try:
-                    json.loads(config_content)
+                    parsed_config = json.loads(config_content)
+
+                    validation_errors = validate_amm_config(parsed_config)
+                    if validation_errors:
+                        for validation_error in validation_errors:
+                            err_messages.append(validation_error)
+                        raise ValueError("Config validation failed")
 
                     with open(config_path, "w") as f:
                         f.write(config_content)
 
-                    try:
-                        config_data = json.loads(config_content)
-                    except Exception:
-                        pass
+                    config_data = parsed_config
 
                     messages.append("Config file saved successfully")
                 except json.JSONDecodeError as e:
                     err_messages.append(f"Invalid JSON: {str(e)}")
+                except ValueError:
+                    pass
                 except Exception as e:
                     err_messages.append(f"Failed to save config file: {str(e)}")
 
@@ -1002,6 +1007,16 @@ def page_amm(self, _, post_string):
                     if "offers" not in current_config:
                         current_config["offers"] = []
 
+                    if any(
+                        o.get("name") == new_offer["name"]
+                        for o in current_config["offers"]
+                        if isinstance(o, dict)
+                    ):
+                        err_messages.append(
+                            f"An offer template named '{new_offer['name']}' already exists"
+                        )
+                        raise ValueError("duplicate template name")
+
                     current_config["offers"].append(new_offer)
 
                     with open(config_path, "w") as f:
@@ -1079,6 +1094,16 @@ def page_amm(self, _, post_string):
 
                     if "bids" not in current_config:
                         current_config["bids"] = []
+
+                    if any(
+                        b.get("name") == new_bid["name"]
+                        for b in current_config["bids"]
+                        if isinstance(b, dict)
+                    ):
+                        err_messages.append(
+                            f"A bid template named '{new_bid['name']}' already exists"
+                        )
+                        raise ValueError("duplicate template name")
 
                     current_config["bids"].append(new_bid)
 

--- a/basicswap/ui/page_offers.py
+++ b/basicswap/ui/page_offers.py
@@ -787,9 +787,7 @@ def page_newoffer(self, url_split, post_string):
     all_addresses = swap_client.listAllSMSGAddresses({})
     addr_notes = {addr["addr"]: addr["note"] for addr in all_addresses}
 
-    addrs_from_all = [
-        (addr[0], addr_notes.get(addr[0], "")) for addr in addrs_from_raw
-    ]
+    addrs_from_all = [(addr[0], addr_notes.get(addr[0], "")) for addr in addrs_from_raw]
     addrs_from = addrs_from_all[:MAX_SEND_FROM_ADDRS]
     selected_addr_from = page_data.get("addr_from")
     if selected_addr_from and selected_addr_from not in (a[0] for a in addrs_from):

--- a/basicswap/ui/page_offers.py
+++ b/basicswap/ui/page_offers.py
@@ -52,6 +52,8 @@ from basicswap.offer_tracking import (
 )
 from basicswap.explorers import default_coingecko_api_key
 
+MAX_SEND_FROM_ADDRS = 50
+
 
 def value_or_none(v):
     if v == -1 or v == "-1":
@@ -785,7 +787,16 @@ def page_newoffer(self, url_split, post_string):
     all_addresses = swap_client.listAllSMSGAddresses({})
     addr_notes = {addr["addr"]: addr["note"] for addr in all_addresses}
 
-    addrs_from = [(addr[0], addr_notes.get(addr[0], "")) for addr in addrs_from_raw]
+    addrs_from_all = [
+        (addr[0], addr_notes.get(addr[0], "")) for addr in addrs_from_raw
+    ]
+    addrs_from = addrs_from_all[:MAX_SEND_FROM_ADDRS]
+    selected_addr_from = page_data.get("addr_from")
+    if selected_addr_from and selected_addr_from not in (a[0] for a in addrs_from):
+        for a in addrs_from_all:
+            if a[0] == selected_addr_from:
+                addrs_from.append(a)
+                break
     addrs_to = [(addr[0], addr_notes.get(addr[0], "")) for addr in addrs_to_raw]
 
     automation_filters = {"type_ind": Concepts.OFFER, "sort_by": "label"}

--- a/tests/basicswap/test_amm_config_api.py
+++ b/tests/basicswap/test_amm_config_api.py
@@ -61,11 +61,42 @@ class AmmConfigValidationTest(unittest.TestCase):
         errors = validate_amm_config({"offers": [offer]})
         self.assertTrue(any("offer_valid_seconds" in e for e in errors))
 
-    def test_standing_requires_min_coin_from_amt(self):
+    def test_standing_allows_zero_min_coin_from_amt(self):
         offer = self._valid_standing_offer()
         offer["min_coin_from_amt"] = 0
+        self.assertEqual(validate_amm_config({"offers": [offer]}), [])
+
+    def test_standing_allows_missing_min_coin_from_amt(self):
+        offer = self._valid_standing_offer()
+        del offer["min_coin_from_amt"]
+        self.assertEqual(validate_amm_config({"offers": [offer]}), [])
+
+    def test_standing_rejects_negative_min_coin_from_amt(self):
+        offer = self._valid_standing_offer()
+        offer["min_coin_from_amt"] = -1
         errors = validate_amm_config({"offers": [offer]})
         self.assertTrue(any("min_coin_from_amt" in e for e in errors))
+
+    def test_fixed_total_allows_zero_min_coin_from_amt(self):
+        offer = self._valid_standing_offer()
+        offer["offer_mode"] = "fixed_total"
+        offer["total_to_sell"] = 100
+        offer["min_coin_from_amt"] = 0
+        self.assertEqual(validate_amm_config({"offers": [offer]}), [])
+
+    def test_legacy_zero_floor_config_saves(self):
+        offer = {
+            "name": "my_offer",
+            "coin_from": "Monero",
+            "coin_to": "Bitcoin",
+            "amount": 0.1,
+            "amount_step": 0.001,
+            "offer_valid_seconds": 3600,
+            "offer_mode": "standing",
+            "min_coin_from_amt": 0,
+            "enabled": False,
+        }
+        self.assertEqual(validate_amm_config({"offers": [offer]}), [])
 
     def test_fixed_total_requires_total(self):
         offer = self._valid_standing_offer()


### PR DESCRIPTION
AMM fixes:
  - Fix template save regression that blocked editing, disabling, deleting, and adding templates when any standing offer had min_coin_from_amt of 0.
  - Restore min_coin_from_amt = 0 as a valid wallet floor for standing offers (0 = no reserve, sell until the wallet is empty). Only negative values are rejected.
  - Config save errors now report all failing templates instead of only the first.
  - Edit form no longer drops a stored minimum balance of 0; editing a template preserves fields that are not shown in the form.
  - AMM start wizard no longer requires a positive minimum balance on all enabled offers.
  - New template modal no longer pre-fills the name "Unnamed Offer".
- New offer page: limit the send-from address dropdown to the 50 most recent addresses to prevent the browser hanging with large address lists. The currently selected address is always included.
- Searchable address on new offer page (label or address).
- Saving the config from the form now checks the whole file first. If anything is wrong, it shows all errors and does not save.
- Adding an offer or bid now checks whether that name already exists. If it does, it stops and does not write to disk.
- When you add, edit, enable/disable, or delete something, the page keeps a backup of the config first.
- If the server rejects the save, it puts the old config back. The screen stays in sync with what is actually saved.
- When you add or rename a template, it checks right away whether that name is already used.
If the name is taken, it shows a clear error telling you which name is the problem.
- Bump AMM v0.5.1.