### PR TITLE
Fix: Skip unconfirmed spends in the getspentinfo watcher.

### DIFF
--- a/basicswap/basicswap.py
+++ b/basicswap/basicswap.py
@@ -9929,6 +9929,11 @@ class BasicSwap(BaseApp, BSXNetwork, UIApp):
                     if "Unable to get spent info" not in str(ex):
                         self.log.warning(f"getspentinfo {ex}")
                 if found_spend is not None:
+                    if found_spend.get("height", 0) <= 0:
+                        self.log.debug(
+                            f"Waiting for spend of {o.txid_hex}:{o.vout} to confirm: {self.logIDT(found_spend['txid'])}"
+                        )
+                        continue
                     spend_txid = found_spend["txid"]
                     spend_n = found_spend["index"]
                     self.log.debug(


### PR DESCRIPTION
The spent-index feeder in checkForSpends passed any spend reported by getspentinfo straight to processSpentOutput, while the Electrum feeder only acts on spends with a known block height. Apply the same rule to the spent-index path so watched-output spend handlers only run once the spending tx has confirmed; unconfirmed spends are picked up again on the next poll.