### PR TITLE
fix: avoid UnboundLocalError in getBLockTxo error paths

### DIFF
--- a/basicswap/interface/btc/btc.py
+++ b/basicswap/interface/btc/btc.py
@@ -2949,6 +2949,7 @@ class BTCInterface(FeeValidator, Secp256k1Interface):
         lock_tx_vout: int,
         script_pk: bytes,
     ) -> (int, int):
+        actual_value = None  # default; error branches below don't set it
         if self.useBackend():
             backend = self.getBackend()
             tx_hex = backend.getTransactionRaw(chain_b_lock_txid.hex())


### PR DESCRIPTION
`getBLockTxo` only assigns `actual_value` on the success path, where the
output is found in a fetched tx. On the two error paths, output not found
in the tx, or the backend failing to fetch the tx, `actual_value` is left
unset, so `return locked_n, actual_value` raises `UnboundLocalError`.

The caller `spendBLockTx` is already written to handle a missing result:
it does `ensure(locked_n is not None, "Output not found in tx")` and guards
the value with `if actual_value is not None`. It just never reaches that
handling because `getBLockTxo` raises first.

This defaults `actual_value` to `None` at the top of the function so both
error paths return normally and the caller's existing handling runs. The
success path is unchanged. Affects both the Electrum backend and RPC
branches.