### PR TITLE
Bid page: WebSocket live updates and clearer state descriptions.

### DIFF
--- a/basicswap/basicswap.py
+++ b/basicswap/basicswap.py
@@ -519,6 +519,7 @@ class BasicSwap(BaseApp, BSXNetwork, UIApp):
         self._price_cache = {}
         self._volume_cache = {}
         self._historical_cache = {}
+        self._pending_bid_notifications = set()
         self._price_cache_lock = threading.Lock()
         self._price_fetch_thread = None
         self._price_fetch_running = False
@@ -5215,6 +5216,8 @@ class BasicSwap(BaseApp, BSXNetwork, UIApp):
                 raise ValueError("Must specify offer for save_in_progress")
             self.swaps_in_progress[bid_id] = (bid, save_in_progress)  # (bid, offer)
 
+        self.notifyBidChanged(bid_id)
+
     def saveBid(self, bid_id: bytes, bid, xmr_swap=None, cursor=None) -> None:
         try:
             use_cursor = self.openDB(cursor)
@@ -5284,6 +5287,36 @@ class BasicSwap(BaseApp, BSXNetwork, UIApp):
     ) -> None:
         self.log.debug(f"logBidEvent {self.log.id(bid_id)} {event_type} {event_msg}")
         self.logEvent(Concepts.BID, bid_id, event_type, event_msg, cursor)
