### PR TITLE
core: don't attempt queued actions while system is locked

### DIFF
--- a/basicswap/basicswap.py
+++ b/basicswap/basicswap.py
@@ -10386,6 +10386,9 @@ class BasicSwap(BaseApp, BSXNetwork, UIApp):
         return q[0]
 
     def checkQueuedActions(self) -> None:
+        if self.isSystemUnlocked() is False:
+            self.log.info("Not checking queued actions.  System is locked.")
+            return
         now: int = self.getTime()
         reload_in_progress: bool = False
         try:


### PR DESCRIPTION
fixes issue:

if you had a swap in progress, thing such as attempted redeems would be retried while system was locked