### PR TITLE
Fix: Electrum trust boundary, mercy tx watch, Simplex connect.

### DIFF
--- a/basicswap/basicswap.py
+++ b/basicswap/basicswap.py
@@ -13574,8 +13574,7 @@ class BasicSwap(BaseApp, BSXNetwork, UIApp):
                 t for t in self._connect_request_times if now_rl - t < 3600
             ]
             ensure(
-                len(self._connect_request_times)
-                < self._max_connect_requests_per_hour,
+                len(self._connect_request_times) < self._max_connect_requests_per_hour,
                 "Connection request rate limit exceeded",
             )
             self._connect_request_times.append(now_rl)

--- a/basicswap/basicswap.py
+++ b/basicswap/basicswap.py
@@ -9821,21 +9821,7 @@ class BasicSwap(BaseApp, BSXNetwork, UIApp):
         bid_id = watched_script.bid_id
         ci = self.ci(coin_type)
 
-        mercy_keyshare = None
-        if len(tx["vout"]) >= 2 and ci.make_int(tx["vout"][vout]["value"]) == 546:
-            try:
-                op_return_script = bytes.fromhex(tx["vout"][0]["scriptPubKey"]["hex"])
-                if (
-                    len(op_return_script) == 39
-                    and op_return_script[:6] == bytes((0x6A, 0x04)) + b"XBSW"
-                    and op_return_script[6] == 0x20
-                ):
-                    keyshare = op_return_script[7:]
-                    if ci.verifyKey(keyshare):
-                        mercy_keyshare = keyshare
-            except Exception as e:
-                self.log.debug(f"Mercy tx check failed: {e}")
-
+        mercy_keyshare = ci.isMercyTx(tx, vout)
         if mercy_keyshare is None:
             self.log.info(
                 f"Found tx is not a mercy tx for bid: {self.log.id(bid_id)}, still watching."

--- a/basicswap/basicswap.py
+++ b/basicswap/basicswap.py
@@ -9453,14 +9453,12 @@ class BasicSwap(BaseApp, BSXNetwork, UIApp):
 
             bid.xmr_a_lock_tx.spend_txid = spending_txid
 
-            is_bch_swap: bool = self.isBchXmrSwap(offer)
             is_spending_lock_tx = False
-            if is_bch_swap:
+            if self.isBchXmrSwap(offer):
                 is_spending_lock_tx = self.ci(coin_from).isSpendingLockTx(spend_tx)
 
             if spending_txid == xmr_swap.a_lock_spend_tx_id or (
-                is_bch_swap
-                and i2b(spend_tx.vin[0].prevout.hash) == xmr_swap.a_lock_tx_id
+                i2b(spend_tx.vin[0].prevout.hash) == xmr_swap.a_lock_tx_id
                 and is_spending_lock_tx
             ):
                 # bch txids change
@@ -9504,8 +9502,7 @@ class BasicSwap(BaseApp, BSXNetwork, UIApp):
                     )
 
             elif spending_txid == xmr_swap.a_lock_refund_tx_id or (
-                is_bch_swap
-                and i2b(spend_tx.vin[0].prevout.hash) == xmr_swap.a_lock_tx_id
+                i2b(spend_tx.vin[0].prevout.hash) == xmr_swap.a_lock_tx_id
                 and not is_spending_lock_tx
             ):
                 self.log.debug("Coin a lock tx spent by lock refund tx.")
@@ -13191,6 +13188,8 @@ class BasicSwap(BaseApp, BSXNetwork, UIApp):
             f"Split message sequence too high: {msg_data.sequence}",
         )
 
+        # TODO: Wait for bid msg to arrive first
+
         if (
             msg_data.msg_type == XmrSplitMsgTypes.BID
             or msg_data.msg_type == XmrSplitMsgTypes.BID_ACCEPT
@@ -13212,27 +13211,6 @@ class BasicSwap(BaseApp, BSXNetwork, UIApp):
                         f"Ignoring duplicate xmr_split_data entry: ({self.logIDM(msg_data.msg_id)}, {msg_data.msg_type}, {msg_data.sequence})."
                     )
                     return
