### PR TITLE
 Fix: Electrum trust boundary and imported-key storage.

### DIFF
--- a/basicswap/basicswap.py
+++ b/basicswap/basicswap.py
@@ -9449,12 +9449,14 @@ class BasicSwap(BaseApp, BSXNetwork, UIApp):
 
             bid.xmr_a_lock_tx.spend_txid = spending_txid
 
+            is_bch_swap: bool = self.isBchXmrSwap(offer)
             is_spending_lock_tx = False
-            if self.isBchXmrSwap(offer):
+            if is_bch_swap:
                 is_spending_lock_tx = self.ci(coin_from).isSpendingLockTx(spend_tx)
 
             if spending_txid == xmr_swap.a_lock_spend_tx_id or (
-                i2b(spend_tx.vin[0].prevout.hash) == xmr_swap.a_lock_tx_id
+                is_bch_swap
+                and i2b(spend_tx.vin[0].prevout.hash) == xmr_swap.a_lock_tx_id
                 and is_spending_lock_tx
             ):
                 # bch txids change
@@ -9498,7 +9500,8 @@ class BasicSwap(BaseApp, BSXNetwork, UIApp):
                     )
 
             elif spending_txid == xmr_swap.a_lock_refund_tx_id or (
-                i2b(spend_tx.vin[0].prevout.hash) == xmr_swap.a_lock_tx_id
+                is_bch_swap
+                and i2b(spend_tx.vin[0].prevout.hash) == xmr_swap.a_lock_tx_id
                 and not is_spending_lock_tx
             ):
                 self.log.debug("Coin a lock tx spent by lock refund tx.")

--- a/basicswap/interface/btc/btc.py
+++ b/basicswap/interface/btc/btc.py
@@ -1083,6 +1083,15 @@ class BTCInterface(FeeValidator, Secp256k1Interface):
                     fee_sat_vb = self._backend.estimateFee(conf_target)
                     if fee_sat_vb and fee_sat_vb > 0:
                         fee_rate = (fee_sat_vb * 1000) / 1e8
+                        if (
+                            self._high_feerate > 0
+                            and self.make_int(fee_rate) > self._high_feerate
+                        ):
+                            self._log.warning(
+                                f"Electrum fee estimate {fee_rate} for {self.coin_name()} "
+                                f"exceeds high_feerate {self._high_feerate}, using default"
+                            )
+                            return 0.00001, "electrum_default"
                         return fee_rate, "electrum"
                 except Exception as e:
                     self._log.debug(f"Electrum estimateFee failed: {e}")
@@ -2949,6 +2958,8 @@ class BTCInterface(FeeValidator, Secp256k1Interface):
         lock_tx_vout: int,
         script_pk: bytes,
     ) -> (int, int):
+        locked_n = None
+        actual_value = None
         if self.useBackend():
             backend = self.getBackend()
             tx_hex = backend.getTransactionRaw(chain_b_lock_txid.hex())
@@ -2970,7 +2981,6 @@ class BTCInterface(FeeValidator, Secp256k1Interface):
                 self._log.warning(
                     f"spendBLockTx: Failed to fetch tx {self._log.id(chain_b_lock_txid)} from backend"
                 )
-                locked_n = lock_tx_vout
             return locked_n, actual_value
         wtx = self.rpc_wallet_watch(
             "gettransaction",
@@ -4689,6 +4699,7 @@ class BTCInterface(FeeValidator, Secp256k1Interface):
             [prevouts_to_spend, {addr_to: self.format_amount(total_amount)}],
         )
         fee_rate, rate_src = self.get_fee_rate(self._conf_target)
+        self._ensureFeeRateWithinMax(fee_rate, rate_src)
         fee_rate_str: str = self.format_amount(fee_rate, True, 1)
         self._log.debug(
             f"Using fee rate: {fee_rate_str}, src: {rate_src}, confirms target: {self._conf_target}"

--- a/basicswap/wallet_manager.py
+++ b/basicswap/wallet_manager.py
@@ -811,10 +811,24 @@ class WalletManager:
                 (int(coin_type), address),
             )
             row = cursor.fetchone()
+            if not row or not row[0]:
+                conn.close()
+                return None
+            encrypted_key = row[0]
+            private_key = self._decryptPrivateKey(encrypted_key, coin_type)
+            if not self._isAEADImportKey(encrypted_key):
+                cursor.execute(
+                    "UPDATE wallet_watch_only SET private_key_encrypted = ? WHERE coin_type = ? AND address = ?",
+                    (
+                        self._encryptPrivateKey(private_key, coin_type),
+                        int(coin_type),
+                        address,
+                    ),
+                )
+                conn.commit()
+                self._log.info("Migrated legacy imported key to AEAD format")
             conn.close()
-            return (
-                self._decryptPrivateKey(row[0], coin_type) if row and row[0] else None
-            )
+            return private_key
         except Exception:
             return None
 


### PR DESCRIPTION
 - Fix crash in spendBLockTx when the Electrum backend fails to return the chain B lock tx or the expected output is missing; getBLockTxo now fails closed with a clear error instead of raising UnboundLocalError.
- BTC/LTC adaptor-sig swaps no longer classify unrecognised spends of the chain A lock tx as refunds. Only exact matches against the precomputed spend/refund txids are accepted (the prevout fallback remains for BCH, where txids are malleable), preventing a malicious Electrum server from forcing a false pre-refund state.
- Electrum fee estimates exceeding the configured high_feerate are rejected at the source and fall back to the default rate. The fee-rate ceiling is also enforced when combining non-segwit prevouts. Prevents fee-inflation griefing by a malicious Electrum server.
- Imported private keys still stored in the legacy XOR format are automatically re-encrypted with AEAD (ChaCha20-Poly1305) on first access.
