### PR TITLE
Fix: Align single-offer contract lock presets with AMM.

### DIFF
--- a/basicswap/templates/offer_new_2.html
+++ b/basicswap/templates/offer_new_2.html
@@ -54,10 +54,10 @@
             <label class="block mb-1.5 text-sm font-medium text-coolGray-800 dark:text-white">Contract locked (hours)</label>
             <div class="relative">
               <div class="flex absolute inset-y-0 left-0 items-center pl-3 pointer-events-none">{{ input_time_svg | safe }}</div>
-              <input class="pl-10 hover:border-blue-500 bg-gray-50 text-gray-900 appearance-none pr-3 dark:bg-gray-500 dark:text-white border border-gray-300 dark:border-gray-400 dark:text-gray-50 dark:placeholder-white text-sm rounded-lg outline-none focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5 focus:ring-0" type="number" name="lockhrs" min="1" max="96" value="{{ data.lockhrs }}">
+              <input class="pl-10 hover:border-blue-500 bg-gray-50 text-gray-900 appearance-none pr-3 dark:bg-gray-500 dark:text-white border border-gray-300 dark:border-gray-400 dark:text-gray-50 dark:placeholder-white text-sm rounded-lg outline-none focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5 focus:ring-0" type="number" name="lockhrs" min="1" max="24" value="{{ data.lockhrs }}">
             </div>
             <div class="mt-2 flex flex-wrap gap-2">
-              {% for h in [12, 24, 48, 72] %}
+              {% for h in [4, 8, 12, 24] %}
               <button type="button" data-set-value="{{ h }}" data-target-name="lockhrs" class="py-1 px-2 bg-blue-500 hover:bg-blue-600 text-white text-xs rounded-md focus:outline-none">{{ h }}h</button>
               {% endfor %}
             </div>

--- a/basicswap/ui/page_offers.py
+++ b/basicswap/ui/page_offers.py
@@ -705,7 +705,7 @@ def page_newoffer(self, url_split, post_string, get_string=""):
         "fee_from_conf": 2,
         "fee_to_conf": 2,
         "validhrs": 1,
-        "lockhrs": 32,
+        "lockhrs": 24,
         "lockmins": 30,  # used in debug mode
         "debug_ui": swap_client.debug_ui,
         "automation_strat_id": -1,


### PR DESCRIPTION
- Update single-offer contract lock presets from 12|24|48|72 to 4|8|12|24 to match the AMM UI.
- Change the default contract lock from 32 hours to 24 hours.
- Cap the manual lock-hours input at 24 hours (was 96).