-
-                if msg_data.msg_type == XmrSplitMsgTypes.BID_ACCEPT:
-                    q = cursor.execute(
-                        "SELECT COUNT(*) FROM bids WHERE bid_id = :bid_id",
-                        {"bid_id": msg_data.msg_id},
-                    ).fetchone()
-                    if q[0] < 1:
-                        self.log.warning(
-                            f"Ignoring bid accept split message for unknown bid: {self.logIDM(msg_data.msg_id)}."
-                        )
-                        return
-                else:
-                    q = cursor.execute(
-                        "SELECT COUNT(*) FROM xmr_split_data WHERE addr_from = :addr_from",
-                        {"addr_from": msg["from"]},
-                    ).fetchone()
-                    if q[0] >= max_chunks * 10:
-                        self.log.warning(
-                            f"Ignoring split message from {self.log.addr(msg['from'])}: too many pending entries."
-                        )
-                        return
 
                 dbr = XmrSplitData()
                 dbr.addr_from = msg["from"]

--- a/basicswap/basicswap.py
+++ b/basicswap/basicswap.py
@@ -598,6 +598,10 @@ class BasicSwap(BaseApp, BSXNetwork, UIApp):
         self._bid_expired_leeway = 5
 
         self.swaps_in_progress = dict()
+        self._connect_request_times = []
+        self._max_connect_requests_per_hour = self.settings.get(
+            "max_connect_requests_per_hour", 30
+        )
 
         self.threads = []
         self.thread_pool = concurrent.futures.ThreadPoolExecutor(
@@ -9449,12 +9453,14 @@ class BasicSwap(BaseApp, BSXNetwork, UIApp):
 
             bid.xmr_a_lock_tx.spend_txid = spending_txid
 
+            is_bch_swap: bool = self.isBchXmrSwap(offer)
             is_spending_lock_tx = False
-            if self.isBchXmrSwap(offer):
+            if is_bch_swap:
                 is_spending_lock_tx = self.ci(coin_from).isSpendingLockTx(spend_tx)
 
             if spending_txid == xmr_swap.a_lock_spend_tx_id or (
-                i2b(spend_tx.vin[0].prevout.hash) == xmr_swap.a_lock_tx_id
+                is_bch_swap
+                and i2b(spend_tx.vin[0].prevout.hash) == xmr_swap.a_lock_tx_id
                 and is_spending_lock_tx
             ):
                 # bch txids change
@@ -9498,7 +9504,8 @@ class BasicSwap(BaseApp, BSXNetwork, UIApp):
                     )
 
             elif spending_txid == xmr_swap.a_lock_refund_tx_id or (
-                i2b(spend_tx.vin[0].prevout.hash) == xmr_swap.a_lock_tx_id
+                is_bch_swap
+                and i2b(spend_tx.vin[0].prevout.hash) == xmr_swap.a_lock_tx_id
                 and not is_spending_lock_tx
             ):
                 self.log.debug("Coin a lock tx spent by lock refund tx.")
@@ -9816,12 +9823,26 @@ class BasicSwap(BaseApp, BSXNetwork, UIApp):
     ) -> None:
         bid_id = watched_script.bid_id
         ci = self.ci(coin_type)
-        if (
-            len(tx["vout"]) < 2 or ci.make_int(tx["vout"][vout]["value"]) != 546
-        ):  # Dust limit
 