+        self.notifyBidChanged(bid_id)
+
+    def notifyBidChanged(self, bid_id: bytes) -> None:
+        if not self.ws_server:
+            return
+        if self._db_lock_held():
+            self._pending_bid_notifications.add(bid_id)
+        else:
+            self._broadcastBidChanged(bid_id)
+
+    def _broadcastBidChanged(self, bid_id: bytes) -> None:
+        if not self.ws_server:
+            return
+        try:
+            self.ws_server.send_message_to_all(
+                json.dumps({"event": "bid_changed", "bid_id": bid_id.hex()})
+            )
+        except Exception as e:  # noqa: F841
+            self.log.debug(f"notifyBidChanged failed: {e}")
+
+    def _onDBCommitted(self) -> None:
+        pending = self._pending_bid_notifications
+        if not pending:
+            return
+        self._pending_bid_notifications = set()
+        for bid_id in pending:
+            self._broadcastBidChanged(bid_id)
+
+    def _onDBRolledBack(self) -> None:
+        self._pending_bid_notifications.clear()
 
     def countEvents(
         self, linked_type: int, linked_id: bytes, event_type: int, cursor

--- a/basicswap/db.py
+++ b/basicswap/db.py
@@ -965,10 +965,18 @@ class DBMethods:
     def commitDB(self):
         assert self._db_lock_held()
         self._db_con.commit()
+        self._onDBCommitted()
 
     def rollbackDB(self):
         assert self._db_lock_held()
         self._db_con.rollback()
+        self._onDBRolledBack()
+
+    def _onDBCommitted(self) -> None:
+        pass
+
+    def _onDBRolledBack(self) -> None:
+        pass
 
     def closeDBCursor(self, cursor):
         assert self._db_lock_held()
@@ -992,6 +1000,11 @@ class DBMethods:
         self._db_con.close()
         self._db_lock_depth = 0
         self.mxDB.release()
+
+        if commit:
+            self._onDBCommitted()
+        else:
+            self._onDBRolledBack()
 
     def setIntKV(self, str_key: str, int_val: int, cursor=None) -> None:
         try:

--- a/basicswap/static/js/pages/bid-page.js
+++ b/basicswap/static/js/pages/bid-page.js
@@ -6,6 +6,13 @@ const BidPage = {
   elapsedTimeInterval: null,
   AUTO_REFRESH_SECONDS: 60,
   refreshPaused: false,
+  wsHandlerId: null,
+  refreshDebounce: null,
+  isRefreshing: false,
+  refreshQueued: false,
+  liveStatusBadge: null,
+  liveStatusHandlersAdded: false,
+  spinAnimation: null,
   swapType: null,
   coinFrom: null,
   coinTo: null,
@@ -189,7 +196,7 @@ const BidPage = {
     this.applyEventTooltips();
     this.createProgressBar();
     this.startElapsedTimeUpdater();
-    this.setupAutoRefresh();
+    this.setupRealtime();
   },
 
   findPreviousState: function() {
@@ -249,77 +256,181 @@ const BidPage = {
     return !this.INACTIVE_STATES.includes(this.bidStateInd);
   },
 
-  setupAutoRefresh: function() {
+  setupRealtime: function() {
     const refreshBtn = document.getElementById('refresh');
-    if (!refreshBtn) return;
-
-    if (!this.isActiveState()) {
-      refreshBtn.style.display = 'none';
-      return;
+    if (refreshBtn) {
+      const span = refreshBtn.querySelector('span');
+      if (span) span.textContent = 'Refresh';
+      refreshBtn.addEventListener('click', (e) => {
+        e.preventDefault();
+        this.refreshLiveContent(true);
+      });
     }
 
-    const originalSpan = refreshBtn.querySelector('span');
-    if (!originalSpan) return;
+    this.setupLiveIndicator();
 
-    let countdown = this.AUTO_REFRESH_SECONDS;
-    let isRefreshing = false;
-    let isPersistentlyPaused = false;
-
-    const updateCountdown = () => {
-      if (this.refreshPaused || isPersistentlyPaused || isRefreshing) return;
-
-      originalSpan.textContent = `Auto-refresh in ${countdown}s`;
-      countdown--;
-
-      if (countdown < 0 && !isRefreshing) {
-        isRefreshing = true;
-        if (this.autoRefreshInterval) {
-          clearInterval(this.autoRefreshInterval);
-          this.autoRefreshInterval = null;
+    if (window.WebSocketManager &&
+        typeof window.WebSocketManager.addMessageHandler === 'function') {
+      this.wsHandlerId = window.WebSocketManager.addMessageHandler('message', (msg) => {
+        if (!msg || msg.bid_id !== this.bidId) return;
+        const ev = msg.event;
+        if (ev === 'bid_changed' || ev === 'bid_accepted' ||
+            ev === 'swap_completed' || ev === 'new_bid') {
+          this.scheduleRefresh();
         }
-        window.location.href = window.location.pathname + window.location.search;
-      }
-    };
+      });
+    }
+  },
 
-    updateCountdown();
-    this.autoRefreshInterval = setInterval(updateCountdown, 1000);
+  setupLiveIndicator: function() {
+    const badge = document.getElementById('bid-live-status');
+    if (!badge) return;
 
-    refreshBtn.addEventListener('click', (e) => {
-      e.preventDefault();
+    const oldDot = document.getElementById('bid-live-dot');
+    if (oldDot) oldDot.remove();
 
-      if (isPersistentlyPaused) {
-        window.location.href = window.location.pathname + window.location.search;
-      } else {
-        isPersistentlyPaused = true;
-        if (this.autoRefreshInterval) {
-          clearInterval(this.autoRefreshInterval);
-          this.autoRefreshInterval = null;
+    this.liveStatusBadge = badge;
+
+    const wm = window.WebSocketManager;
+    const connected = !!(wm && typeof wm.isConnected === 'function' && wm.isConnected());
+    this.setLiveStatus(connected);
+    if (!this.liveStatusHandlersAdded &&
+        wm && typeof wm.addMessageHandler === 'function') {
+      this.liveStatusHandlersAdded = true;
+      wm.addMessageHandler('connect', () => this.setLiveStatus(true));
+      wm.addMessageHandler('disconnect', () => this.setLiveStatus(false));
+      wm.addMessageHandler('error', () => this.setLiveStatus(false));
+    }
+  },
+
+  setLiveStatus: function(connected) {
+    if (!this.liveStatusBadge) return;
+    const chipClass =
+      'inline-flex items-center px-3 py-1.5 rounded-full bg-white bg-opacity-10 text-xs font-medium text-white';
+    if (connected) {
+      this.liveStatusBadge.className = chipClass;
+      this.liveStatusBadge.title = 'Live updates connected';
+      this.liveStatusBadge.innerHTML =
+        '<span class="relative flex h-2 w-2 mr-2">' +
+        '<span class="animate-ping absolute inline-flex h-full w-full rounded-full bg-green-400 opacity-75"></span>' +
+        '<span class="relative inline-flex rounded-full h-2 w-2 bg-green-400"></span>' +
+        '</span>Live';
+    } else {
+      this.liveStatusBadge.className = chipClass;
+      this.liveStatusBadge.title = 'Live updates disconnected — click Refresh to update';
+      this.liveStatusBadge.innerHTML =
+        '<span class="relative flex h-2 w-2 mr-2">' +
+        '<span class="relative inline-flex rounded-full h-2 w-2 bg-gray-400"></span>' +
+        '</span>Offline';
+    }
+  },
+
+  startIconSpin: function() {
+    if (this.spinAnimation) return;
+    const refreshBtn = document.getElementById('refresh');
+    const icon = refreshBtn ? refreshBtn.querySelector('svg') : null;
+    if (!icon || typeof icon.animate !== 'function') return;
+    icon.style.transformOrigin = 'center';
+    this.spinAnimation = icon.animate(
+      [{ transform: 'rotate(0deg)' }, { transform: 'rotate(360deg)' }],
+      { duration: 700, iterations: Infinity }
+    );
+  },
+
+  stopIconSpin: function() {
+    if (!this.spinAnimation) return;
+    this.spinAnimation.cancel();
+    this.spinAnimation = null;
+  },
+
+  scheduleRefresh: function() {
+    if (this.refreshDebounce) {
+      clearTimeout(this.refreshDebounce);
+    }
+    this.refreshDebounce = setTimeout(() => {
+      this.refreshDebounce = null;
+      this.refreshLiveContent(false);
+    }, 500);
+  },
+
+  canSwapActions: function(el) {
+    if (!el) return false;
+    if (el.getAttribute('data-interactive') === '1') return false;
+    const active = document.activeElement;
+    if (active && el.contains(active) &&
+        ['INPUT', 'SELECT', 'TEXTAREA'].indexOf(active.tagName) !== -1) {
+      return false;
+    }
+    return true;
+  },
+
+  refreshLiveContent: function(force) {
+    if (this.isRefreshing) {
+      this.refreshQueued = true;
+      return;
+    }
+    if (!document.getElementById('bid-live-content')) return;
+    this.isRefreshing = true;
+    this.startIconSpin();
+    const spinStart = Date.now();
+
+    const url = window.location.pathname + window.location.search;
+    fetch(url, {
+      credentials: 'same-origin',
+      headers: { 'X-Requested-With': 'XMLHttpRequest' }
+    })
+      .then((r) => r.text())
+      .then((html) => {
+        const doc = new DOMParser().parseFromString(html, 'text/html');
+
+        const freshInfo = doc.getElementById('bid-live-content');
+        const curInfo = document.getElementById('bid-live-content');
+        if (freshInfo && curInfo) {
+          const importedInfo = document.importNode(freshInfo, true);
+          curInfo.replaceWith(importedInfo);
+          const newInd = parseInt(importedInfo.getAttribute('data-bid-state-ind'), 10);
+          if (!isNaN(newInd)) {
+            this.bidStateInd = newInd;
+          }
         }
-        originalSpan.textContent = 'Paused (click to refresh)';
-      }
-    });
 
-    refreshBtn.addEventListener('mouseenter', () => {
-      if (!isPersistentlyPaused) {
-        this.refreshPaused = true;
-        if (this.autoRefreshInterval) {
-          clearInterval(this.autoRefreshInterval);
-          this.autoRefreshInterval = null;
+        const curActions = document.getElementById('bid-actions-content');
+        const freshActions = doc.getElementById('bid-actions-content');
+        if (curActions && freshActions && (force || this.canSwapActions(curActions))) {
+          const importedActions = document.importNode(freshActions, true);
+          curActions.replaceWith(importedActions);
+          if (typeof window.setupBidConfirmDialog === 'function') {
+            try { window.setupBidConfirmDialog(); } catch (e) { /* ignore */ }
+          }
         }
-        originalSpan.textContent = 'Click to pause';
-      }
-    });
 
-    refreshBtn.addEventListener('mouseleave', () => {
-      if (!isPersistentlyPaused) {
-        this.refreshPaused = false;
-        countdown = this.AUTO_REFRESH_SECONDS;
-        if (!this.autoRefreshInterval) {
-          updateCountdown();
-          this.autoRefreshInterval = setInterval(updateCountdown, 1000);
+        this.reinitLiveContent();
+      })
+      .catch(() => { /* keep current content on failure */ })
+      .finally(() => {
+        this.isRefreshing = false;
+        setTimeout(() => {
+          if (!this.isRefreshing) this.stopIconSpin();
+        }, Math.max(0, 500 - (Date.now() - spinStart)));
+        if (this.refreshQueued) {
+          this.refreshQueued = false;
+          this.scheduleRefresh();
         }
-      }
-    });
+      });
+  },
+
+  reinitLiveContent: function() {
+    if (this.elapsedTimeInterval) {
+      clearInterval(this.elapsedTimeInterval);
+      this.elapsedTimeInterval = null;
+    }
+    if (this.bidStateInd === this.DELAYING_STATE) {
+      this.previousStateInd = this.findPreviousState();
+    }
+    try { this.applyStateTooltips(); } catch (e) { /* ignore */ }
+    try { this.applyEventTooltips(); } catch (e) { /* ignore */ }
+    try { this.createProgressBar(); } catch (e) { /* ignore */ }
+    try { this.startElapsedTimeUpdater(); } catch (e) { /* ignore */ }
   },
 
   createTooltip: function(element, tooltipText) {

--- a/basicswap/static/js/pages/bid-page.js
+++ b/basicswap/static/js/pages/bid-page.js
@@ -10,8 +10,8 @@ const BidPage = {
   refreshDebounce: null,
   isRefreshing: false,
   refreshQueued: false,
-  liveStatusBadge: null,
-  liveStatusHandlersAdded: false,
+  liveStatusDot: null,
+  liveStatusRecheckTimer: null,
   spinAnimation: null,
   swapType: null,
   coinFrom: null,
@@ -259,8 +259,10 @@ const BidPage = {
   setupRealtime: function() {
     const refreshBtn = document.getElementById('refresh');
     if (refreshBtn) {
-      const span = refreshBtn.querySelector('span');
-      if (span) span.textContent = 'Refresh';
+      const label = refreshBtn.lastElementChild;
+      if (label && label.tagName === 'SPAN' && label.id !== 'bid-live-dot') {
+        label.textContent = 'Refresh';
+      }
       refreshBtn.addEventListener('click', (e) => {
         e.preventDefault();
         this.refreshLiveContent(true);
@@ -276,52 +278,59 @@ const BidPage = {
         const ev = msg.event;
         if (ev === 'bid_changed' || ev === 'bid_accepted' ||
             ev === 'swap_completed' || ev === 'new_bid') {
+          this.setLiveStatus(true);
           this.scheduleRefresh();
         }
       });
     }
   },
 
+  isWsConnected: function() {
+    const wm = window.WebSocketManager;
+    return !!(wm && typeof wm.isConnected === 'function' && wm.isConnected());
+  },
+
   setupLiveIndicator: function() {
-    const badge = document.getElementById('bid-live-status');
-    if (!badge) return;
+    const refreshBtn = document.getElementById('refresh');
+    const dot = document.getElementById('bid-live-dot');
+    if (!refreshBtn || !dot) return;
 
-    const oldDot = document.getElementById('bid-live-dot');
-    if (oldDot) oldDot.remove();
-
-    this.liveStatusBadge = badge;
+    this.liveStatusDot = dot;
+    this.syncLiveStatus();
 
     const wm = window.WebSocketManager;
-    const connected = !!(wm && typeof wm.isConnected === 'function' && wm.isConnected());
-    this.setLiveStatus(connected);
-    if (!this.liveStatusHandlersAdded &&
-        wm && typeof wm.addMessageHandler === 'function') {
-      this.liveStatusHandlersAdded = true;
+    if (wm && typeof wm.addMessageHandler === 'function') {
       wm.addMessageHandler('connect', () => this.setLiveStatus(true));
       wm.addMessageHandler('disconnect', () => this.setLiveStatus(false));
       wm.addMessageHandler('error', () => this.setLiveStatus(false));
     }
+
+    if (this.liveStatusRecheckTimer) {
+      clearTimeout(this.liveStatusRecheckTimer);
+    }
+    this.liveStatusRecheckTimer = setTimeout(() => this.syncLiveStatus(), 500);
+  },
+
+  syncLiveStatus: function() {
+    this.setLiveStatus(this.isWsConnected());
   },
 
   setLiveStatus: function(connected) {
-    if (!this.liveStatusBadge) return;
-    const chipClass =
-      'inline-flex items-center px-3 py-1.5 rounded-full bg-white bg-opacity-10 text-xs font-medium text-white';
+    if (!this.liveStatusDot) return;
+    const refreshBtn = document.getElementById('refresh');
     if (connected) {
-      this.liveStatusBadge.className = chipClass;
-      this.liveStatusBadge.title = 'Live updates connected';
-      this.liveStatusBadge.innerHTML =
-        '<span class="relative flex h-2 w-2 mr-2">' +
+      if (refreshBtn) {
+        refreshBtn.title = 'Live updates connected';
+      }
+      this.liveStatusDot.innerHTML =
         '<span class="animate-ping absolute inline-flex h-full w-full rounded-full bg-green-400 opacity-75"></span>' +
-        '<span class="relative inline-flex rounded-full h-2 w-2 bg-green-400"></span>' +
-        '</span>Live';
+        '<span class="relative inline-flex rounded-full h-2 w-2 bg-green-400"></span>';
     } else {
-      this.liveStatusBadge.className = chipClass;
-      this.liveStatusBadge.title = 'Live updates disconnected — click Refresh to update';
-      this.liveStatusBadge.innerHTML =
-        '<span class="relative flex h-2 w-2 mr-2">' +
-        '<span class="relative inline-flex rounded-full h-2 w-2 bg-gray-400"></span>' +
-        '</span>Offline';
+      if (refreshBtn) {
+        refreshBtn.title = 'Live updates disconnected — click Refresh to update';
+      }
+      this.liveStatusDot.innerHTML =
+        '<span class="relative inline-flex rounded-full h-2 w-2 bg-gray-400"></span>';
     }
   },
 

--- a/basicswap/templates/bid.html
+++ b/basicswap/templates/bid.html
@@ -25,14 +25,11 @@
       <h2 class="mb-6 text-4xl font-bold text-white tracking-tighter">Bid {% if debug_mode == true %} (Debug: bid template) {% endif %}</h2>
       <p class="font-normal text-coolGray-200 dark:text-white"><span class="bold">BID ID:</span> {{ bid_id }}</p>
      </div>
-     <div class="w-full md:w-1/2 p-3 p-6 flex flex-wrap items-center justify-end gap-3 mx-auto">
-      <span id="bid-live-status" class="inline-flex items-center px-3 py-1.5 rounded-full bg-white bg-opacity-10 text-xs font-medium text-white" title="Live updates disconnected — click Refresh to update">
-        <span class="relative flex h-2 w-2 mr-2">
+     <div class="w-full md:w-1/2 p-3 p-6 flex flex-wrap items-center justify-end mx-auto">
+      <a id="refresh" href="/bid/{{ bid_id }}" class="inline-flex items-center gap-2 rounded-full px-5 py-3 bg-blue-500 hover:bg-blue-600 font-medium text-sm text-white border dark:bg-gray-500 dark:hover:bg-gray-700 border-blue-500 rounded-md shadow-button focus:ring-0 focus:outline-none" title="Live updates disconnected — click Refresh to update">
+        <span id="bid-live-dot" class="relative flex h-2 w-2 shrink-0">
           <span class="relative inline-flex rounded-full h-2 w-2 bg-gray-400"></span>
         </span>
-        Offline
-      </span>
-      <a id="refresh" href="/bid/{{ bid_id }}"  class="rounded-full flex flex-wrap justify-center px-5 py-3 bg-blue-500 hover:bg-blue-600 font-medium text-sm text-white border dark:bg-gray-500 dark:hover:bg-gray-700 border-blue-500 rounded-md shadow-button focus:ring-0 focus:outline-none">
         {{ circular_arrows_svg | safe }}
        <span>Refresh</span>
       </a>

--- a/basicswap/templates/bid.html
+++ b/basicswap/templates/bid.html
@@ -25,24 +25,24 @@
       <h2 class="mb-6 text-4xl font-bold text-white tracking-tighter">Bid {% if debug_mode == true %} (Debug: bid template) {% endif %}</h2>
       <p class="font-normal text-coolGray-200 dark:text-white"><span class="bold">BID ID:</span> {{ bid_id }}</p>
      </div>
-     <div class="w-full md:w-1/2 p-3 p-6 container flex flex-wrap items-center justify-end items-center mx-auto">
-      {% if refresh %}
-      <a id="refresh" href="/bid/{{ bid_id }}"  class="rounded-full flex flex-wrap justify-center px-5 py-3 bg-blue-500 hover:bg-blue-600 font-medium text-sm text-white border dark:bg-gray-500 dark:hover:bg-gray-700 border-blue-500 rounded-md shadow-button focus:ring-0 focus:outline-none">
-        {{ circular_arrows_svg | safe }}
-       <span>Refresh {{ refresh }} seconds</span>
-      </a>
-      {% else %}
+     <div class="w-full md:w-1/2 p-3 p-6 flex flex-wrap items-center justify-end gap-3 mx-auto">
+      <span id="bid-live-status" class="inline-flex items-center px-3 py-1.5 rounded-full bg-white bg-opacity-10 text-xs font-medium text-white" title="Live updates disconnected — click Refresh to update">
+        <span class="relative flex h-2 w-2 mr-2">
+          <span class="relative inline-flex rounded-full h-2 w-2 bg-gray-400"></span>
+        </span>
+        Offline
+      </span>
       <a id="refresh" href="/bid/{{ bid_id }}"  class="rounded-full flex flex-wrap justify-center px-5 py-3 bg-blue-500 hover:bg-blue-600 font-medium text-sm text-white border dark:bg-gray-500 dark:hover:bg-gray-700 border-blue-500 rounded-md shadow-button focus:ring-0 focus:outline-none">
         {{ circular_arrows_svg | safe }}
        <span>Refresh</span>
       </a>
-    {% endif %}
       </div>
     </div>
    </div>
   </div>
  </section>
  {% include 'inc_messages.html' %}
+ <div id="bid-live-content" data-bid-state-ind="{{ data.bid_state_ind }}">
  <section>
   <div class="pl-6 pr-6 pt-0 pb-0 mt-5 h-full overflow-hidden">
    <div class="pb-6 border-coolGray-100">
@@ -336,7 +336,8 @@
  </section>
  {% else %}
  {% endif %}
- <form method="post"> {% if data.show_bidder_seq_diagram %} <section class="p-6">
+ </div>
+ <form method="post" id="bid-actions-content" data-interactive="{% if edit_bid or data.show_txns or data.show_bidder_seq_diagram or data.show_offerer_seq_diagram %}1{% else %}0{% endif %}"> {% if data.show_bidder_seq_diagram %} <section class="p-6">
    <div class="flex flex-wrap items-center">
     <div class="w-full">
      <h4 class="font-semibold text-black dark:text-white text-2xl">Bidder Sequence Diagram</h4>
@@ -601,7 +602,7 @@
        </div>
  </form>
  <script>
-document.addEventListener('DOMContentLoaded', function() {
+window.setupBidConfirmDialog = function() {
   let confirmCallback = null;
   let triggerElement = null;
 
@@ -689,7 +690,8 @@ document.addEventListener('DOMContentLoaded', function() {
 
   const acceptBidBtn = document.querySelector('button[name="accept_bid"]');
   overrideButtonConfirm(acceptBidBtn, 'Accept');
-});
+};
+document.addEventListener('DOMContentLoaded', window.setupBidConfirmDialog);
  </script>
 <script src="/static/js/pages/bid-page.js"></script>
 <script>

--- a/basicswap/templates/bid_xmr.html
+++ b/basicswap/templates/bid_xmr.html
@@ -25,24 +25,24 @@
       <h2 class="mb-6 text-4xl font-bold text-white tracking-tighter">Bid {% if debug_mode == true %} (Debug: bid_xmr template) {% endif %}</h2>
       <p class="font-normal text-coolGray-200 dark:text-white"><span class="bold">BID ID:</span> {{ bid_id }}</p>
      </div>
-     <div class="w-full md:w-1/2 p-3 p-6 container flex flex-wrap items-center justify-end items-center mx-auto">
-      {% if refresh %}
-      <a id="refresh" href="/bid/{{ bid_id }}"  class="rounded-full flex flex-wrap justify-center px-5 py-3 bg-blue-500 hover:bg-blue-600 font-medium text-sm text-white border dark:bg-gray-500 dark:hover:bg-gray-700 border-blue-500 rounded-md shadow-button focus:ring-0 focus:outline-none">
-        {{ circular_arrows_svg | safe }}
-       <span>Refresh {{ refresh }} seconds</span>
-      </a>
-      {% else %}
+     <div class="w-full md:w-1/2 p-3 p-6 flex flex-wrap items-center justify-end gap-3 mx-auto">
+      <span id="bid-live-status" class="inline-flex items-center px-3 py-1.5 rounded-full bg-white bg-opacity-10 text-xs font-medium text-white" title="Live updates disconnected — click Refresh to update">
+        <span class="relative flex h-2 w-2 mr-2">
+          <span class="relative inline-flex rounded-full h-2 w-2 bg-gray-400"></span>
+        </span>
+        Offline
+      </span>
       <a id="refresh" href="/bid/{{ bid_id }}"  class="rounded-full flex flex-wrap justify-center px-5 py-3 bg-blue-500 hover:bg-blue-600 font-medium text-sm text-white border dark:bg-gray-500 dark:hover:bg-gray-700 border-blue-500 rounded-md shadow-button focus:ring-0 focus:outline-none">
         {{ circular_arrows_svg | safe }}
        <span>Refresh</span>
       </a>
-    {% endif %}
-  </div>
+      </div>
     </div>
    </div>
   </div>
  </section>
  {% include 'inc_messages.html' %}
+ <div id="bid-live-content" data-bid-state-ind="{{ data.bid_state_ind }}">
  <section>
   <div class="pl-6 pr-6 pt-0 pb-0 mt-5 h-full overflow-hidden">
    <div class="pb-6 border-coolGray-100">
@@ -316,7 +316,8 @@
  </section>
  {% else %}
  {% endif %}
- <form method="post">
+ </div>
+ <form method="post" id="bid-actions-content" data-interactive="{% if edit_bid or data.show_txns or data.show_bidder_seq_diagram or data.show_offerer_seq_diagram %}1{% else %}0{% endif %}">
   {% if data.show_txns %}
   {% if data.xmr_b_shared_address or data.xmr_b_shared_viewkey or data.xmr_b_half_privatekey %}
   <section class="p-6">
@@ -877,7 +878,7 @@
        </div>
  </form>
  <script>
-document.addEventListener('DOMContentLoaded', function() {
+window.setupBidConfirmDialog = function() {
   let confirmCallback = null;
   let triggerElement = null;
 
@@ -965,7 +966,8 @@ document.addEventListener('DOMContentLoaded', function() {
 
   const acceptBidBtn = document.querySelector('button[name="accept_bid"]');
   overrideButtonConfirm(acceptBidBtn, 'Accept');
-});
+};
+document.addEventListener('DOMContentLoaded', window.setupBidConfirmDialog);
  </script>
 <script src="/static/js/pages/bid-page.js"></script>
 <script>

--- a/basicswap/templates/bid_xmr.html
+++ b/basicswap/templates/bid_xmr.html
@@ -25,14 +25,11 @@
       <h2 class="mb-6 text-4xl font-bold text-white tracking-tighter">Bid {% if debug_mode == true %} (Debug: bid_xmr template) {% endif %}</h2>
       <p class="font-normal text-coolGray-200 dark:text-white"><span class="bold">BID ID:</span> {{ bid_id }}</p>
      </div>
-     <div class="w-full md:w-1/2 p-3 p-6 flex flex-wrap items-center justify-end gap-3 mx-auto">
-      <span id="bid-live-status" class="inline-flex items-center px-3 py-1.5 rounded-full bg-white bg-opacity-10 text-xs font-medium text-white" title="Live updates disconnected — click Refresh to update">
-        <span class="relative flex h-2 w-2 mr-2">
+     <div class="w-full md:w-1/2 p-3 p-6 flex flex-wrap items-center justify-end mx-auto">
+      <a id="refresh" href="/bid/{{ bid_id }}" class="inline-flex items-center gap-2 rounded-full px-5 py-3 bg-blue-500 hover:bg-blue-600 font-medium text-sm text-white border dark:bg-gray-500 dark:hover:bg-gray-700 border-blue-500 rounded-md shadow-button focus:ring-0 focus:outline-none" title="Live updates disconnected — click Refresh to update">
+        <span id="bid-live-dot" class="relative flex h-2 w-2 shrink-0">
           <span class="relative inline-flex rounded-full h-2 w-2 bg-gray-400"></span>
         </span>
-        Offline
-      </span>
-      <a id="refresh" href="/bid/{{ bid_id }}"  class="rounded-full flex flex-wrap justify-center px-5 py-3 bg-blue-500 hover:bg-blue-600 font-medium text-sm text-white border dark:bg-gray-500 dark:hover:bg-gray-700 border-blue-500 rounded-md shadow-button focus:ring-0 focus:outline-none">
         {{ circular_arrows_svg | safe }}
        <span>Refresh</span>
       </a>

--- a/basicswap/ui/util.py
+++ b/basicswap/ui/util.py
@@ -271,9 +271,7 @@ def describeBid(
             if canAcceptBidState(last_state):
                 state_description = "Pausing briefly before accepting bid"
             elif last_state == BidStates.BID_RECEIVING_ACC:
-                state_description = (
-                    "Pausing briefly before responding to accepted bid"
-                )
+                state_description = "Pausing briefly before responding to accepted bid"
             elif last_state == BidStates.XMR_SWAP_SCRIPT_TX_REDEEMED:
                 state_description = f"Pausing briefly before spending from {ci_follower.ticker()} lock tx"
             elif last_state == BidStates.BID_ACCEPTED:

--- a/basicswap/ui/util.py
+++ b/basicswap/ui/util.py
@@ -254,60 +254,90 @@ def describeBid(
             state_description = "Bid error"
     elif offer.swap_type == SwapTypes.XMR_SWAP:
         if bid.state == BidStates.BID_SENT:
-            state_description = "Waiting for offerer to accept"
-        if bid.state == BidStates.BID_RECEIVING:
+            state_description = "Bid sent, waiting for offerer to accept"
+        elif bid.state == BidStates.BID_RECEIVING:
             # Offerer receiving bid from bidder
-            state_description = "Waiting for bid to be fully received"
+            state_description = "Receiving bid, waiting for it to be fully received"
         elif canAcceptBidState(bid.state):
             # Offerer received bid from bidder
             # TODO: Manual vs automatic
-            state_description = "Bid must be accepted"
+            state_description = "Bid received, waiting to be accepted"
         elif bid.state == BidStates.BID_RECEIVING_ACC:
             state_description = "Receiving accepted bid message"
         elif bid.state == BidStates.BID_ACCEPTED:
-            state_description = (
-                "Offerer has accepted bid, waiting for bidder to respond"
-            )
+            state_description = "Bid accepted, waiting for bidder to respond"
         elif bid.state == BidStates.SWAP_DELAYING:
             last_state = getLastBidState(bid.states)
             if canAcceptBidState(last_state):
-                state_description = "Delaying before accepting bid"
+                state_description = "Pausing briefly before accepting bid"
             elif last_state == BidStates.BID_RECEIVING_ACC:
-                state_description = "Delaying before responding to accepted bid"
-            elif last_state == BidStates.XMR_SWAP_SCRIPT_TX_REDEEMED:
                 state_description = (
-                    f"Delaying before spending from {ci_follower.ticker()} lock tx"
+                    "Pausing briefly before responding to accepted bid"
                 )
+            elif last_state == BidStates.XMR_SWAP_SCRIPT_TX_REDEEMED:
+                state_description = f"Pausing briefly before spending from {ci_follower.ticker()} lock tx"
             elif last_state == BidStates.BID_ACCEPTED:
                 state_description = (
-                    f"Delaying before sending {ci_leader.ticker()} lock tx"
+                    f"Pausing briefly before sending {ci_leader.ticker()} lock tx"
                 )
             else:
-                state_description = "Delaying before automated action"
+                state_description = "Pausing briefly before next automated action"
+        elif bid.state == BidStates.XMR_SWAP_MSG_SCRIPT_LOCK_TX_SIGS:
+            state_description = f"Exchanged lock tx signatures, waiting for {ci_leader.ticker()} lock tx"
+        elif bid.state == BidStates.XMR_SWAP_MSG_SCRIPT_LOCK_SPEND_TX:
+            state_description = f"Exchanged lock spend tx, waiting for {ci_leader.ticker()} lock tx to confirm"
         elif bid.state == BidStates.XMR_SWAP_HAVE_SCRIPT_COIN_SPEND_TX:
-            state_description = f"Waiting for {ci_leader.ticker()} lock tx to confirm in chain ({ci_leader.blocks_confirmed} blocks)"
+            state_description = f"{ci_leader.ticker()} lock tx sent, waiting for it to confirm in chain ({ci_leader.blocks_confirmed} blocks)"
         elif bid.state == BidStates.XMR_SWAP_SCRIPT_COIN_LOCKED:
             if xmr_swap.b_lock_tx_id is None:
-                state_description = f"Waiting for {ci_follower.ticker()} lock tx"
+                state_description = f"{ci_leader.ticker()} lock tx confirmed, waiting for {ci_follower.ticker()} lock tx"
             else:
-                state_description = f"Waiting for {ci_follower.ticker()} lock tx to confirm in chain ({ci_follower.blocks_confirmed} blocks)"
+                state_description = f"{ci_follower.ticker()} lock tx sent, waiting for it to confirm in chain ({ci_follower.blocks_confirmed} blocks)"
         elif bid.state == BidStates.XMR_SWAP_NOSCRIPT_COIN_LOCKED:
-            state_description = (
-                f"Waiting for {initiator_role} to unlock {ci_leader.ticker()} lock tx"
-            )
+            state_description = f"Both lock txs confirmed, waiting for {initiator_role} to release the {ci_leader.ticker()} lock tx"
         elif bid.state == BidStates.XMR_SWAP_LOCK_RELEASED:
-            state_description = f"Waiting for {participant_role} to spend from {ci_leader.ticker()} lock tx"
+            state_description = f"Lock released, waiting for {participant_role} to spend from {ci_leader.ticker()} lock tx"
         elif bid.state == BidStates.XMR_SWAP_SCRIPT_TX_REDEEMED:
-            state_description = f"Waiting for {initiator_role} to spend from {ci_follower.ticker()} lock tx"
+            state_description = f"{ci_leader.ticker()} lock tx spent, waiting for {initiator_role} to spend from {ci_follower.ticker()} lock tx"
         elif bid.state == BidStates.XMR_SWAP_NOSCRIPT_TX_REDEEMED:
-            state_description = f"Waiting for {ci_follower.ticker()} lock tx spend tx to confirm in chain"
+            state_description = f"{ci_follower.ticker()} lock tx spend tx sent, waiting for it to confirm in chain"
         elif bid.state == BidStates.XMR_SWAP_SCRIPT_TX_PREREFUND:
             if bid.was_sent:
-                state_description = (
-                    f"Waiting for {initiator_role} to redeem or locktime to expire"
-                )
+                state_description = f"Pre-refund tx in chain, waiting for {initiator_role} to redeem or locktime to expire"
             else:
-                state_description = "Redeeming output"
+                state_description = "Pre-refund tx in chain, redeeming output"
+        elif bid.state == BidStates.SWAP_COMPLETED:
+            state_description = "Swap completed successfully"
+        elif bid.state == BidStates.XMR_SWAP_NOSCRIPT_TX_RECOVERED:
+            state_description = (
+                f"{ci_follower.ticker()} lock tx recovered after failed swap"
+            )
+        elif bid.state == BidStates.XMR_SWAP_FAILED_REFUNDED:
+            state_description = "Swap failed, locked coins were refunded"
+        elif bid.state == BidStates.XMR_SWAP_FAILED_SWIPED:
+            state_description = "Swap failed, the other party claimed the refund"
+        elif bid.state == BidStates.XMR_SWAP_FAILED:
+            state_description = "Swap failed"
+
+    if state_description == "":
+        if bid.state == BidStates.SWAP_TIMEDOUT:
+            state_description = "Swap timed out"
+        elif bid.state == BidStates.BID_ABANDONED:
+            state_description = "Bid abandoned, no longer processed"
+        elif bid.state == BidStates.BID_ERROR:
+            state_description = "Bid error, check events for details"
+        elif bid.state == BidStates.BID_REJECTED:
+            state_description = "Bid rejected by offerer"
+        elif bid.state == BidStates.BID_EXPIRED:
+            state_description = "Bid expired before being accepted"
+        elif bid.state == BidStates.BID_AACCEPT_DELAY:
+            state_description = "Waiting for auto-accept delay"
+        elif bid.state == BidStates.BID_AACCEPT_FAIL:
+            state_description = "Auto-accept failed, bid can be accepted manually"
+        elif bid.state == BidStates.BID_REQUEST_SENT:
+            state_description = "Bid request sent, waiting for response"
+        elif bid.state == BidStates.BID_REQUEST_ACCEPTED:
+            state_description = "Bid request accepted"
 
     addr_label = swap_client.getAddressLabel(
         [


### PR DESCRIPTION
- Replace the 60s full-page reload on the bid page with WebSocket-driven partial refreshes
- Broadcast bid_changed on bid saves and event logs, deferred until DB commit when inside a transaction
- Green dot (Green light still on, everything working as expected) refresh button.
- Improve XMR swap State Description text so it reflects the current step, not the previous one.