### PR TITLE
refactor gpg verification

### DIFF
--- a/basicswap/bin/prepare.py
+++ b/basicswap/bin/prepare.py
@@ -46,8 +46,8 @@ from basicswap.bin.run import (
 from basicswap.interface.prepare_util import (
     createGPG,
     ensureFileHashInFile,
+    ensureValidSignatureBy,
     exitWithError,
-    isValidSignature,
     PrepareContext,
     havePubkey,
     getFileHash,
@@ -488,18 +488,6 @@ def testOnionLink():
         "The Tor Project's free software protects your privacy online." in test_response
     )
     logger.info("Onion links work.")
-
-
-def ensureValidSignatureBy(result, signing_key_name):
-    if not isValidSignature(result):
-        raise ValueError("Signature verification failed.")
-
-    if result.fingerprint not in expected_key_ids[signing_key_name]:
-        raise ValueError(
-            "Signature made by unexpected key fingerprint: " + result.fingerprint
-        )
-
-    logger.debug(f"Found valid signature by {signing_key_name} ({result.key_id}).")
 
 
 def prepareCore(coin, version_data, settings, data_dir, extra_opts={}):
@@ -1854,7 +1842,9 @@ def main():
                 importPubkey(gpg, pubkey_filename, pubkeyurls)
             with open(assert_sig_path, "rb") as fp:
                 verified = gpg.verify_file(fp, assert_path)
-            ensureValidSignatureBy(verified, "SimpleX_Chat")
+            ensureValidSignatureBy(
+                verified, "SimpleX_Chat", expected_key_ids, logger, filepath=assert_path
+            )
 
             shutil.copyfile(simplex_chat_release_path, simplex_chat_client_path)
 

--- a/basicswap/bin/prepare.py
+++ b/basicswap/bin/prepare.py
@@ -44,6 +44,7 @@ from basicswap.bin.run import (
 )
 
 from basicswap.interface.prepare_util import (
+    createGPG,
     ensureFileHashInFile,
     exitWithError,
     isValidSignature,
@@ -553,7 +554,7 @@ def tryPrepareCore(coin, version_data, signer, settings, data_dir, extra_opts={}
         )
         return
 
-    gpg = gnupg.GPG()
+    gpg = createGPG(gnupg, extra_opts["prepare_ctx"].gpg_homedir)
 
     keysdirpath = extra_opts.get("keysdirpath", None)
     if keysdirpath is not None:
@@ -1414,6 +1415,7 @@ def main():
         data_dir = os.path.join(os.path.expanduser(cfg.BASICSWAP_DATADIR))
     if bin_dir is None:
         bin_dir = os.path.join(data_dir, "bin")
+    gpg_homedir = os.path.join(data_dir, "gnupg")
 
     logger.info(f"BasicSwap prepare script {__version__}\n")
     logger.info(f"Python version: {platform.python_version()}")
@@ -1431,6 +1433,8 @@ def main():
 
     if not os.path.exists(data_dir):
         os.makedirs(data_dir)
+    if not os.path.exists(gpg_homedir):
+        os.makedirs(gpg_homedir)
     config_path = os.path.join(data_dir, cfg.CONFIG_FILENAME)
 
     config_exists = os.path.exists(config_path)
@@ -1513,6 +1517,7 @@ def main():
         docker_mode=BSX_DOCKER_MODE,
         write_tor_settings=writeTorSettings,
         gnupg=gnupg,
+        gpg_homedir=gpg_homedir,
         wallet_encryption_pwd=WALLET_ENCRYPTION_PWD,
         monerod_proxy_config=monerod_proxy_config,
         monero_wallet_rpc_proxy_config=monero_wallet_rpc_proxy_config,
@@ -1842,7 +1847,7 @@ def main():
             if not os.path.exists(assert_sig_path):
                 downloadFile(assert_sig_url, assert_sig_path)
 
-            gpg = gnupg.GPG()
+            gpg = createGPG(gnupg, extra_opts["prepare_ctx"].gpg_homedir)
             pubkey_filename = "SimpleX_Chat.pgp"
             pubkeyurls = []
             if not havePubkey(gpg, expected_key_ids["SimpleX_Chat"][0]):

--- a/basicswap/interface/bch/core.py
+++ b/basicswap/interface/bch/core.py
@@ -10,6 +10,7 @@ from basicswap.interface.bch.chainparams import params
 from basicswap.interface.prepare_util import (
     CoinPrepareModule,
     PrepareContext,
+    ensurePubkey,
     isValidSignature,
 )
 
@@ -89,13 +90,10 @@ class BCHPrepare(CoinPrepareModule):
         pubkey_filename = self.getPubkeyFilename(signing_key_name)
         pubkeyurls = self.getAllPubkeyUrls(ctx)
 
+        ensurePubkey(gpg, ctx, signing_key_name, self.signers, pubkey_filename, pubkeyurls)
+
         with open(assert_path, "rb") as fp:
             verified = gpg.verify_file(fp)
-        if not isValidSignature(verified) and verified.username is None:
-            ctx.logger.warning("Signature made by unknown key.")
-            ctx.import_pubkey(gpg, pubkey_filename, pubkeyurls)
-            with open(assert_path, "rb") as fp:
-                verified = gpg.verify_file(fp)
 
         self.ensureValidSignatureBy(ctx, verified, signing_key_name)
 

--- a/basicswap/interface/bch/core.py
+++ b/basicswap/interface/bch/core.py
@@ -11,7 +11,6 @@ from basicswap.interface.prepare_util import (
     CoinPrepareModule,
     PrepareContext,
     ensurePubkey,
-    isValidSignature,
 )
 
 BITCOINCASH_VERSION = os.getenv("BITCOINCASH_VERSION", "29.0.0")
@@ -90,12 +89,16 @@ class BCHPrepare(CoinPrepareModule):
         pubkey_filename = self.getPubkeyFilename(signing_key_name)
         pubkeyurls = self.getAllPubkeyUrls(ctx)
 
-        ensurePubkey(gpg, ctx, signing_key_name, self.signers, pubkey_filename, pubkeyurls)
+        ensurePubkey(
+            gpg, ctx, signing_key_name, self.signers, pubkey_filename, pubkeyurls
+        )
 
         with open(assert_path, "rb") as fp:
             verified = gpg.verify_file(fp)
 
-        self.ensureValidSignatureBy(ctx, verified, signing_key_name)
+        self.ensureValidSignatureBy(
+            ctx, verified, signing_key_name, filepath=assert_path
+        )
 
     def getExtractBins(self) -> list:
         bins = ["bitcoind", "bitcoin-cli", "bitcoin-tx"]

--- a/basicswap/interface/btc/core.py
+++ b/basicswap/interface/btc/core.py
@@ -206,7 +206,9 @@ class BTCPrepare(CoinPrepareModule):
             isValidSignature(verified)
             and verified.fingerprint in fastsync_signers["tecnovert"]
         ):
-            self.ensureValidSignatureBy(ctx, verified, "tecnovert", fastsync_signers)
+            self.ensureValidSignatureBy(
+                ctx, verified, "tecnovert", fastsync_signers, filepath=asc_file_path
+            )
         else:
             pubkey_filename = "nicolasdorier.asc"
             if not havePubkey(gpg, fastsync_signers["nicolasdorier"][0]):
@@ -214,7 +216,7 @@ class BTCPrepare(CoinPrepareModule):
             with open(asc_file_path, "rb") as fp:
                 verified = gpg.verify_file(fp)
             self.ensureValidSignatureBy(
-                ctx, verified, "nicolasdorier", fastsync_signers
+                ctx, verified, "nicolasdorier", fastsync_signers, filepath=asc_file_path
             )
 
     def prepareFastsync(self, ctx: PrepareContext, extra_opts):

--- a/basicswap/interface/btc/core.py
+++ b/basicswap/interface/btc/core.py
@@ -13,6 +13,7 @@ from basicswap.interface.btc.chainparams import params
 from basicswap.interface.prepare_util import (
     CoinPrepareModule,
     PrepareContext,
+    createGPG,
     isValidSignature,
     havePubkey,
     getFileHash,
@@ -196,7 +197,7 @@ class BTCPrepare(CoinPrepareModule):
         pubkey_filename = "{}_{}.pgp".format("particl", "tecnovert")
         pubkeyurls = []
 
-        gpg = ctx.gnupg.GPG()
+        gpg = createGPG(ctx.gnupg, ctx.gpg_homedir)
         if not havePubkey(gpg, fastsync_signers["tecnovert"][0]):
             ctx.import_pubkey(gpg, pubkey_filename, pubkeyurls)
         with open(asc_file_path, "rb") as fp:

--- a/basicswap/interface/firo/core.py
+++ b/basicswap/interface/firo/core.py
@@ -13,7 +13,6 @@ from basicswap.interface.prepare_util import (
     ensurePubkey,
     exitWithError,
     generate_salt,
-    isValidSignature,
 )
 
 FIRO_VERSION = os.getenv("FIRO_VERSION", "0.14.16.1")
@@ -98,12 +97,16 @@ class FIROPrepare(CoinPrepareModule):
         pubkey_filename = self.getPubkeyFilename(signing_key_name)
         pubkeyurls = self.getAllPubkeyUrls(ctx)
 
-        ensurePubkey(gpg, ctx, signing_key_name, self.signers, pubkey_filename, pubkeyurls)
+        ensurePubkey(
+            gpg, ctx, signing_key_name, self.signers, pubkey_filename, pubkeyurls
+        )
 
         with open(assert_path, "rb") as fp:
             verified = gpg.verify_file(fp)
 
-        self.ensureValidSignatureBy(ctx, verified, signing_key_name)
+        self.ensureValidSignatureBy(
+            ctx, verified, signing_key_name, filepath=assert_path
+        )
 
     def extractCore(
         self,

--- a/basicswap/interface/firo/core.py
+++ b/basicswap/interface/firo/core.py
@@ -10,6 +10,7 @@ from basicswap.interface.firo.chainparams import params
 from basicswap.interface.prepare_util import (
     CoinPrepareModule,
     PrepareContext,
+    ensurePubkey,
     exitWithError,
     generate_salt,
     isValidSignature,
@@ -97,13 +98,10 @@ class FIROPrepare(CoinPrepareModule):
         pubkey_filename = self.getPubkeyFilename(signing_key_name)
         pubkeyurls = self.getAllPubkeyUrls(ctx)
 
+        ensurePubkey(gpg, ctx, signing_key_name, self.signers, pubkey_filename, pubkeyurls)
+
         with open(assert_path, "rb") as fp:
             verified = gpg.verify_file(fp)
-        if not isValidSignature(verified) and verified.username is None:
-            ctx.logger.warning("Signature made by unknown key.")
-            ctx.import_pubkey(gpg, pubkey_filename, pubkeyurls)
-            with open(assert_path, "rb") as fp:
-                verified = gpg.verify_file(fp)
 
         self.ensureValidSignatureBy(ctx, verified, signing_key_name)
 

--- a/basicswap/interface/nav/core.py
+++ b/basicswap/interface/nav/core.py
@@ -14,7 +14,6 @@ from basicswap.interface.prepare_util import (
     exitWithError,
     getFileHash,
     getOSDirNames,
-    isValidSignature,
 )
 from basicswap.contrib.rpcauth import generate_salt
 
@@ -123,12 +122,16 @@ class NAVPrepare(CoinPrepareModule):
         pubkey_filename = self.getPubkeyFilename(signing_key_name)
         pubkeyurls = self.getAllPubkeyUrls(ctx)
 
-        ensurePubkey(gpg, ctx, signing_key_name, self.signers, pubkey_filename, pubkeyurls)
+        ensurePubkey(
+            gpg, ctx, signing_key_name, self.signers, pubkey_filename, pubkeyurls
+        )
 
         with open(assert_sig_path, "rb") as fp:
             verified = gpg.verify_file(fp)
 
-        self.ensureValidSignatureBy(ctx, verified, signing_key_name)
+        self.ensureValidSignatureBy(
+            ctx, verified, signing_key_name, filepath=assert_sig_path
+        )
 
         # .sig file is not a detached signature, recheck release hash in decrypted data
         release_hash = getFileHash(release_path)

--- a/basicswap/interface/nav/core.py
+++ b/basicswap/interface/nav/core.py
@@ -10,6 +10,7 @@ from basicswap.interface.nav.chainparams import params
 from basicswap.interface.prepare_util import (
     CoinPrepareModule,
     PrepareContext,
+    ensurePubkey,
     exitWithError,
     getFileHash,
     getOSDirNames,
@@ -122,13 +123,10 @@ class NAVPrepare(CoinPrepareModule):
         pubkey_filename = self.getPubkeyFilename(signing_key_name)
         pubkeyurls = self.getAllPubkeyUrls(ctx)
 
+        ensurePubkey(gpg, ctx, signing_key_name, self.signers, pubkey_filename, pubkeyurls)
+
         with open(assert_sig_path, "rb") as fp:
             verified = gpg.verify_file(fp)
-        if not isValidSignature(verified) and verified.username is None:
-            ctx.logger.warning("Signature made by unknown key.")
-            ctx.import_pubkey(gpg, pubkey_filename, pubkeyurls)
-            with open(assert_sig_path, "rb") as fp:
-                verified = gpg.verify_file(fp)
 
         self.ensureValidSignatureBy(ctx, verified, signing_key_name)
 

--- a/basicswap/interface/prepare_util.py
+++ b/basicswap/interface/prepare_util.py
@@ -84,6 +84,13 @@ def havePubkey(gpg, key_id: str) -> bool:
     return False
 
 
+def ensurePubkey(gpg, ctx, signing_key_name, signers, pubkey_filename, pubkeyurls):
+    for fingerprint in signers[signing_key_name]:
+        if havePubkey(gpg, fingerprint):
+            return
+    ctx.import_pubkey(gpg, pubkey_filename, pubkeyurls)
+
+
 def ensureFileHashInFile(release_hash: str, assert_path: str, logger=None) -> None:
     with (
         open(assert_path, "rb", 0) as fp,
@@ -272,13 +279,10 @@ class CoinPrepareModule:
         pubkey_filename = self.getPubkeyFilename(signing_key_name)
         pubkeyurls = self.getAllPubkeyUrls(ctx)
 
+        ensurePubkey(gpg, ctx, signing_key_name, self.signers, pubkey_filename, pubkeyurls)
+
         with open(assert_sig_path, "rb") as fp:
             verified = gpg.verify_file(fp, assert_path)
-        if not isValidSignature(verified) and verified.username is None:
-            ctx.logger.warning("Signature made by unknown key.")
-            ctx.import_pubkey(gpg, pubkey_filename, pubkeyurls)
-            with open(assert_sig_path, "rb") as fp:
-                verified = gpg.verify_file(fp, assert_path)
 
         self.ensureValidSignatureBy(ctx, verified, signing_key_name)
 

--- a/basicswap/interface/prepare_util.py
+++ b/basicswap/interface/prepare_util.py
@@ -37,9 +37,14 @@ class PrepareContext:
     docker_mode: bool = False
     write_tor_settings: Optional[Callable] = None
     gnupg: Optional[Callable] = None
+    gpg_homedir: str = ""
     wallet_encryption_pwd: str = ""
     monerod_proxy_config: Optional[list] = None
     monero_wallet_rpc_proxy_config: Optional[list] = None
+
+
+def createGPG(gnupg_module, homedir):
+    return gnupg_module.GPG(gnupghome=homedir)
 
 
 def exitWithError(error_msg: str):

--- a/basicswap/interface/prepare_util.py
+++ b/basicswap/interface/prepare_util.py
@@ -91,6 +91,20 @@ def ensurePubkey(gpg, ctx, signing_key_name, signers, pubkey_filename, pubkeyurl
     ctx.import_pubkey(gpg, pubkey_filename, pubkeyurls)
 
 
+def ensureValidSignatureBy(result, signing_key_name, signers, logger, filepath):
+    if not isValidSignature(result):
+        raise ValueError("Signature verification failed.")
+
+    if result.fingerprint not in signers[signing_key_name]:
+        raise ValueError(
+            "Signature made by unexpected key fingerprint: " + result.fingerprint
+        )
+
+    logger.info(
+        f'Successfully verified "{os.path.basename(filepath)}" is signed by {signing_key_name} ({result.key_id}).'
+    )
+
+
 def ensureFileHashInFile(release_hash: str, assert_path: str, logger=None) -> None:
     with (
         open(assert_path, "rb", 0) as fp,
@@ -236,20 +250,15 @@ class CoinPrepareModule:
         return pubkeyurls
 
     def ensureValidSignatureBy(
-        self, ctx: PrepareContext, result, signing_key_name: str, signers=None
+        self,
+        ctx: PrepareContext,
+        result,
+        signing_key_name: str,
+        signers=None,
+        filepath=None,
     ) -> None:
-        if signers is None:
-            signers = self.signers
-        if not isValidSignature(result):
-            raise ValueError("Signature verification failed.")
-
-        if result.fingerprint not in signers[signing_key_name]:
-            raise ValueError(
-                "Signature made by unexpected key fingerprint: " + result.fingerprint
-            )
-
-        ctx.logger.debug(
-            f"Found valid signature by {signing_key_name} ({result.key_id})."
+        ensureValidSignatureBy(
+            result, signing_key_name, signers or self.signers, ctx.logger, filepath
         )
 
     def verifyCoreHash(
@@ -279,12 +288,16 @@ class CoinPrepareModule:
         pubkey_filename = self.getPubkeyFilename(signing_key_name)
         pubkeyurls = self.getAllPubkeyUrls(ctx)
 
-        ensurePubkey(gpg, ctx, signing_key_name, self.signers, pubkey_filename, pubkeyurls)
+        ensurePubkey(
+            gpg, ctx, signing_key_name, self.signers, pubkey_filename, pubkeyurls
+        )
 
         with open(assert_sig_path, "rb") as fp:
             verified = gpg.verify_file(fp, assert_path)
 
-        self.ensureValidSignatureBy(ctx, verified, signing_key_name)
+        self.ensureValidSignatureBy(
+            ctx, verified, signing_key_name, filepath=assert_path
+        )
 
     def getExtractBins(self) -> list:
         bins = [self.name + "d", self.name + "-cli", self.name + "-tx"]

--- a/basicswap/interface/xmr/core.py
+++ b/basicswap/interface/xmr/core.py
@@ -10,6 +10,7 @@ from basicswap.interface.xmr.chainparams import params
 from basicswap.interface.prepare_util import (
     CoinPrepareModule,
     PrepareContext,
+    ensurePubkey,
     exitWithError,
     getOSDirNames,
     isValidSignature,
@@ -119,13 +120,10 @@ class XMRPrepare(CoinPrepareModule):
         pubkey_filename = self.getPubkeyFilename(signing_key_name)
         pubkeyurls = self.getAllPubkeyUrls(ctx)
 
+        ensurePubkey(gpg, ctx, signing_key_name, self.signers, pubkey_filename, pubkeyurls)
+
         with open(assert_path, "rb") as fp:
             verified = gpg.verify_file(fp)
-        if not isValidSignature(verified) and verified.username is None:
-            ctx.logger.warning("Signature made by unknown key.")
-            ctx.import_pubkey(gpg, pubkey_filename, pubkeyurls)
-            with open(assert_path, "rb") as fp:
-                verified = gpg.verify_file(fp)
 
         self.ensureValidSignatureBy(ctx, verified, signing_key_name)
 

--- a/basicswap/interface/xmr/core.py
+++ b/basicswap/interface/xmr/core.py
@@ -13,7 +13,6 @@ from basicswap.interface.prepare_util import (
     ensurePubkey,
     exitWithError,
     getOSDirNames,
-    isValidSignature,
 )
 
 MONERO_VERSION = os.getenv("MONERO_VERSION", "0.18.5.0")
@@ -120,12 +119,16 @@ class XMRPrepare(CoinPrepareModule):
         pubkey_filename = self.getPubkeyFilename(signing_key_name)
         pubkeyurls = self.getAllPubkeyUrls(ctx)
 
-        ensurePubkey(gpg, ctx, signing_key_name, self.signers, pubkey_filename, pubkeyurls)
+        ensurePubkey(
+            gpg, ctx, signing_key_name, self.signers, pubkey_filename, pubkeyurls
+        )
 
         with open(assert_path, "rb") as fp:
             verified = gpg.verify_file(fp)
 
-        self.ensureValidSignatureBy(ctx, verified, signing_key_name)
+        self.ensureValidSignatureBy(
+            ctx, verified, signing_key_name, filepath=assert_path
+        )
 
     def usesWalletRpcDaemonForInit(self) -> bool:
         return True


### PR DESCRIPTION
- Use a separate gpg homedir for BSX: DATADIR/gnupg
  - For users who don't run docker
- Import the pgp pubkey before trying to verify a signature
  - Avoids the "Signature made by unknown key." warnings
- De-duplicate ensureValidSignatureBy, add filename to log