-            self.log.info(f"Found tx is not a mercy tx for bid: {self.log.id(bid_id)}.")
-            self.removeWatchedScript(coin_type, bid_id, watched_script.script)
+        mercy_keyshare = None
+        if len(tx["vout"]) >= 2 and ci.make_int(tx["vout"][vout]["value"]) == 546:
+            try:
+                op_return_script = bytes.fromhex(tx["vout"][0]["scriptPubKey"]["hex"])
+                if (
+                    len(op_return_script) == 39
+                    and op_return_script[:6] == bytes((0x6A, 0x04)) + b"XBSW"
+                    and op_return_script[6] == 0x20
+                ):
+                    keyshare = op_return_script[7:]
+                    if ci.verifyKey(keyshare):
+                        mercy_keyshare = keyshare
+            except Exception as e:
+                self.log.debug(f"Mercy tx check failed: {e}")
+
+        if mercy_keyshare is None:
+            self.log.info(
+                f"Found tx is not a mercy tx for bid: {self.log.id(bid_id)}, still watching."
+            )
             return
 
         self.log.info(f"Found mercy tx for bid: {self.log.id(bid_id)}.")
@@ -9835,11 +9856,6 @@ class BasicSwap(BaseApp, BSXNetwork, UIApp):
                 f"Could not find active bid for found mercy tx: {self.logIDB(bid_id)}."
             )
         else:
-            mercy_keyshare = bytes.fromhex(
-                tx["vout"][0]["scriptPubKey"]["asm"].split(" ")[2]
-            )
-            ensure(ci.verifyKey(mercy_keyshare), "Invalid keyshare")
-
             bid = self.swaps_in_progress[bid_id][0]
             bid.txns[TxTypes.BCH_MERCY] = SwapTx(
                 bid_id=bid_id,
@@ -10046,6 +10062,11 @@ class BasicSwap(BaseApp, BSXNetwork, UIApp):
                 self.log.debug(f"Checking output {o.txid_hex}:{o.vout} for spend")
                 spend_info = ci.checkWatchedOutput(o.txid_hex, o.vout)
                 if spend_info:
+                    if spend_info.get("height", 0) <= 0:
+                        self.log.debug(
+                            f"Waiting for spend of {o.txid_hex}:{o.vout} to confirm: {self.logIDT(spend_info['txid'])}"
+                        )
+                        continue
                     self.log.debug(
                         f"Found spend via Electrum {self.logIDT(o.txid_hex)} {o.vout} in {self.logIDT(spend_info['txid'])} {spend_info['vin']}"
                     )
@@ -10120,6 +10141,11 @@ class BasicSwap(BaseApp, BSXNetwork, UIApp):
             try:
                 spend_info = ci.checkWatchedOutput(o.txid_hex, o.vout)
                 if spend_info:
+                    if spend_info.get("height", 0) <= 0:
+                        self.log.debug(
+                            f"Waiting for spend of {o.txid_hex}:{o.vout} to confirm: {self.logIDT(spend_info['txid'])}"
+                        )
+                        continue
                     raw_tx = ci.getBackend().getTransactionRaw(spend_info["txid"])
                     if raw_tx:
                         tx = ci.loadTx(bytes.fromhex(raw_tx))
@@ -13165,8 +13191,6 @@ class BasicSwap(BaseApp, BSXNetwork, UIApp):
             f"Split message sequence too high: {msg_data.sequence}",
         )
 
-        # TODO: Wait for bid msg to arrive first
-
         if (
             msg_data.msg_type == XmrSplitMsgTypes.BID
             or msg_data.msg_type == XmrSplitMsgTypes.BID_ACCEPT
@@ -13188,6 +13212,27 @@ class BasicSwap(BaseApp, BSXNetwork, UIApp):
                         f"Ignoring duplicate xmr_split_data entry: ({self.logIDM(msg_data.msg_id)}, {msg_data.msg_type}, {msg_data.sequence})."
                     )
                     return
+
+                if msg_data.msg_type == XmrSplitMsgTypes.BID_ACCEPT:
+                    q = cursor.execute(
+                        "SELECT COUNT(*) FROM bids WHERE bid_id = :bid_id",
+                        {"bid_id": msg_data.msg_id},
+                    ).fetchone()
+                    if q[0] < 1:
+                        self.log.warning(
+                            f"Ignoring bid accept split message for unknown bid: {self.logIDM(msg_data.msg_id)}."
+                        )
+                        return
+                else:
+                    q = cursor.execute(
+                        "SELECT COUNT(*) FROM xmr_split_data WHERE addr_from = :addr_from",
+                        {"addr_from": msg["from"]},
+                    ).fetchone()
+                    if q[0] >= max_chunks * 10:
+                        self.log.warning(
+                            f"Ignoring split message from {self.log.addr(msg['from'])}: too many pending entries."
+                        )
+                        return
 
                 dbr = XmrSplitData()
                 dbr.addr_from = msg["from"]
