### PR TITLE
AMM: Allow duplicate template names; restore default offer name.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,6 +133,7 @@ jobs:
           - name: test_other
             command: |
               pytest tests/basicswap/test_other.py
+              pytest tests/basicswap/test_amm_config_api.py
           - name: test_prepare
             command: |
               export PYTHONPATH=$(pwd)

--- a/basicswap/static/js/pages/amm-tables.js
+++ b/basicswap/static/js/pages/amm-tables.js
@@ -1519,7 +1519,7 @@ const AmmTablesManager = (function() {
 
         document.getElementById('add-amm-type').value = type;
 
-        document.getElementById('add-amm-name').value = '';
+        document.getElementById('add-amm-name').value = 'Unnamed Offer';
         document.getElementById('add-amm-enabled').checked = true;
 
         const coinFromSelect = document.getElementById('add-amm-coin-from');
@@ -1871,16 +1871,6 @@ const AmmTablesManager = (function() {
                 }
             }
 
-            const existingList = type === 'offer' ? config.offers : config.bids;
-            if (Array.isArray(existingList) && existingList.some(item => item && item.name === name)) {
-                if (window.showErrorModal) {
-                    window.showErrorModal('Validation Error', `A ${type} template named "${name}" already exists.`);
-                } else {
-                    alert(`A ${type} template named "${name}" already exists.`);
-                }
-                return;
-            }
-
             if (type === 'offer') {
                 if (!Array.isArray(config.offers)) {
                     config.offers = [];
@@ -2204,16 +2194,6 @@ const AmmTablesManager = (function() {
                 originalItem = config.bids.find(item =>
                     (id && item.id === id) || (!id && item.name === originalName)
                 );
-            }
-
-            const targetList = type === 'offer' ? config.offers : config.bids;
-            if (Array.isArray(targetList) && targetList.some(item => item && item !== originalItem && item.name === name)) {
-                if (window.showErrorModal) {
-                    window.showErrorModal('Validation Error', `A ${type} template named "${name}" already exists.`);
-                } else {
-                    alert(`A ${type} template named "${name}" already exists.`);
-                }
-                return;
             }
 
             const updatedItem = Object.assign({}, originalItem || {}, {

--- a/basicswap/ui/page_amm.py
+++ b/basicswap/ui/page_amm.py
@@ -1007,16 +1007,6 @@ def page_amm(self, _, post_string):
                     if "offers" not in current_config:
                         current_config["offers"] = []
 
-                    if any(
-                        o.get("name") == new_offer["name"]
-                        for o in current_config["offers"]
-                        if isinstance(o, dict)
-                    ):
-                        err_messages.append(
-                            f"An offer template named '{new_offer['name']}' already exists"
-                        )
-                        raise ValueError("duplicate template name")
-
                     current_config["offers"].append(new_offer)
 
                     with open(config_path, "w") as f:
@@ -1094,16 +1084,6 @@ def page_amm(self, _, post_string):
 
                     if "bids" not in current_config:
                         current_config["bids"] = []
-
-                    if any(
-                        b.get("name") == new_bid["name"]
-                        for b in current_config["bids"]
-                        if isinstance(b, dict)
-                    ):
-                        err_messages.append(
-                            f"A bid template named '{new_bid['name']}' already exists"
-                        )
-                        raise ValueError("duplicate template name")
 
                     current_config["bids"].append(new_bid)
 
@@ -1376,7 +1356,6 @@ def validate_amm_config(config_data):
         errors.append("'offers' must be a list")
         offers = []
 
-    seen_offer_names = set()
     for idx, offer in enumerate(offers):
         if not isinstance(offer, dict):
             errors.append(f"Offer #{idx + 1} must be an object")
@@ -1387,10 +1366,6 @@ def validate_amm_config(config_data):
         name = offer.get("name", "")
         if not name or not str(name).strip():
             errors.append(f"{label}: name is required")
-        elif name in seen_offer_names:
-            errors.append(f"{label}: duplicate template name")
-        else:
-            seen_offer_names.add(name)
 
         coin_from = offer.get("coin_from", "")
         coin_to = offer.get("coin_to", "")
@@ -1457,7 +1432,6 @@ def validate_amm_config(config_data):
         errors.append("'bids' must be a list")
         bids = []
 
-    seen_bid_names = set()
     for idx, bid in enumerate(bids):
         if not isinstance(bid, dict):
             errors.append(f"Bid #{idx + 1} must be an object")
@@ -1466,10 +1440,6 @@ def validate_amm_config(config_data):
         name = bid.get("name", "")
         if not name or not str(name).strip():
             errors.append(f"{label}: name is required")
-        elif name in seen_bid_names:
-            errors.append(f"{label}: duplicate template name")
-        else:
-            seen_bid_names.add(name)
         if not bid.get("coin_from") or not bid.get("coin_to"):
             errors.append(f"{label}: both coin_from and coin_to are required")
         elif bid.get("coin_from") == bid.get("coin_to"):

--- a/tests/basicswap/test_amm_config_api.py
+++ b/tests/basicswap/test_amm_config_api.py
@@ -37,11 +37,13 @@ class AmmConfigValidationTest(unittest.TestCase):
         errors = validate_amm_config({"offers": [offer]})
         self.assertTrue(any("name is required" in e for e in errors))
 
-    def test_duplicate_names_reported(self):
+    def test_duplicate_names_allowed(self):
+        # createoffers.py de-duplicates template names on load (name -> name_2),
+        # so the config layer must not reject duplicates.
         offer = self._valid_standing_offer()
         config = {"offers": [dict(offer), dict(offer)]}
         errors = validate_amm_config(config)
-        self.assertTrue(any("duplicate template name" in e for e in errors))
+        self.assertFalse(any("duplicate template name" in e for e in errors))
 
     def test_same_coin_reported(self):
         offer = self._valid_standing_offer()


### PR DESCRIPTION
- Remove duplicate template name rejection from the AMM add/edit UI.
- Remove duplicate name checks when creating offer/bid templates via the API.
- Remove duplicate name validation from validate_amm_config() for offers and bids.
- Pre-fill new template modal with "Unnamed Offer" again instead of an empty name.
- Update test: duplicate names are allowed (aligned with createoffers.py, which renames name → name_2, etc. on load).

@nahuhh Thanks for testing!