@@ -13513,6 +13558,28 @@ class BasicSwap(BaseApp, BSXNetwork, UIApp):
                 raise ValueError("Direct message route already exists")
 
             connReqInvitation = req_data["connection_req"]
+            ensure(
+                isinstance(connReqInvitation, str), "Invalid connection request type"
+            )
+            ensure(
+                0 < len(connReqInvitation) <= 4096, "Invalid connection request length"
+            )
+            ensure(
+                all(33 <= ord(c) <= 126 for c in connReqInvitation),
+                "Invalid characters in connection request",
+            )
+
+            now_rl: int = self.getTime()
+            self._connect_request_times = [
+                t for t in self._connect_request_times if now_rl - t < 3600
+            ]
+            ensure(
+                len(self._connect_request_times)
+                < self._max_connect_requests_per_hour,
+                "Connection request rate limit exceeded",
+            )
+            self._connect_request_times.append(now_rl)
+
             cmd_id = net_i.send_command(f"/connect {connReqInvitation}")
             response = net_i.wait_for_command_response(cmd_id)
             pccConnId = getResponseData(response, "connection")["pccConnId"]
@@ -13583,9 +13650,11 @@ class BasicSwap(BaseApp, BSXNetwork, UIApp):
             if found_direct_message_route:
                 query_str = (
                     "SELECT record_id, linked_type, linked_id FROM direct_message_route_links "
-                    + "WHERE active_ind = 1"
+                    + "WHERE active_ind = 1 AND direct_message_route_id = :route_id"
                 )
-                rows = cursor.execute(query_str).fetchall()
+                rows = cursor.execute(
+                    query_str, {"route_id": found_direct_message_route}
+                ).fetchall()
                 for row in rows:
                     record_id, linked_type, linked_id = row
 

--- a/basicswap/interface/bch/bch.py
+++ b/basicswap/interface/bch/bch.py
@@ -4,7 +4,7 @@
 # Distributed under the MIT software license, see the accompanying
 # file LICENSE or http://www.opensource.org/licenses/mit-license.php.
 
-from typing import Union
+from typing import Optional, Union
 from basicswap.contrib.test_framework.messages import COutPoint, CTransaction, CTxIn
 from basicswap.util import b2i, ensure, i2b
 from basicswap.util.script import decodePushData, decodeScriptNum
@@ -1145,6 +1145,28 @@ class BCHInterface(BTCInterface):
 
     def lockNonSegwitPrevouts(self) -> None:
         pass
+
+    def isMercyTx(self, tx: dict, vout: int) -> Optional[bytes]:
+        # Returns the keyshare if tx matches the mercy tx format created by
+        # createMercyTx: an OP_RETURN "XBSW" keyshare output at vout 0 and a
+        # dust limit output paying the watched script.
+        if len(tx["vout"]) < 2:
+            return None
+        if self.make_int(tx["vout"][vout]["value"]) != 546:
+            return None
+        try:
+            op_return_script = bytes.fromhex(tx["vout"][0]["scriptPubKey"]["hex"])
+            if (
+                len(op_return_script) == 39
+                and op_return_script[:6] == bytes((0x6A, 0x04)) + b"XBSW"
+                and op_return_script[6] == 0x20
+            ):
+                keyshare = op_return_script[7:]
+                if self.verifyKey(keyshare):
+                    return keyshare
+        except Exception as e:
+            self._log.debug(f"isMercyTx check failed: {e}")
+        return None
 
     def createMercyTx(
         self,

--- a/basicswap/interface/btc/btc.py
+++ b/basicswap/interface/btc/btc.py
@@ -1083,6 +1083,15 @@ class BTCInterface(FeeValidator, Secp256k1Interface):
                     fee_sat_vb = self._backend.estimateFee(conf_target)
                     if fee_sat_vb and fee_sat_vb > 0:
                         fee_rate = (fee_sat_vb * 1000) / 1e8
+                        if (
+                            self._high_feerate > 0
+                            and self.make_int(fee_rate) > self._high_feerate
+                        ):
+                            self._log.warning(
+                                f"Electrum fee estimate {fee_rate} for {self.coin_name()} "
+                                f"exceeds high_feerate {self._high_feerate}, using default"
+                            )
+                            return 0.00001, "electrum_default"
                         return fee_rate, "electrum"
                 except Exception as e:
                     self._log.debug(f"Electrum estimateFee failed: {e}")
@@ -2949,6 +2958,8 @@ class BTCInterface(FeeValidator, Secp256k1Interface):
         lock_tx_vout: int,
         script_pk: bytes,
     ) -> (int, int):
+        locked_n = None
+        actual_value = None
         if self.useBackend():
             backend = self.getBackend()
             tx_hex = backend.getTransactionRaw(chain_b_lock_txid.hex())
@@ -2970,7 +2981,6 @@ class BTCInterface(FeeValidator, Secp256k1Interface):
                 self._log.warning(
                     f"spendBLockTx: Failed to fetch tx {self._log.id(chain_b_lock_txid)} from backend"
                 )
-                locked_n = lock_tx_vout
             return locked_n, actual_value
         wtx = self.rpc_wallet_watch(
             "gettransaction",
@@ -4689,6 +4699,7 @@ class BTCInterface(FeeValidator, Secp256k1Interface):
             [prevouts_to_spend, {addr_to: self.format_amount(total_amount)}],
         )
         fee_rate, rate_src = self.get_fee_rate(self._conf_target)
+        self._ensureFeeRateWithinMax(fee_rate, rate_src)
         fee_rate_str: str = self.format_amount(fee_rate, True, 1)
         self._log.debug(
             f"Using fee rate: {fee_rate_str}, src: {rate_src}, confirms target: {self._conf_target}"

--- a/basicswap/wallet_manager.py
+++ b/basicswap/wallet_manager.py
@@ -811,10 +811,24 @@ class WalletManager:
                 (int(coin_type), address),
             )
             row = cursor.fetchone()
+            if not row or not row[0]:
+                conn.close()
+                return None
+            encrypted_key = row[0]
+            private_key = self._decryptPrivateKey(encrypted_key, coin_type)
+            if not self._isAEADImportKey(encrypted_key):
+                cursor.execute(
+                    "UPDATE wallet_watch_only SET private_key_encrypted = ? WHERE coin_type = ? AND address = ?",
+                    (
+                        self._encryptPrivateKey(private_key, coin_type),
+                        int(coin_type),
+                        address,
+                    ),
+                )
+                conn.commit()
+                self._log.info("Migrated legacy imported key to AEAD format")
             conn.close()
-            return (
-                self._decryptPrivateKey(row[0], coin_type) if row and row[0] else None
-            )
+            return private_key
         except Exception:
             return None
 


### PR DESCRIPTION
- Fix crash when the Electrum backend fails to return the chain B lock tx or its output; now fails closed with a clear error.
- Clamp Electrum fee estimates to the configured high_feerate maximum; prevents fee-inflation griefing by a malicious server.
- Auto-migrate legacy XOR-encrypted imported keys to AEAD (ChaCha20-Poly1305) on first access.
Keep BCH mercy tx watch alive when an unrelated tx pays the watched script; verify the XBSW marker and keyshare first.
- Validate and rate-limit Simplex connection request invitations before passing to /connect.
- Only dispatch route links belonging to the connected route on Simplex contact-connected events.
- Act on Electrum-reported spends only once confirmed, matching full-node behaviour.
- Move isMercyTx to a function.