### PR TITLE
Fixes: Electrum Verify lock-tx depth via merkle+PoW and bid UTXO locking, getChainMedianTime fails softly, TOR fix + Fixes.

### DIFF
--- a/basicswap/basicswap.py
+++ b/basicswap/basicswap.py
@@ -2064,7 +2064,7 @@ class BasicSwap(BaseApp, BSXNetwork, UIApp):
             return result
 
         try:
-            for bid_id, swap in self.swaps_in_progress.items():
+            for bid_id, swap in list(self.swaps_in_progress.items()):
                 try:
                     bid, offer = swap
                     if offer.coin_from == coin_type or offer.coin_to == coin_type:
@@ -2174,7 +2174,7 @@ class BasicSwap(BaseApp, BSXNetwork, UIApp):
 
     def _checkRPCWalletEmpty(self, coin_type: Coins) -> dict:
         try:
-            for bid_id, swap in self.swaps_in_progress.items():
+            for bid_id, swap in list(self.swaps_in_progress.items()):
                 try:
                     if hasattr(swap, "coin_from") and swap.coin_from == coin_type:
                         return {
@@ -2222,7 +2222,7 @@ class BasicSwap(BaseApp, BSXNetwork, UIApp):
 
     def _checkElectrumWalletEmpty(self, coin_type: Coins) -> dict:
         try:
-            for bid_id, swap in self.swaps_in_progress.items():
+            for bid_id, swap in list(self.swaps_in_progress.items()):
                 try:
                     if hasattr(swap, "coin_from") and swap.coin_from == coin_type:
                         return {
@@ -2586,7 +2586,7 @@ class BasicSwap(BaseApp, BSXNetwork, UIApp):
     def _transferLiteWalletBalanceToRPC(self, coin_type: Coins) -> dict:
         try:
 
-            for bid_id, swap in self.swaps_in_progress.items():
+            for bid_id, swap in list(self.swaps_in_progress.items()):
                 try:
                     if hasattr(swap, "coin_from") and swap.coin_from == coin_type:
                         self.log.warning(
@@ -8789,13 +8789,28 @@ class BasicSwap(BaseApp, BSXNetwork, UIApp):
                 # Wait for script spend tx to confirm
                 # TODO: Use explorer to get tx / block hash for getrawtransaction
 
-                if was_received:
+                spend_seen: bool = (
+                    bid.xmr_a_lock_tx is not None
+                    and bid.xmr_a_lock_tx.spend_txid == xmr_swap.a_lock_spend_tx_id
+                    and xmr_swap.a_lock_spend_tx is not None
+                )
+                if was_received or spend_seen:
                     try:
-                        txn_hex = ci_from.getMempoolTx(xmr_swap.a_lock_spend_tx_id)
-                        if txn_hex:
-                            self.log.info(
-                                f"Found lock spend txn in {ci_from.coin_name()} mempool, {self.logIDT(xmr_swap.a_lock_spend_tx_id)}"
+                        txn_hex = None
+                        try:
+                            txn_hex = ci_from.getMempoolTx(xmr_swap.a_lock_spend_tx_id)
+                            if txn_hex:
+                                self.log.info(
+                                    f"Found lock spend txn in {ci_from.coin_name()} mempool, {self.logIDT(xmr_swap.a_lock_spend_tx_id)}"
+                                )
+                        except Exception as e:
+                            self.log.debug(
+                                f"getrawtransaction lock spend tx failed: {e}"
                             )
+                        if txn_hex is None and spend_seen:
+                            # Spend tx was detected previously, recheck depth
+                            txn_hex = xmr_swap.a_lock_spend_tx.hex()
+                        if txn_hex:
                             self.process_XMR_SWAP_A_LOCK_tx_spend(
                                 bid_id,
                                 xmr_swap.a_lock_spend_tx_id.hex(),
@@ -8803,7 +8818,7 @@ class BasicSwap(BaseApp, BSXNetwork, UIApp):
                                 cursor,
                             )
                     except Exception as e:
-                        self.log.debug(f"getrawtransaction lock spend tx failed: {e}")
+                        self.log.debug(f"process lock spend tx failed: {e}")
             elif state == BidStates.XMR_SWAP_SCRIPT_TX_REDEEMED:
                 if (
                     was_received
@@ -9559,9 +9574,31 @@ class BasicSwap(BaseApp, BSXNetwork, UIApp):
 
                 if state == BidStates.XMR_SWAP_LOCK_RELEASED:
                     xmr_swap.a_lock_spend_tx = bytes.fromhex(spend_txn_hex)
-                    bid.setState(
-                        BidStates.XMR_SWAP_SCRIPT_TX_REDEEMED
-                    )  # TODO: Wait for confirmation?
+
+                    spend_tx_depth: int = 0
+                    try:
+                        spend_txout_info = ci_from.getTxOutInfo(spending_txid, 0)
+                        if spend_txout_info is not None:
+                            chain_height: int = ci_from.getChainHeight()
+                            spend_tx_depth = max(
+                                0,
+                                chain_height - spend_txout_info["block_height"] + 1,
+                            )
+                    except Exception as e:
+                        self.log.debug(
+                            f"Could not get lock spend tx depth for bid {self.log.id(bid_id)}: {e}"
+                        )
+
+                    if spend_tx_depth < ci_from.blocks_confirmed:
+                        self.log.info(
+                            f"Waiting for lock spend tx {self.logIDT(spending_txid)} to reach depth {ci_from.blocks_confirmed}, currently {spend_tx_depth}, for bid {self.log.id(bid_id)}."
+                        )
+                        self.saveBidInSession(
+                            bid_id, bid, use_cursor, xmr_swap, save_in_progress=offer
+                        )
+                        return
+
+                    bid.setState(BidStates.XMR_SWAP_SCRIPT_TX_REDEEMED)
 
                     if bid.xmr_a_lock_tx:
                         bid.xmr_a_lock_tx.setState(TxStates.TX_REDEEMED)
@@ -14052,7 +14089,7 @@ class BasicSwap(BaseApp, BSXNetwork, UIApp):
 
             to_remove = []
             if now - self._last_checked_progress >= self.check_progress_seconds:
-                for bid_id, v in self.swaps_in_progress.items():
+                for bid_id, v in list(self.swaps_in_progress.items()):
                     bid, offer = v
                     try:
                         if self.checkBidState(bid_id, bid, offer) is True:
@@ -14078,7 +14115,7 @@ class BasicSwap(BaseApp, BSXNetwork, UIApp):
                     self.deactivateBid(None, offer, bid)
 
                 if self._wallet_manager:
-                    for bid_id, v in self.swaps_in_progress.items():
+                    for bid_id, v in list(self.swaps_in_progress.items()):
                         bid, offer = v
                         try:
                             for coin_type in (

--- a/basicswap/basicswap.py
+++ b/basicswap/basicswap.py
@@ -8179,39 +8179,35 @@ class BasicSwap(BaseApp, BSXNetwork, UIApp):
                 refund_tx = bid.txns[TxTypes.XMR_SWAP_A_LOCK_REFUND]
 
                 # Track the depth of the lock refund tx.
-                refund_tx_depth: int = 0
-                if refund_tx.state == TxStates.TX_CONFIRMED:
-                    refund_tx_depth = ci_from.blocks_confirmed
-                else:
-                    refund_tx_chain_info = ci_from.getLockTxHeight(
-                        refund_tx.txid,
-                        ci_from.getSCLockScriptAddress(
-                            xmr_swap.a_lock_refund_tx_script
-                        ),
-                        ci_from.getLockRefundTxSwapOutputValue(bid, xmr_swap),
-                        bid.chain_a_height_start,
-                        vout=refund_tx.vout,
-                    )
-                    if refund_tx_chain_info is not None:
-                        bid_changed: bool = False
-                        refund_tx_depth = refund_tx_chain_info.get("depth", 0)
-                        if (
-                            refund_tx.state
-                            in (None, TxStates.TX_NONE, TxStates.TX_SENT)
-                            and refund_tx_chain_info["height"] == 0
-                        ):
-                            refund_tx.setState(TxStates.TX_IN_MEMPOOL)
-                            bid_changed = True
-                        if (
-                            not refund_tx.block_height
-                            and refund_tx_chain_info["height"] != 0
-                        ):
-                            self.setTxBlockInfoFromHeight(
-                                ci_from, refund_tx, refund_tx_chain_info["height"]
-                            )
-                            refund_tx.setState(TxStates.TX_IN_CHAIN)
-                            bid_changed = True
-                        if refund_tx_depth >= ci_from.blocks_confirmed:
+                was_confirmed: bool = refund_tx.state == TxStates.TX_CONFIRMED
+                refund_tx_depth: int = ci_from.blocks_confirmed if was_confirmed else 0
+                refund_tx_chain_info = ci_from.getLockTxHeight(
+                    refund_tx.txid,
+                    ci_from.getSCLockScriptAddress(xmr_swap.a_lock_refund_tx_script),
+                    ci_from.getLockRefundTxSwapOutputValue(bid, xmr_swap),
+                    bid.chain_a_height_start,
+                    vout=refund_tx.vout,
+                )
+                if refund_tx_chain_info is not None:
+                    bid_changed: bool = False
+                    refund_tx_depth = refund_tx_chain_info.get("depth", 0)
+                    if (
+                        refund_tx.state in (None, TxStates.TX_NONE, TxStates.TX_SENT)
+                        and refund_tx_chain_info["height"] == 0
+                    ):
+                        refund_tx.setState(TxStates.TX_IN_MEMPOOL)
+                        bid_changed = True
+                    if (
+                        not refund_tx.block_height
+                        and refund_tx_chain_info["height"] != 0
+                    ):
+                        self.setTxBlockInfoFromHeight(
+                            ci_from, refund_tx, refund_tx_chain_info["height"]
+                        )
+                        refund_tx.setState(TxStates.TX_IN_CHAIN)
+                        bid_changed = True
+                    if refund_tx_depth >= ci_from.blocks_confirmed:
+                        if not was_confirmed:
                             self.logBidEvent(
                                 bid.bid_id,
                                 EventLogTypes.LOCK_TX_A_REFUND_TX_CONFIRMED,
@@ -8220,9 +8216,19 @@ class BasicSwap(BaseApp, BSXNetwork, UIApp):
                             )
                             refund_tx.setState(TxStates.TX_CONFIRMED)
                             bid_changed = True
-                        if bid_changed:
-                            self.add(refund_tx, cursor, upsert=True)
-                            self.commitDB()
+                    elif was_confirmed:
+                        self.log.warning(
+                            f"Lock refund tx {self.logIDT(refund_tx.txid)} dropped below depth {ci_from.blocks_confirmed} (now {refund_tx_depth}) for bid {self.log.id(bid_id)}."
+                        )
+                        refund_tx.setState(
+                            TxStates.TX_IN_CHAIN
+                            if refund_tx_chain_info["height"] != 0
+                            else TxStates.TX_IN_MEMPOOL
+                        )
+                        bid_changed = True
+                    if bid_changed:
+                        self.add(refund_tx, cursor, upsert=True)
+                        self.commitDB()
 
                 if was_received:
                     if bid.debug_ind == DebugTypes.BID_DONT_SPEND_COIN_A_LOCK_REFUND:
@@ -8713,6 +8719,24 @@ class BasicSwap(BaseApp, BSXNetwork, UIApp):
                             bid_changed = True
                     else:
                         raise
+
+                if (
+                    was_sent
+                    and state == BidStates.XMR_SWAP_SCRIPT_COIN_LOCKED
+                    and bid.xmr_b_lock_tx is None
+                    and self.countQueuedActions(
+                        cursor, bid_id, ActionTypes.SEND_XMR_SWAP_LOCK_TX_B
+                    )
+                    < 1
+                ):
+                    delay = self.get_delay_event_seconds()
+                    self.log.info(
+                        f"Re-queueing adaptor-sig swap chain B lock tx for bid {self.log.id(bid_id)} in {delay} seconds."
+                    )
+                    self.createActionInSession(
+                        delay, ActionTypes.SEND_XMR_SWAP_LOCK_TX_B, bid_id, cursor
+                    )
+                    self.commitDB()
 
                 if (
                     bid.xmr_b_lock_tx
@@ -12264,6 +12288,12 @@ class BasicSwap(BaseApp, BSXNetwork, UIApp):
         ensure(bid, f"Bid not found: {self.log.id(bid_id)}.")
         ensure(xmr_swap, f"Adaptor-sig swap not found: {self.log.id(bid_id)}.")
 
+        if bid.state != BidStates.XMR_SWAP_MSG_SCRIPT_LOCK_TX_SIGS:
+            self.log.warning(
+                f"Not sending coin A lock tx for adaptor-sig bid {self.log.id(bid_id)}, unexpected bid state: {strBidState(bid.state)}."
+            )
+            return
+
         offer, xmr_offer = self.getXmrOfferFromSession(cursor, bid.offer_id)
         ensure(offer, f"Offer not found: {self.log.id(bid.offer_id)}.")
         ensure(xmr_offer, f"Adaptor-sig offer not found: {self.log.id(bid.offer_id)}.")
@@ -12474,6 +12504,32 @@ class BasicSwap(BaseApp, BSXNetwork, UIApp):
             TxTypes.PTX_PRE_FUNDED,
             cursor=cursor,
         )
+
+        num_publish_started = self.countBidEvents(
+            bid, EventLogTypes.LOCK_TX_B_PUBLISH_STARTED, cursor
+        )
+        num_published = self.countBidEvents(
+            bid, EventLogTypes.LOCK_TX_B_PUBLISHED, cursor
+        )
+        num_publish_failed = self.countBidEvents(
+            bid, EventLogTypes.FAILED_TX_B_LOCK_PUBLISH, cursor
+        )
+        if num_publish_started > num_published + num_publish_failed:
+            error_msg = f"A previous coin B lock tx publish attempt for bid {self.log.id(bid_id)} may have broadcast before an unclean shutdown. Not republishing, check the {ci_to.coin_name()} wallet."
+            self.log.error(error_msg)
+            self.setBidError(
+                bid,
+                "Possible coin B lock tx broadcast before crash, manual intervention required.",
+                save_bid=False,
+                cursor=cursor,
+            )
+            self.saveBidInSession(bid_id, bid, cursor, xmr_swap, save_in_progress=offer)
+            return
+
+        self.logBidEvent(
+            bid.bid_id, EventLogTypes.LOCK_TX_B_PUBLISH_STARTED, "", cursor
+        )
+        self.commitDB()
 
         try:
             b_lock_vout = None
@@ -13120,16 +13176,17 @@ class BasicSwap(BaseApp, BSXNetwork, UIApp):
         ensure(msg["to"] == addr_sent_to, "Received on incorrect address")
         ensure(msg["from"] == addr_sent_from, "Sent from incorrect address")
 
+        allowed_states = [
+            BidStates.BID_ACCEPTED,
+        ]
+        if bid.was_sent and offer.was_sent:
+            allowed_states.append(BidStates.XMR_SWAP_MSG_SCRIPT_LOCK_TX_SIGS)
+        ensure(
+            bid.state in allowed_states,
+            "Invalid state for bid {}".format(bid.state),
+        )
+
         try:
-            allowed_states = [
-                BidStates.BID_ACCEPTED,
-            ]
-            if bid.was_sent and offer.was_sent:
-                allowed_states.append(BidStates.XMR_SWAP_MSG_SCRIPT_LOCK_TX_SIGS)
-            ensure(
-                bid.state in allowed_states,
-                "Invalid state for bid {}".format(bid.state),
-            )
             xmr_swap.af_lock_refund_spend_tx_esig = (
                 msg_data.af_lock_refund_spend_tx_esig
             )

--- a/basicswap/basicswap.py
+++ b/basicswap/basicswap.py
@@ -6892,7 +6892,7 @@ class BasicSwap(BaseApp, BSXNetwork, UIApp):
                     bid.amount, xmr_swap.a_lock_tx_script, xmr_swap.vkbv
                 )
                 xmr_swap.a_lock_tx = ci_from.fundSCLockTx(
-                    xmr_swap.a_lock_tx, a_fee_rate, xmr_swap.vkbv
+                    xmr_swap.a_lock_tx, a_fee_rate, xmr_swap.vkbv, bid_id=bid.bid_id
                 )
 
             xmr_swap.a_lock_tx_id = ci_from.getTxid(xmr_swap.a_lock_tx)
@@ -10189,6 +10189,11 @@ class BasicSwap(BaseApp, BSXNetwork, UIApp):
             try:
                 found = ci.checkWatchedScript(s.script)
                 if found:
+                    if found.get("height", 0) <= 0:
+                        self.log.debug(
+                            f"Waiting for watched script tx to confirm for bid {self.log.id(s.bid_id)}: {self.logIDT(bytes.fromhex(found['txid']))}"
+                        )
+                        continue
                     txid_bytes = bytes.fromhex(found["txid"])
                     self.log.debug(
                         f"Found script via Electrum for bid {self.log.id(s.bid_id)}: {self.logIDT(txid_bytes)} {found['vout']}."

--- a/basicswap/basicswap.py
+++ b/basicswap/basicswap.py
@@ -374,6 +374,12 @@ def threadPollElectrumChainState(swap_client, coin_type):
                     if "bestblockhash" in chain_state:
                         cc["chain_best_block"] = chain_state["bestblockhash"]
 
+                if hasattr(ci, "getChainMedianTime"):
+                    mtp = ci.getChainMedianTime()
+                    if mtp is not None:
+                        with swap_client.mxDB:
+                            cc["chain_median_time"] = mtp
+
             try:
                 ci.refreshElectrumWalletInfo()
                 checkAndNotifyBalanceChange(

--- a/basicswap/basicswap_util.py
+++ b/basicswap/basicswap_util.py
@@ -220,6 +220,7 @@ class EventLogTypes(IntEnum):
     LOCK_TX_B_REFUND_TX_SEEN = auto()
     LOCK_TX_A_INVALID = auto()
     LOCK_TX_A_REFUND_TX_CONFIRMED = auto()
+    LOCK_TX_B_PUBLISH_STARTED = auto()
 
 
 class XmrSplitMsgTypes(IntEnum):
@@ -450,6 +451,8 @@ def describeEventEntry(event_type, event_msg):
         return "Lock tx A published"
     if event_type == EventLogTypes.LOCK_TX_B_PUBLISHED:
         return "Lock tx B published"
+    if event_type == EventLogTypes.LOCK_TX_B_PUBLISH_STARTED:
+        return "Lock tx B publish started"
     if event_type == EventLogTypes.FAILED_TX_B_SPEND:
         return "Failed to publish lock tx B spend: " + event_msg
     if event_type == EventLogTypes.LOCK_TX_A_IN_MEMPOOL:

--- a/basicswap/interface/btc/btc.py
+++ b/basicswap/interface/btc/btc.py
@@ -327,6 +327,8 @@ class BTCInterface(FeeValidator, Secp256k1Interface):
         self._pending_utxos_lock = threading.Lock()
         self._utxo_reserve_lock = threading.RLock()
         self._merkle_verified: Dict[str, int] = {}
+        self._median_time_cache: Optional[int] = None
+        self._median_time_cache_height: Optional[int] = None
 
     def setBackend(self, backend) -> None:
         self._backend = backend
@@ -521,26 +523,50 @@ class BTCInterface(FeeValidator, Secp256k1Interface):
         tx_obj = self.loadTx(tx_data)
         return tx_obj.vin[vout].nSequence
 
-    def getChainMedianTime(self) -> int:
+    def getChainMedianTime(self) -> Optional[int]:
         if self.useBackend():
-            import struct
+            return self._getChainMedianTimeElectrum()
+        try:
+            mtp = self.rpc("getblockchaininfo")["mediantime"]
+            self._median_time_cache = mtp
+            return mtp
+        except Exception as e:
+            self._log.warning(f"getChainMedianTime rpc error: {e}")
+            return self._median_time_cache
 
-            backend = self.getBackend()
-            if not backend:
-                raise ValueError("No electrum backend available")
+    def _getChainMedianTimeElectrum(self) -> Optional[int]:
+        import struct
+
+        backend = self.getBackend()
+        if not backend:
+            self._log.warning("getChainMedianTime: no electrum backend available")
+            return self._median_time_cache
+        try:
             height = backend.getBlockHeight()
+            if (
+                self._median_time_cache is not None
+                and self._median_time_cache_height == height
+            ):
+                return self._median_time_cache
             start = max(0, height - 10)
             count = height - start + 1
             result = backend._server.call("blockchain.block.headers", [start, count])
             header_bytes = bytes.fromhex(result["hex"])
-            returned = result.get("count", count)
+            returned = min(result.get("count", count), len(header_bytes) // 80)
+            if returned < 1:
+                raise ValueError("No headers returned")
             times = [
                 struct.unpack("<I", header_bytes[i * 80 + 68 : i * 80 + 72])[0]
                 for i in range(returned)
             ]
             times.sort()
-            return times[len(times) // 2]
-        return self.rpc("getblockchaininfo")["mediantime"]
+            mtp = times[len(times) // 2]
+            self._median_time_cache = mtp
+            self._median_time_cache_height = height
+            return mtp
+        except Exception as e:
+            self._log.warning(f"getChainMedianTime electrum error: {e}")
+            return self._median_time_cache
 
     def isCsvLockMature(
         self,
@@ -563,6 +589,8 @@ class BTCInterface(FeeValidator, Secp256k1Interface):
                 return False
             if chain_mtp is None:
                 chain_mtp = self.getChainMedianTime()
+            if chain_mtp is None:
+                return False
             return chain_mtp >= parent_block_time + lock_value
         raise ValueError(f"Unknown lock type {lock_type}")
 
@@ -580,6 +608,8 @@ class BTCInterface(FeeValidator, Secp256k1Interface):
             return chain_height + 1 >= nlocktime
         if chain_mtp is None:
             chain_mtp = self.getChainMedianTime()
+        if chain_mtp is None:
+            return False
         return chain_mtp >= nlocktime
 
     def getMempoolTx(self, txid):

--- a/basicswap/interface/btc/btc.py
+++ b/basicswap/interface/btc/btc.py
@@ -52,6 +52,10 @@ from basicswap.util.crypto import (
     hash160,
     sha256,
 )
+from basicswap.util.merkle import (
+    check_header_pow,
+    verify_tx_merkle_proof,
+)
 from coincurve.keys import (
     PrivateKey,
     PublicKey,
@@ -321,6 +325,8 @@ class BTCInterface(FeeValidator, Secp256k1Interface):
         self._backend = None
         self._pending_utxos_map: Dict[str, list] = {}
         self._pending_utxos_lock = threading.Lock()
+        self._utxo_reserve_lock = threading.RLock()
+        self._merkle_verified: Dict[str, int] = {}
 
     def setBackend(self, backend) -> None:
         self._backend = backend
@@ -607,6 +613,42 @@ class BTCInterface(FeeValidator, Secp256k1Interface):
         block_time = struct.unpack("<I", header_bytes[68:72])[0]
         block_hash = sha256(sha256(header_bytes))[::-1].hex()
         return {"height": height, "hash": block_hash, "time": block_time}
+
+    def _verifyTxMerkleElectrum(
+        self, backend, txid_hex: str, block_height: int
+    ) -> bool:
+        if block_height <= 0:
+            return False
+        if self._merkle_verified.get(txid_hex) == block_height:
+            return True
+        try:
+            proof = backend._server.get_merkle(txid_hex, block_height)
+            if not proof or "merkle" not in proof or "pos" not in proof:
+                self._log.error(
+                    f"Merkle proof missing for {self._log.id(txid_hex)} at height {block_height}"
+                )
+                return False
+            header_hex = backend._server.call("blockchain.block.header", [block_height])
+            header_bytes = bytes.fromhex(header_hex)
+            if not check_header_pow(header_bytes):
+                self._log.error(
+                    f"Block header PoW invalid at height {block_height} for {self._log.id(txid_hex)}"
+                )
+                return False
+            if not verify_tx_merkle_proof(
+                txid_hex, header_bytes, proof["merkle"], proof["pos"]
+            ):
+                self._log.error(
+                    f"Merkle proof mismatch for {self._log.id(txid_hex)} at height {block_height}"
+                )
+                return False
+        except Exception as e:
+            self._log.error(
+                f"Merkle verification failed for {self._log.id(txid_hex)}: {e}"
+            )
+            return False
+        self._merkle_verified[txid_hex] = block_height
+        return True
 
     def getBestBlockHash(self) -> str:
         if self._connection_type == "electrum":
@@ -1276,8 +1318,8 @@ class BTCInterface(FeeValidator, Secp256k1Interface):
         tx.vout.append(self.txoType()(value, self.getScriptDest(script)))
         return tx.serialize()
 
-    def fundSCLockTx(self, tx_bytes, feerate, vkbv=None) -> bytes:
-        funded_tx = self.fundTx(tx_bytes, feerate)
+    def fundSCLockTx(self, tx_bytes, feerate, vkbv=None, bid_id: bytes = None) -> bytes:
+        funded_tx = self.fundTx(tx_bytes, feerate, bid_id=bid_id)
 
         if self._disable_lock_tx_rbf:
             tx = self.loadTx(funded_tx)
@@ -1968,11 +2010,16 @@ class BTCInterface(FeeValidator, Secp256k1Interface):
         return pubkey.verify(sig[:-1], sig_hash, hasher=None)  # Pop the hashtype byte
 
     def fundTx(
-        self, tx: bytes, feerate: int, lock_unspents: bool = True, subfee: bool = False
+        self,
+        tx: bytes,
+        feerate: int,
+        lock_unspents: bool = True,
+        subfee: bool = False,
+        bid_id: bytes = None,
     ) -> bytes:
         if self.useBackend():
             return self._fundTxElectrum(
-                tx, feerate, lock_unspents=lock_unspents, subfee=subfee
+                tx, feerate, lock_unspents=lock_unspents, subfee=subfee, bid_id=bid_id
             )
 
         feerate_str = self.format_amount(feerate)
@@ -1992,7 +2039,12 @@ class BTCInterface(FeeValidator, Secp256k1Interface):
         return tx_bytes
 
     def _fundTxElectrum(
-        self, tx, feerate, lock_unspents: bool = True, subfee: bool = False
+        self,
+        tx,
+        feerate,
+        lock_unspents: bool = True,
+        subfee: bool = False,
+        bid_id: bytes = None,
     ) -> bytes:
         wm = self.getWalletManager()
         backend = self.getBackend()
@@ -2156,15 +2208,25 @@ class BTCInterface(FeeValidator, Secp256k1Interface):
             funded_tx.vout[0].nValue = new_value
 
         if lock_unspents:
-            for utxo in selected_utxos:
-                wm.lockUTXO(
-                    self.coin_type(),
-                    utxo.get("txid", ""),
-                    utxo.get("vout", 0),
-                    value=utxo.get("value", 0),
-                    address=utxo.get("address"),
-                    expires_in=3600,
-                )
+            lock_expires_in = 86400 if bid_id is not None else 3600
+            with self._utxo_reserve_lock:
+                for utxo in selected_utxos:
+                    if wm.isUTXOLocked(
+                        self.coin_type(), utxo.get("txid", ""), utxo.get("vout", 0)
+                    ):
+                        raise ValueError(
+                            "UTXO reserved by a concurrent operation, retry funding"
+                        )
+                for utxo in selected_utxos:
+                    wm.lockUTXO(
+                        self.coin_type(),
+                        utxo.get("txid", ""),
+                        utxo.get("vout", 0),
+                        value=utxo.get("value", 0),
+                        address=utxo.get("address"),
+                        bid_id=bid_id,
+                        expires_in=lock_expires_in,
+                    )
 
         tx_serialized = funded_tx.serialize()
         tx_key = self._getTxInputsKey(funded_tx)
@@ -2285,7 +2347,7 @@ class BTCInterface(FeeValidator, Secp256k1Interface):
             else:
                 raise
 
-    def lockPrefundedTxInputs(self, tx_data: bytes) -> None:
+    def lockPrefundedTxInputs(self, tx_data: bytes, bid_id: bytes = None) -> None:
         tx = self.loadTx(tx_data)
         if self.useBackend():
             wm = self.getWalletManager()
@@ -2293,12 +2355,14 @@ class BTCInterface(FeeValidator, Secp256k1Interface):
             if not wm or not backend:
                 raise ValueError("Electrum backend or WalletManager not available")
 
+            lock_expires_in = 86400 if bid_id is not None else 3600
             for txi in tx.vin:
                 wm.lockUTXO(
                     self.coin_type(),
                     i2h(txi.prevout.hash),
                     txi.prevout.n,
-                    expires_in=3600,
+                    bid_id=bid_id,
+                    expires_in=lock_expires_in,
                 )
             return
 
@@ -3282,7 +3346,13 @@ class BTCInterface(FeeValidator, Secp256k1Interface):
             if cached is not None:
                 confirmations, block_height = cached
                 if block_height > 0:
-                    confirmations = max(0, chain_height - block_height + 1)
+                    if not self._verifyTxMerkleElectrum(
+                        backend, txid.hex(), block_height
+                    ):
+                        block_height = 0
+                        confirmations = 0
+                    else:
+                        confirmations = max(0, chain_height - block_height + 1)
                 rv = {"depth": confirmations, "height": block_height}
                 if find_index:
                     try:
@@ -3330,6 +3400,12 @@ class BTCInterface(FeeValidator, Secp256k1Interface):
                         if block_height > 0:
                             confirmations = max(0, chain_height - block_height + 1)
                         break
+
+            if block_height > 0 and not self._verifyTxMerkleElectrum(
+                backend, txid.hex(), block_height
+            ):
+                block_height = 0
+                confirmations = 0
 
             if wm:
                 wm.cacheTxConfirmations(

--- a/basicswap/interface/electrumx.py
+++ b/basicswap/interface/electrumx.py
@@ -571,7 +571,7 @@ class ElectrumServer:
         self._using_default_servers = not user_clearnet and not user_onion
 
         if use_tor:
-            if user_onion and not user_clearnet:
+            if user_onion:
                 final_clearnet = []
             else:
                 final_clearnet = (

--- a/basicswap/protocols/atomic_swap_1.py
+++ b/basicswap/protocols/atomic_swap_1.py
@@ -24,6 +24,7 @@ from . import ProtocolInterface
 
 INITIATE_TX_TIMEOUT = 40 * 60  # TODO: make variable per coin
 ABS_LOCK_TIME_LEEWAY = 10 * 60
+ABS_LOCK_BLOCKS_LEEWAY = 4
 
 
 def buildContractScript(

--- a/basicswap/util/merkle.py
+++ b/basicswap/util/merkle.py
@@ -1,0 +1,67 @@
+# -*- coding: utf-8 -*-
+
+# Copyright (c) 2026 The Basicswap developers
+# Distributed under the MIT software license, see the accompanying
+# file LICENSE or http://www.opensource.org/licenses/mit-license.php.
+
+import struct
+
+from hashlib import sha256 as _hashlib_sha256
+
+
+def _double_sha256(data: bytes) -> bytes:
+    return _hashlib_sha256(_hashlib_sha256(data).digest()).digest()
+
+
+def electrum_merkle_root(txid_hex: str, branch: list, tx_pos: int) -> bytes:
+    current = bytes.fromhex(txid_hex)[::-1]
+    pos = tx_pos
+    for sibling_hex in branch:
+        sibling = bytes.fromhex(sibling_hex)[::-1]
+        if pos & 1:
+            current = _double_sha256(sibling + current)
+        else:
+            current = _double_sha256(current + sibling)
+        pos >>= 1
+    return current
+
+
+def parse_header_merkle_root(header_bytes: bytes) -> bytes:
+    if len(header_bytes) < 80:
+        raise ValueError("Block header too short")
+    return header_bytes[36:68]
+
+
+def header_bits(header_bytes: bytes) -> int:
+    if len(header_bytes) < 80:
+        raise ValueError("Block header too short")
+    return struct.unpack("<I", header_bytes[72:76])[0]
+
+
+def target_from_bits(bits: int) -> int:
+    exponent = bits >> 24
+    mantissa = bits & 0x007FFFFF
+    if exponent <= 3:
+        return mantissa >> (8 * (3 - exponent))
+    return mantissa << (8 * (exponent - 3))
+
+
+def check_header_pow(header_bytes: bytes) -> bool:
+    target = target_from_bits(header_bits(header_bytes))
+    if target <= 0:
+        return False
+    block_hash = int.from_bytes(_double_sha256(header_bytes), "little")
+    return block_hash <= target
+
+
+def verify_tx_merkle_proof(
+    txid_hex: str,
+    header_bytes: bytes,
+    branch: list,
+    tx_pos: int,
+    require_pow: bool = True,
+) -> bool:
+    if require_pow and not check_header_pow(header_bytes):
+        return False
+    computed_root = electrum_merkle_root(txid_hex, branch, tx_pos)
+    return computed_root == parse_header_merkle_root(header_bytes)

--- a/tests/basicswap/test_ads_spend_depth_gate.py
+++ b/tests/basicswap/test_ads_spend_depth_gate.py
@@ -1,0 +1,178 @@
+# -*- coding: utf-8 -*-
+
+# Copyright (c) 2026 The Basicswap developers
+# Distributed under the MIT software license, see the accompanying
+# file LICENSE or http://www.opensource.org/licenses/mit-license.php.
+
+import unittest
+from types import SimpleNamespace
+
+from basicswap.basicswap import BasicSwap
+from basicswap.basicswap_util import BidStates
+from basicswap.chainparams import Coins
+
+SPEND_TXID = bytes.fromhex("aa" * 32)
+LOCK_TXID = bytes.fromhex("bb" * 32)
+
+
+class StubLog:
+    def id(self, v):
+        return str(v)
+
+    def info(self, *args, **kwargs):
+        pass
+
+    def warning(self, *args, **kwargs):
+        pass
+
+    def debug(self, *args, **kwargs):
+        pass
+
+    def error(self, *args, **kwargs):
+        pass
+
+
+class StubTx:
+    def __init__(self):
+        self.spend_txid = None
+        self.states = []
+
+    def setState(self, state):
+        self.states.append(state)
+
+
+class StubBid:
+    def __init__(self, state):
+        self.state = state
+        self.states_set = []
+        self.was_received = False
+        self.was_sent = True
+        self.offer_id = b"offer"
+        self.bid_id = b"bid"
+        self.xmr_a_lock_tx = StubTx()
+
+    def setState(self, state):
+        self.states_set.append(state)
+        self.state = state
+
+
+class StubCI:
+    def __init__(self, spend_depth, blocks_confirmed=2, chain_height=100):
+        self._spend_depth = spend_depth
+        self.blocks_confirmed = blocks_confirmed
+        self._chain_height = chain_height
+
+    def loadTx(self, tx_bytes):
+        return SimpleNamespace(vin=[])
+
+    def getChainHeight(self):
+        return self._chain_height
+
+    def getTxOutInfo(self, txid, n):
+        if self._spend_depth < 1:
+            return None
+        return {
+            "block_height": self._chain_height - (self._spend_depth - 1),
+            "block_hash": b"\x00" * 32,
+            "block_time": 1000,
+        }
+
+
+def make_swap_client(ci, bid, xmr_swap):
+    sc = BasicSwap.__new__(BasicSwap)
+    sc.fp = None
+    sc.log = StubLog()
+    sc.saved = []
+    sc.events = []
+    sc.notifications = []
+
+    offer = SimpleNamespace(
+        coin_from=int(Coins.BTC),
+        coin_to=int(Coins.PART),
+        offer_id=b"offer",
+        swap_type=None,
+    )
+    xmr_offer = SimpleNamespace()
+
+    sc.openDB = lambda cursor=None: object()
+    sc.closeDB = lambda cursor, commit=True: None
+    sc.getXmrBidFromSession = lambda cursor, bid_id: (bid, xmr_swap)
+    sc.getXmrOfferFromSession = lambda cursor, offer_id: (offer, xmr_offer)
+    sc.is_reverse_ads_bid = lambda cf, ct: False
+    sc.isBchXmrSwap = lambda offer: False
+    sc.ci = lambda coin: ci
+    sc.saveBidInSession = (
+        lambda bid_id, bid, cursor, xmr_swap, save_in_progress=None: sc.saved.append(
+            bid.state
+        )
+    )
+    sc.logBidEvent = lambda bid_id, event, msg, cursor: sc.events.append(event)
+    sc.notify = lambda event_type, data: sc.notifications.append(event_type)
+    sc.logIDT = lambda t: str(t)
+    sc.logException = lambda msg: (_ for _ in ()).throw(AssertionError(msg))
+    return sc
+
+
+def make_xmr_swap():
+    return SimpleNamespace(
+        a_lock_spend_tx_id=SPEND_TXID,
+        a_lock_tx_id=LOCK_TXID,
+        a_lock_spend_tx=None,
+        a_lock_refund_tx_id=bytes.fromhex("cc" * 32),
+    )
+
+
+class TestAdsSpendDepthGate(unittest.TestCase):
+    def test_unconfirmed_spend_does_not_transition(self):
+        bid = StubBid(BidStates.XMR_SWAP_LOCK_RELEASED)
+        xmr_swap = make_xmr_swap()
+        ci = StubCI(spend_depth=0, blocks_confirmed=2)
+        sc = make_swap_client(ci, bid, xmr_swap)
+
+        sc.process_XMR_SWAP_A_LOCK_tx_spend(b"bid", SPEND_TXID.hex(), "00")
+
+        self.assertEqual(bid.states_set, [])
+        self.assertEqual(bid.state, BidStates.XMR_SWAP_LOCK_RELEASED)
+        self.assertEqual(len(sc.saved), 1)
+        self.assertEqual(xmr_swap.a_lock_spend_tx, b"\x00")
+
+    def test_shallow_spend_does_not_transition(self):
+        bid = StubBid(BidStates.XMR_SWAP_LOCK_RELEASED)
+        xmr_swap = make_xmr_swap()
+        ci = StubCI(spend_depth=1, blocks_confirmed=2)
+        sc = make_swap_client(ci, bid, xmr_swap)
+
+        sc.process_XMR_SWAP_A_LOCK_tx_spend(b"bid", SPEND_TXID.hex(), "00")
+
+        self.assertEqual(bid.states_set, [])
+        self.assertEqual(bid.state, BidStates.XMR_SWAP_LOCK_RELEASED)
+
+    def test_confirmed_spend_transitions_sender(self):
+        bid = StubBid(BidStates.XMR_SWAP_LOCK_RELEASED)
+        xmr_swap = make_xmr_swap()
+        ci = StubCI(spend_depth=2, blocks_confirmed=2)
+        sc = make_swap_client(ci, bid, xmr_swap)
+
+        sc.process_XMR_SWAP_A_LOCK_tx_spend(b"bid", SPEND_TXID.hex(), "00")
+
+        self.assertIn(BidStates.XMR_SWAP_SCRIPT_TX_REDEEMED, bid.states_set)
+        self.assertIn(BidStates.SWAP_COMPLETED, bid.states_set)
+        self.assertEqual(len(sc.notifications), 1)
+
+    def test_confirmed_spend_transitions_receiver(self):
+        bid = StubBid(BidStates.XMR_SWAP_LOCK_RELEASED)
+        bid.was_received = True
+        bid.was_sent = False
+        xmr_swap = make_xmr_swap()
+        ci = StubCI(spend_depth=2, blocks_confirmed=2)
+        sc = make_swap_client(ci, bid, xmr_swap)
+
+        sc.process_XMR_SWAP_A_LOCK_tx_spend(b"bid", SPEND_TXID.hex(), "00")
+
+        self.assertIn(BidStates.XMR_SWAP_SCRIPT_TX_REDEEMED, bid.states_set)
+        self.assertNotIn(BidStates.SWAP_COMPLETED, bid.states_set)
+        self.assertEqual(len(sc.notifications), 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/basicswap/test_ads_swap_recovery.py
+++ b/tests/basicswap/test_ads_swap_recovery.py
@@ -5,12 +5,8 @@
 # file LICENSE or http://www.opensource.org/licenses/mit-license.php.
 
 """
-Tests for the restart/reorg hardening fixes:
-  R5  - coin B lock tx write-ahead idempotency (no double-broadcast after crash).
-  R6  - replayed XMR_BID_TXN_SIGS must not error the bid,
-        sendXmrBidCoinALockTx gated on bid state.
-  R7  - purged SEND_XMR_SWAP_LOCK_TX_B action is re-created.
-  R10 - lock refund tx depth re-queried when TX_CONFIRMED.
+Unit tests for adaptor-sig swap resilience: crash recovery, message replays,
+lost queued actions, and chain reorg handling.
 """
 
 import unittest
@@ -83,13 +79,13 @@ def base_swap_client():
     sc.setBidError = lambda bid, msg, save_bid=True, xmr_swap=None, cursor=None: sc.bid_errors.append(
         msg
     )
-    sc.saveBidInSession = (
-        lambda bid_id, bid, cursor, xmr_swap=None, save_in_progress=None: sc.saved.append(
-            bid.state
-        )
+    sc.saveBidInSession = lambda bid_id, bid, cursor, xmr_swap=None, save_in_progress=None: sc.saved.append(
+        bid.state
     )
-    sc.createActionInSession = lambda delay, action_type, bid_id, cursor: sc.created_actions.append(
-        action_type
+    sc.createActionInSession = (
+        lambda delay, action_type, bid_id, cursor: sc.created_actions.append(
+            action_type
+        )
     )
     sc.get_delay_event_seconds = lambda: 1
     sc.is_reverse_ads_bid = lambda cf, ct: False
@@ -109,7 +105,7 @@ def make_offer():
 
 
 # ---------------------------------------------------------------------------
-# R5 - coin B lock write-ahead idempotency
+# Coin B lock publish recovery
 # ---------------------------------------------------------------------------
 
 
@@ -164,7 +160,7 @@ def make_b_lock_bid():
     )
 
 
-class TestR5CoinBLockIdempotency(unittest.TestCase):
+class TestAdsSwapRecoveryCoinBLock(unittest.TestCase):
     def test_write_ahead_marker_committed_before_broadcast(self):
         bid = make_b_lock_bid()
         sc = make_b_lock_client(bid)
@@ -208,11 +204,11 @@ class TestR5CoinBLockIdempotency(unittest.TestCase):
 
 
 # ---------------------------------------------------------------------------
-# R6 - replayed XMR_BID_TXN_SIGS / sendXmrBidCoinALockTx state gate
+# Replayed bid message and coin A lock state gate
 # ---------------------------------------------------------------------------
 
 
-class TestR6ReplayedSigsMessage(unittest.TestCase):
+class TestAdsSwapRecoveryReplayedSigs(unittest.TestCase):
     def make_sigs_msg_client(self, bid):
         sc = base_swap_client()
         xmr_swap = SimpleNamespace()
@@ -258,7 +254,7 @@ class TestR6ReplayedSigsMessage(unittest.TestCase):
         self.assertEqual(bid.state, BidStates.XMR_SWAP_MSG_SCRIPT_LOCK_TX_SIGS)
 
 
-class TestR6CoinALockStateGate(unittest.TestCase):
+class TestAdsSwapRecoveryCoinALockGate(unittest.TestCase):
     def test_errored_bid_does_not_publish_coin_a(self):
         sc = base_swap_client()
         bid = SimpleNamespace(
@@ -299,7 +295,7 @@ class TestR6CoinALockStateGate(unittest.TestCase):
 
 
 # ---------------------------------------------------------------------------
-# R7 / R10 - checkXmrBidState based tests
+# Bid state polling recovery
 # ---------------------------------------------------------------------------
 
 
@@ -360,7 +356,7 @@ def make_refund_bid(state, refund_tx):
     )
 
 
-class TestR10RefundDepthRequery(unittest.TestCase):
+class TestAdsSwapRecoveryRefundDepth(unittest.TestCase):
     def run_check(self, refund_tx, chain_info):
         xmr_swap = SimpleNamespace(a_lock_refund_tx_script=b"script")
         bid = make_refund_bid(BidStates.SWAP_COMPLETED, refund_tx)
@@ -422,7 +418,7 @@ class TestR10RefundDepthRequery(unittest.TestCase):
         )
 
 
-class TestR7RequeueLockTxB(unittest.TestCase):
+class TestAdsSwapRecoveryRequeueLockTxB(unittest.TestCase):
     def run_check(self, bid, queued_count=0):
         xmr_swap = SimpleNamespace(a_lock_refund_tx_script=b"script")
         ci = StubCIA(blocks_confirmed=2)

--- a/tests/basicswap/test_ads_swap_recovery.py
+++ b/tests/basicswap/test_ads_swap_recovery.py
@@ -1,0 +1,469 @@
+# -*- coding: utf-8 -*-
+
+# Copyright (c) 2026 The Basicswap developers
+# Distributed under the MIT software license, see the accompanying
+# file LICENSE or http://www.opensource.org/licenses/mit-license.php.
+
+"""
+Tests for the restart/reorg hardening fixes:
+  R5  - coin B lock tx write-ahead idempotency (no double-broadcast after crash).
+  R6  - replayed XMR_BID_TXN_SIGS must not error the bid,
+        sendXmrBidCoinALockTx gated on bid state.
+  R7  - purged SEND_XMR_SWAP_LOCK_TX_B action is re-created.
+  R10 - lock refund tx depth re-queried when TX_CONFIRMED.
+"""
+
+import unittest
+from types import SimpleNamespace
+
+from basicswap.basicswap import BasicSwap
+from basicswap.basicswap_util import (
+    ActionTypes,
+    BidStates,
+    DebugTypes,
+    EventLogTypes,
+    TxStates,
+)
+from basicswap.chainparams import Coins
+from basicswap.messages_npb import XmrBidLockTxSigsMessage
+
+BID_ID = b"b" * 28
+REFUND_TXID = bytes.fromhex("cc" * 32)
+
+
+class StubLog:
+    def id(self, v):
+        return str(v)
+
+    def info(self, *args, **kwargs):
+        pass
+
+    def warning(self, *args, **kwargs):
+        pass
+
+    def debug(self, *args, **kwargs):
+        pass
+
+    def error(self, *args, **kwargs):
+        pass
+
+
+class StubTx:
+    def __init__(self, state=None, txid=REFUND_TXID, vout=0, block_height=10):
+        self.state = state
+        self.txid = txid
+        self.vout = vout
+        self.block_height = block_height
+        self.states_set = []
+
+    def setState(self, state):
+        self.states_set.append(state)
+        self.state = state
+
+
+def base_swap_client():
+    sc = BasicSwap.__new__(BasicSwap)
+    sc.fp = None
+    sc.log = StubLog()
+    sc.event_log = []  # (event_type, msg)
+    sc.commits = []
+    sc.saved = []
+    sc.bid_errors = []
+    sc.created_actions = []
+
+    sc.openDB = lambda cursor=None: object()
+    sc.closeDB = lambda cursor, commit=True: None
+    sc.commitDB = lambda: sc.commits.append(len(sc.event_log))
+    sc.logBidEvent = lambda bid_id, event, msg, cursor: sc.event_log.append(
+        (event, msg)
+    )
+    sc.countBidEvents = lambda bid, event, cursor: sum(
+        1 for e, _ in sc.event_log if e == event
+    )
+    sc.setBidError = lambda bid, msg, save_bid=True, xmr_swap=None, cursor=None: sc.bid_errors.append(
+        msg
+    )
+    sc.saveBidInSession = (
+        lambda bid_id, bid, cursor, xmr_swap=None, save_in_progress=None: sc.saved.append(
+            bid.state
+        )
+    )
+    sc.createActionInSession = lambda delay, action_type, bid_id, cursor: sc.created_actions.append(
+        action_type
+    )
+    sc.get_delay_event_seconds = lambda: 1
+    sc.is_reverse_ads_bid = lambda cf, ct: False
+    sc.isBchXmrSwap = lambda offer: False
+    sc.logIDT = lambda t: str(t)
+    sc.logIDM = lambda t: str(t)
+    return sc
+
+
+def make_offer():
+    return SimpleNamespace(
+        coin_from=int(Coins.BTC),
+        coin_to=int(Coins.PART),
+        offer_id=b"offer",
+        swap_type=None,
+    )
+
+
+# ---------------------------------------------------------------------------
+# R5 - coin B lock write-ahead idempotency
+# ---------------------------------------------------------------------------
+
+
+class StubCIB:
+    def __init__(self, calls):
+        self.calls = calls
+
+    def coin_name(self):
+        return "PART"
+
+    def publishBLockTx(self, vkbv, pkbs, amount, fee_rate, unlock_time=0):
+        self.calls.append("publish")
+        return bytes.fromhex("dd" * 32)
+
+
+def make_b_lock_client(bid):
+    sc = base_swap_client()
+    calls = []
+    sc.calls = calls
+    sc.commitDB = lambda: calls.append("commit")
+
+    orig_log = sc.logBidEvent
+    sc.logBidEvent = lambda bid_id, event, msg, cursor: (
+        sc.event_log.append((event, msg)),
+        calls.append(event),
+    )
+    assert orig_log  # silence lint
+
+    xmr_swap = SimpleNamespace(vkbv=b"v", pkbs=b"p", b_lock_tx_id=None)
+    offer = make_offer()
+    xmr_offer = SimpleNamespace(a_fee_rate=1, b_fee_rate=1)
+
+    sc.getXmrBidFromSession = lambda cursor, bid_id: (bid, xmr_swap)
+    sc.getXmrOfferFromSession = lambda cursor, offer_id: (offer, xmr_offer)
+    sc.findTxB = lambda ci, xmr_swap, bid, cursor, was_sent: False
+    sc.getPreFundedTx = lambda concept, bid_id, tx_type, cursor=None: None
+    sc.ci = lambda coin: StubCIB(calls)
+    return sc
+
+
+def make_b_lock_bid():
+    return SimpleNamespace(
+        bid_id=BID_ID,
+        offer_id=b"offer",
+        was_sent=True,
+        was_received=False,
+        debug_ind=DebugTypes.NONE,
+        xmr_b_lock_tx=None,
+        amount_to=1000,
+        state=BidStates.XMR_SWAP_SCRIPT_COIN_LOCKED,
+        setState=lambda s: None,
+    )
+
+
+class TestR5CoinBLockIdempotency(unittest.TestCase):
+    def test_write_ahead_marker_committed_before_broadcast(self):
+        bid = make_b_lock_bid()
+        sc = make_b_lock_client(bid)
+
+        sc.sendXmrBidCoinBLockTx(BID_ID, object())
+
+        calls = sc.calls
+        self.assertIn("publish", calls)
+        started_idx = calls.index(EventLogTypes.LOCK_TX_B_PUBLISH_STARTED)
+        commit_idx = calls.index("commit")
+        publish_idx = calls.index("publish")
+        published_idx = calls.index(EventLogTypes.LOCK_TX_B_PUBLISHED)
+        self.assertLess(started_idx, commit_idx)
+        self.assertLess(commit_idx, publish_idx)
+        self.assertLess(publish_idx, published_idx)
+        self.assertEqual(len(sc.bid_errors), 0)
+
+    def test_unmatched_marker_blocks_rebroadcast(self):
+        bid = make_b_lock_bid()
+        sc = make_b_lock_client(bid)
+        # Simulate a crash after the marker was committed but before the
+        # publish outcome was recorded.
+        sc.event_log.append((EventLogTypes.LOCK_TX_B_PUBLISH_STARTED, ""))
+
+        sc.sendXmrBidCoinBLockTx(BID_ID, object())
+
+        self.assertNotIn("publish", sc.calls)
+        self.assertEqual(len(sc.bid_errors), 1)
+
+    def test_failed_attempt_allows_retry(self):
+        bid = make_b_lock_bid()
+        sc = make_b_lock_client(bid)
+        # A previous attempt that failed cleanly must not block the retry.
+        sc.event_log.append((EventLogTypes.LOCK_TX_B_PUBLISH_STARTED, ""))
+        sc.event_log.append((EventLogTypes.FAILED_TX_B_LOCK_PUBLISH, "err"))
+
+        sc.sendXmrBidCoinBLockTx(BID_ID, object())
+
+        self.assertIn("publish", sc.calls)
+        self.assertEqual(len(sc.bid_errors), 0)
+
+
+# ---------------------------------------------------------------------------
+# R6 - replayed XMR_BID_TXN_SIGS / sendXmrBidCoinALockTx state gate
+# ---------------------------------------------------------------------------
+
+
+class TestR6ReplayedSigsMessage(unittest.TestCase):
+    def make_sigs_msg_client(self, bid):
+        sc = base_swap_client()
+        xmr_swap = SimpleNamespace()
+        offer = make_offer()
+        offer.addr_from = "addr_offerer"
+        offer.was_sent = False
+        xmr_offer = SimpleNamespace()
+
+        msg_buf = XmrBidLockTxSigsMessage(
+            bid_msg_id=BID_ID,
+            af_lock_refund_spend_tx_esig=b"\x01" * 32,
+            af_lock_refund_tx_sig=b"\x02" * 32,
+        )
+        msg = {
+            "msgid": "aa" * 28,
+            "to": "addr_offerer",
+            "from": "addr_bidder",
+            "hex": "00" + msg_buf.to_bytes().hex() + "00",
+        }
+        sc.getSmsgMsgBytes = lambda m: msg_buf.to_bytes()
+        sc.getXmrBid = lambda bid_id: (bid, xmr_swap)
+        sc.getXmrOffer = lambda offer_id: (offer, xmr_offer)
+        sc.ci = lambda coin: SimpleNamespace(curve_type=lambda: None)
+        return sc, msg
+
+    def test_replayed_message_does_not_error_bid(self):
+        # Bid has already progressed past BID_ACCEPTED.
+        bid = SimpleNamespace(
+            bid_id=BID_ID,
+            offer_id=b"offer",
+            state=BidStates.XMR_SWAP_MSG_SCRIPT_LOCK_TX_SIGS,
+            was_sent=False,
+            was_received=True,
+            bid_addr="addr_bidder",
+        )
+        sc, msg = self.make_sigs_msg_client(bid)
+
+        with self.assertRaises(ValueError):
+            sc.processXmrBidCoinALockSigs(msg)
+
+        # The state guard must reject the replay without erroring the bid.
+        self.assertEqual(len(sc.bid_errors), 0)
+        self.assertEqual(bid.state, BidStates.XMR_SWAP_MSG_SCRIPT_LOCK_TX_SIGS)
+
+
+class TestR6CoinALockStateGate(unittest.TestCase):
+    def test_errored_bid_does_not_publish_coin_a(self):
+        sc = base_swap_client()
+        bid = SimpleNamespace(
+            bid_id=BID_ID,
+            offer_id=b"offer",
+            state=BidStates.BID_ERROR,
+        )
+        xmr_swap = SimpleNamespace()
+        sc.getXmrBidFromSession = lambda cursor, bid_id: (bid, xmr_swap)
+
+        def fail_offer_lookup(cursor, offer_id):
+            raise AssertionError("Should have returned before the offer lookup")
+
+        sc.getXmrOfferFromSession = fail_offer_lookup
+
+        sc.sendXmrBidCoinALockTx(BID_ID, object())
+        self.assertEqual(len(sc.bid_errors), 0)
+
+    def test_expected_state_proceeds(self):
+        sc = base_swap_client()
+        bid = SimpleNamespace(
+            bid_id=BID_ID,
+            offer_id=b"offer",
+            state=BidStates.XMR_SWAP_MSG_SCRIPT_LOCK_TX_SIGS,
+        )
+        xmr_swap = SimpleNamespace()
+        sc.getXmrBidFromSession = lambda cursor, bid_id: (bid, xmr_swap)
+
+        sentinel = RuntimeError("reached offer lookup")
+
+        def offer_lookup(cursor, offer_id):
+            raise sentinel
+
+        sc.getXmrOfferFromSession = offer_lookup
+
+        with self.assertRaises(RuntimeError):
+            sc.sendXmrBidCoinALockTx(BID_ID, object())
+
+
+# ---------------------------------------------------------------------------
+# R7 / R10 - checkXmrBidState based tests
+# ---------------------------------------------------------------------------
+
+
+class StubCIA:
+    def __init__(
+        self, blocks_confirmed=2, refund_chain_info=None, have_signed_refund=False
+    ):
+        self.blocks_confirmed = blocks_confirmed
+        self.coin_ticker = "BTC"
+        self._refund_chain_info = refund_chain_info
+        self._have_signed_refund = have_signed_refund
+
+    def getSCLockScriptAddress(self, script):
+        return "addr"
+
+    def getLockRefundTxSwapOutputValue(self, bid, xmr_swap):
+        return 1000
+
+    def getLockTxHeight(self, txid, dest_address, bid_amount, rescan_from, vout=None):
+        return self._refund_chain_info
+
+    def haveSignedLockRefundTx(self, xmr_swap):
+        return self._have_signed_refund
+
+    def isCsvLockMature(self, lock_type, lock_time, block_height, block_time):
+        return False
+
+
+def make_check_state_client(ci, bid, xmr_swap):
+    sc = base_swap_client()
+    xmr_offer = SimpleNamespace(lock_time_1=10, lock_time_2=10)
+    sc.queryOne = lambda model, cursor, filters: (
+        xmr_offer if model.__name__ == "XmrOffer" else xmr_swap
+    )
+    sc.ci = lambda coin: ci
+    sc.add = lambda obj, cursor, upsert=False: sc.saved.append(obj)
+    sc.setTxBlockInfoFromHeight = lambda ci_, tx, height: None
+    sc.findTxB = lambda ci_, xmr_swap_, bid_, cursor, was_sent: False
+    sc.countQueuedActions = lambda cursor, bid_id, action_type: 0
+    sc.haveDebugInd = lambda bid_id, ind: False
+    return sc
+
+
+def make_refund_bid(state, refund_tx):
+    from basicswap.basicswap_util import TxTypes
+
+    return SimpleNamespace(
+        bid_id=BID_ID,
+        offer_id=b"offer",
+        state=state,
+        was_sent=False,
+        was_received=False,
+        chain_a_height_start=1,
+        txns={TxTypes.XMR_SWAP_A_LOCK_REFUND: refund_tx},
+        xmr_a_lock_tx=None,
+        xmr_b_lock_tx=None,
+        debug_ind=DebugTypes.NONE,
+    )
+
+
+class TestR10RefundDepthRequery(unittest.TestCase):
+    def run_check(self, refund_tx, chain_info):
+        xmr_swap = SimpleNamespace(a_lock_refund_tx_script=b"script")
+        bid = make_refund_bid(BidStates.SWAP_COMPLETED, refund_tx)
+        ci = StubCIA(blocks_confirmed=2, refund_chain_info=chain_info)
+        sc = make_check_state_client(ci, bid, xmr_swap)
+        offer = make_offer()
+        sc.checkXmrBidState(BID_ID, bid, offer)
+        return sc
+
+    def test_reorged_refund_reverts_cached_state(self):
+        refund_tx = StubTx(state=TxStates.TX_CONFIRMED)
+        sc = self.run_check(refund_tx, {"height": 100, "depth": 1})
+
+        self.assertEqual(refund_tx.state, TxStates.TX_IN_CHAIN)
+        self.assertEqual(refund_tx.states_set, [TxStates.TX_IN_CHAIN])
+        assert sc is not None
+
+    def test_evicted_refund_reverts_to_mempool_state(self):
+        refund_tx = StubTx(state=TxStates.TX_CONFIRMED)
+        self.run_check(refund_tx, {"height": 0, "depth": 0})
+
+        self.assertEqual(refund_tx.state, TxStates.TX_IN_MEMPOOL)
+
+    def test_still_confirmed_no_state_change(self):
+        refund_tx = StubTx(state=TxStates.TX_CONFIRMED)
+        sc = self.run_check(refund_tx, {"height": 100, "depth": 5})
+
+        self.assertEqual(refund_tx.state, TxStates.TX_CONFIRMED)
+        self.assertEqual(refund_tx.states_set, [])
+        # No duplicate confirmed event.
+        self.assertEqual(
+            sum(
+                1
+                for e, _ in sc.event_log
+                if e == EventLogTypes.LOCK_TX_A_REFUND_TX_CONFIRMED
+            ),
+            0,
+        )
+
+    def test_query_failure_keeps_confirmed_state(self):
+        refund_tx = StubTx(state=TxStates.TX_CONFIRMED)
+        self.run_check(refund_tx, None)
+
+        self.assertEqual(refund_tx.state, TxStates.TX_CONFIRMED)
+        self.assertEqual(refund_tx.states_set, [])
+
+    def test_fresh_confirmation_still_recorded(self):
+        refund_tx = StubTx(state=TxStates.TX_IN_CHAIN)
+        sc = self.run_check(refund_tx, {"height": 100, "depth": 2})
+
+        self.assertEqual(refund_tx.state, TxStates.TX_CONFIRMED)
+        self.assertEqual(
+            sum(
+                1
+                for e, _ in sc.event_log
+                if e == EventLogTypes.LOCK_TX_A_REFUND_TX_CONFIRMED
+            ),
+            1,
+        )
+
+
+class TestR7RequeueLockTxB(unittest.TestCase):
+    def run_check(self, bid, queued_count=0):
+        xmr_swap = SimpleNamespace(a_lock_refund_tx_script=b"script")
+        ci = StubCIA(blocks_confirmed=2)
+        sc = make_check_state_client(ci, bid, xmr_swap)
+        sc.countQueuedActions = lambda cursor, bid_id, action_type: queued_count
+        offer = make_offer()
+        sc.checkXmrBidState(BID_ID, bid, offer)
+        return sc
+
+    def make_bid(self, state):
+        return SimpleNamespace(
+            bid_id=BID_ID,
+            offer_id=b"offer",
+            state=state,
+            was_sent=True,
+            was_received=False,
+            chain_a_height_start=1,
+            txns={},
+            xmr_a_lock_tx=None,
+            xmr_b_lock_tx=None,
+            debug_ind=DebugTypes.NONE,
+        )
+
+    def test_purged_action_is_recreated(self):
+        bid = self.make_bid(BidStates.XMR_SWAP_SCRIPT_COIN_LOCKED)
+        sc = self.run_check(bid, queued_count=0)
+
+        self.assertIn(ActionTypes.SEND_XMR_SWAP_LOCK_TX_B, sc.created_actions)
+
+    def test_existing_action_not_duplicated(self):
+        bid = self.make_bid(BidStates.XMR_SWAP_SCRIPT_COIN_LOCKED)
+        sc = self.run_check(bid, queued_count=1)
+
+        self.assertNotIn(ActionTypes.SEND_XMR_SWAP_LOCK_TX_B, sc.created_actions)
+
+    def test_not_recreated_in_prerefund_state(self):
+        bid = self.make_bid(BidStates.XMR_SWAP_SCRIPT_TX_PREREFUND)
+        sc = self.run_check(bid, queued_count=0)
+
+        self.assertNotIn(ActionTypes.SEND_XMR_SWAP_LOCK_TX_B, sc.created_actions)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/basicswap/test_electrum_median_time.py
+++ b/tests/basicswap/test_electrum_median_time.py
@@ -1,0 +1,141 @@
+# -*- coding: utf-8 -*-
+
+# Copyright (c) 2026 The Basicswap developers
+# Distributed under the MIT software license, see the accompanying
+# file LICENSE or http://www.opensource.org/licenses/mit-license.php.
+
+import struct
+import unittest
+
+from basicswap.interface.btc.btc import BTCInterface
+from basicswap.basicswap_util import TxLockTypes
+
+
+def make_header(timestamp: int) -> bytes:
+    header = bytearray(80)
+    header[68:72] = struct.pack("<I", timestamp)
+    return bytes(header)
+
+
+class StubLog:
+    def id(self, v):
+        return str(v)
+
+    def error(self, *args, **kwargs):
+        pass
+
+    def warning(self, *args, **kwargs):
+        pass
+
+    def debug(self, *args, **kwargs):
+        pass
+
+
+class StubServer:
+    def __init__(self, headers=None, raise_on_call=False):
+        self._headers = headers or []
+        self._raise_on_call = raise_on_call
+        self.call_count = 0
+
+    def call(self, method, params):
+        self.call_count += 1
+        if self._raise_on_call:
+            raise RuntimeError("server error")
+        if method == "blockchain.block.headers":
+            joined = b"".join(self._headers)
+            return {"hex": joined.hex(), "count": len(self._headers)}
+        raise RuntimeError(f"unexpected call {method}")
+
+
+class StubBackend:
+    def __init__(self, server, height=100, raise_on_height=False):
+        self._server = server
+        self._height = height
+        self._raise_on_height = raise_on_height
+
+    def getBlockHeight(self):
+        if self._raise_on_height:
+            raise RuntimeError("no connection")
+        return self._height
+
+
+def make_interface(backend):
+    ci = BTCInterface.__new__(BTCInterface)
+    ci._log = StubLog()
+    ci._connection_type = "electrum"
+    ci._backend = backend
+    ci._median_time_cache = None
+    ci._median_time_cache_height = None
+    return ci
+
+
+class TestElectrumMedianTime(unittest.TestCase):
+    def test_successful_fetch(self):
+        timestamps = list(range(1000, 1011))
+        headers = [make_header(t) for t in timestamps]
+        backend = StubBackend(StubServer(headers), height=100)
+        ci = make_interface(backend)
+        self.assertEqual(ci.getChainMedianTime(), 1005)
+        self.assertEqual(ci._median_time_cache, 1005)
+        self.assertEqual(ci._median_time_cache_height, 100)
+
+    def test_server_error_returns_none_without_cache(self):
+        backend = StubBackend(StubServer(raise_on_call=True), height=100)
+        ci = make_interface(backend)
+        self.assertIsNone(ci.getChainMedianTime())
+
+    def test_server_error_returns_cached_value(self):
+        backend = StubBackend(StubServer(raise_on_call=True), height=100)
+        ci = make_interface(backend)
+        ci._median_time_cache = 1005
+        ci._median_time_cache_height = 99
+        self.assertEqual(ci.getChainMedianTime(), 1005)
+
+    def test_height_error_returns_cached_value(self):
+        backend = StubBackend(StubServer(), height=100, raise_on_height=True)
+        ci = make_interface(backend)
+        ci._median_time_cache = 1005
+        self.assertEqual(ci.getChainMedianTime(), 1005)
+
+    def test_no_backend_returns_none(self):
+        ci = make_interface(None)
+        # useBackend() is False with no backend, rpc path raises -> fail soft
+        ci.rpc = lambda *args: (_ for _ in ()).throw(RuntimeError("no rpc"))
+        self.assertIsNone(ci.getChainMedianTime())
+
+    def test_cache_reused_when_height_unchanged(self):
+        timestamps = list(range(1000, 1011))
+        headers = [make_header(t) for t in timestamps]
+        server = StubServer(headers)
+        backend = StubBackend(server, height=100)
+        ci = make_interface(backend)
+        self.assertEqual(ci.getChainMedianTime(), 1005)
+        self.assertEqual(ci.getChainMedianTime(), 1005)
+        self.assertEqual(server.call_count, 1)
+
+    def test_empty_headers_fails_soft(self):
+        backend = StubBackend(StubServer(headers=[]), height=100)
+        ci = make_interface(backend)
+        self.assertIsNone(ci.getChainMedianTime())
+
+    def test_csv_lock_not_mature_when_mtp_unknown(self):
+        backend = StubBackend(StubServer(raise_on_call=True), height=100)
+        ci = make_interface(backend)
+        encoded_sequence = ci.getExpectedSequence(TxLockTypes.SEQUENCE_LOCK_TIME, 3600)
+        self.assertFalse(
+            ci.isCsvLockMature(
+                TxLockTypes.SEQUENCE_LOCK_TIME,
+                encoded_sequence,
+                parent_block_height=50,
+                parent_block_time=1000,
+            )
+        )
+
+    def test_abs_lock_not_mature_when_mtp_unknown(self):
+        backend = StubBackend(StubServer(raise_on_call=True), height=100)
+        ci = make_interface(backend)
+        self.assertFalse(ci.isAbsLockTimeMature(500000001))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/basicswap/test_electrum_merkle_adversarial.py
+++ b/tests/basicswap/test_electrum_merkle_adversarial.py
@@ -1,0 +1,107 @@
+# -*- coding: utf-8 -*-
+
+# Copyright (c) 2026 The Basicswap developers
+# Distributed under the MIT software license, see the accompanying
+# file LICENSE or http://www.opensource.org/licenses/mit-license.php.
+
+import unittest
+
+from basicswap.interface.btc.btc import BTCInterface
+
+GENESIS_HEADER_HEX = (
+    "0100000000000000000000000000000000000000000000000000000000000000000000003b"
+    "a3edfd7a7b12b27ac72c3e67768f617fc81bc3888a51323a9fb8aa4b1e5e4a29ab5f49ffff"
+    "001d1dac2b7c"
+)
+GENESIS_COINBASE_TXID = (
+    "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"
+)
+
+
+class StubLog:
+    def id(self, v):
+        return str(v)
+
+    def error(self, *args, **kwargs):
+        pass
+
+    def debug(self, *args, **kwargs):
+        pass
+
+
+class StubServer:
+    def __init__(self, merkle_result, header_hex, raise_on_merkle=False):
+        self._merkle_result = merkle_result
+        self._header_hex = header_hex
+        self._raise_on_merkle = raise_on_merkle
+
+    def get_merkle(self, txid, height):
+        if self._raise_on_merkle:
+            raise RuntimeError("no merkle support")
+        return self._merkle_result
+
+    def call(self, method, params):
+        if method == "blockchain.block.header":
+            return self._header_hex
+        raise RuntimeError(f"unexpected call {method}")
+
+
+class StubBackend:
+    def __init__(self, server):
+        self._server = server
+
+
+def make_interface():
+    ci = BTCInterface.__new__(BTCInterface)
+    ci._log = StubLog()
+    ci._merkle_verified = {}
+    return ci
+
+
+class TestElectrumMerkleAdversarial(unittest.TestCase):
+    def test_honest_server_verifies(self):
+        ci = make_interface()
+        server = StubServer({"merkle": [], "pos": 0}, GENESIS_HEADER_HEX)
+        backend = StubBackend(server)
+        self.assertTrue(ci._verifyTxMerkleElectrum(backend, GENESIS_COINBASE_TXID, 1))
+
+    def test_phantom_height_bad_merkle_fails_closed(self):
+        ci = make_interface()
+        server = StubServer({"merkle": ["cc" * 32], "pos": 0}, GENESIS_HEADER_HEX)
+        backend = StubBackend(server)
+        self.assertFalse(
+            ci._verifyTxMerkleElectrum(backend, GENESIS_COINBASE_TXID, 100000)
+        )
+
+    def test_missing_merkle_support_fails_closed(self):
+        ci = make_interface()
+        server = StubServer(None, GENESIS_HEADER_HEX, raise_on_merkle=True)
+        backend = StubBackend(server)
+        self.assertFalse(
+            ci._verifyTxMerkleElectrum(backend, GENESIS_COINBASE_TXID, 100000)
+        )
+
+    def test_tampered_header_fails_closed(self):
+        ci = make_interface()
+        tampered = bytearray(bytes.fromhex(GENESIS_HEADER_HEX))
+        tampered[76] ^= 0x01
+        server = StubServer({"merkle": [], "pos": 0}, bytes(tampered).hex())
+        backend = StubBackend(server)
+        self.assertFalse(ci._verifyTxMerkleElectrum(backend, GENESIS_COINBASE_TXID, 1))
+
+    def test_zero_height_fails_closed(self):
+        ci = make_interface()
+        server = StubServer({"merkle": [], "pos": 0}, GENESIS_HEADER_HEX)
+        backend = StubBackend(server)
+        self.assertFalse(ci._verifyTxMerkleElectrum(backend, GENESIS_COINBASE_TXID, 0))
+
+    def test_verified_result_is_cached(self):
+        ci = make_interface()
+        server = StubServer({"merkle": [], "pos": 0}, GENESIS_HEADER_HEX)
+        backend = StubBackend(server)
+        self.assertTrue(ci._verifyTxMerkleElectrum(backend, GENESIS_COINBASE_TXID, 1))
+        self.assertEqual(ci._merkle_verified.get(GENESIS_COINBASE_TXID), 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/basicswap/test_electrum_server_selection.py
+++ b/tests/basicswap/test_electrum_server_selection.py
@@ -1,0 +1,69 @@
+# -*- coding: utf-8 -*-
+
+# Copyright (c) 2026 The Basicswap developers
+# Distributed under the MIT software license, see the accompanying
+# file LICENSE or http://www.opensource.org/licenses/mit-license.php.
+
+import unittest
+
+from basicswap.interface.electrumx import ElectrumServer
+
+ONION = "abcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefab.onion:50001:false"
+CLEARNET = "electrum.example.com:50002:true"
+
+
+class TestElectrumServerSelection(unittest.TestCase):
+    def test_tor_with_onion_only_uses_onion(self):
+        server = ElectrumServer(
+            "bitcoin",
+            onion_servers=[ONION],
+            proxy_host="127.0.0.1",
+            proxy_port=9050,
+        )
+        hosts = [s["host"] for s in server._servers]
+        self.assertEqual(len(hosts), 1)
+        self.assertTrue(hosts[0].endswith(".onion"))
+
+    def test_tor_with_onion_and_clearnet_uses_onion_only(self):
+        server = ElectrumServer(
+            "bitcoin",
+            clearnet_servers=[CLEARNET],
+            onion_servers=[ONION],
+            proxy_host="127.0.0.1",
+            proxy_port=9050,
+        )
+        hosts = [s["host"] for s in server._servers]
+        self.assertEqual(len(hosts), 1)
+        self.assertTrue(hosts[0].endswith(".onion"))
+
+    def test_tor_without_onion_falls_back_to_clearnet(self):
+        server = ElectrumServer(
+            "bitcoin",
+            clearnet_servers=[CLEARNET],
+            proxy_host="127.0.0.1",
+            proxy_port=9050,
+        )
+        hosts = [s["host"] for s in server._servers]
+        self.assertIn("electrum.example.com", hosts)
+
+    def test_tor_without_any_config_uses_default_clearnet(self):
+        server = ElectrumServer(
+            "bitcoin",
+            proxy_host="127.0.0.1",
+            proxy_port=9050,
+        )
+        self.assertGreater(len(server._servers), 0)
+
+    def test_no_tor_uses_clearnet_only(self):
+        server = ElectrumServer(
+            "bitcoin",
+            clearnet_servers=[CLEARNET],
+            onion_servers=[ONION],
+        )
+        hosts = [s["host"] for s in server._servers]
+        self.assertNotIn(ONION.split(":")[0], hosts)
+        self.assertIn("electrum.example.com", hosts)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/basicswap/test_merkle.py
+++ b/tests/basicswap/test_merkle.py
@@ -1,0 +1,109 @@
+# -*- coding: utf-8 -*-
+
+# Copyright (c) 2026 The Basicswap developers
+# Distributed under the MIT software license, see the accompanying
+# file LICENSE or http://www.opensource.org/licenses/mit-license.php.
+
+import struct
+import unittest
+
+from hashlib import sha256
+
+from basicswap.util.merkle import (
+    check_header_pow,
+    electrum_merkle_root,
+    header_bits,
+    parse_header_merkle_root,
+    target_from_bits,
+    verify_tx_merkle_proof,
+)
+
+
+def dsha256(data: bytes) -> bytes:
+    return sha256(sha256(data).digest()).digest()
+
+
+GENESIS_HEADER_HEX = (
+    "0100000000000000000000000000000000000000000000000000000000000000000000003b"
+    "a3edfd7a7b12b27ac72c3e67768f617fc81bc3888a51323a9fb8aa4b1e5e4a29ab5f49ffff"
+    "001d1dac2b7c"
+)
+GENESIS_COINBASE_TXID = (
+    "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"
+)
+
+
+def build_regtest_header(merkle_root_le: bytes) -> bytes:
+    version = struct.pack("<I", 1)
+    prev = bytes(32)
+    time_field = struct.pack("<I", 1000)
+    bits = struct.pack("<I", 0x207FFFFF)
+    nonce = struct.pack("<I", 0)
+    return version + prev + merkle_root_le + time_field + bits + nonce
+
+
+class TestMerkle(unittest.TestCase):
+    def test_single_tx_root_equals_txid(self):
+        header_bytes = bytes.fromhex(GENESIS_HEADER_HEX)
+        self.assertEqual(len(header_bytes), 80)
+        root = electrum_merkle_root(GENESIS_COINBASE_TXID, [], 0)
+        self.assertEqual(root, parse_header_merkle_root(header_bytes))
+
+    def test_genesis_pow_valid(self):
+        header_bytes = bytes.fromhex(GENESIS_HEADER_HEX)
+        self.assertTrue(check_header_pow(header_bytes))
+
+    def test_verify_full_genesis(self):
+        header_bytes = bytes.fromhex(GENESIS_HEADER_HEX)
+        self.assertTrue(
+            verify_tx_merkle_proof(GENESIS_COINBASE_TXID, header_bytes, [], 0)
+        )
+
+    def test_two_tx_branch(self):
+        txa = "aa" * 32
+        txb = "bb" * 32
+        txa_le = bytes.fromhex(txa)[::-1]
+        txb_le = bytes.fromhex(txb)[::-1]
+        root_le = dsha256(txa_le + txb_le)
+        header_bytes = build_regtest_header(root_le)
+
+        self.assertTrue(
+            verify_tx_merkle_proof(txa, header_bytes, [txb], 0, require_pow=False)
+        )
+        self.assertTrue(
+            verify_tx_merkle_proof(txb, header_bytes, [txa], 1, require_pow=False)
+        )
+
+    def test_bad_branch_fails(self):
+        txa = "aa" * 32
+        txb = "bb" * 32
+        txc = "cc" * 32
+        txa_le = bytes.fromhex(txa)[::-1]
+        txb_le = bytes.fromhex(txb)[::-1]
+        root_le = dsha256(txa_le + txb_le)
+        header_bytes = build_regtest_header(root_le)
+
+        self.assertFalse(
+            verify_tx_merkle_proof(txa, header_bytes, [txc], 0, require_pow=False)
+        )
+
+    def test_bits_and_target(self):
+        header_bytes = bytes.fromhex(GENESIS_HEADER_HEX)
+        self.assertEqual(header_bits(header_bytes), 0x1D00FFFF)
+        self.assertEqual(
+            target_from_bits(0x1D00FFFF),
+            0x00000000FFFF0000000000000000000000000000000000000000000000000000,
+        )
+
+    def test_pow_fails_on_tampered_header(self):
+        header_bytes = bytearray(bytes.fromhex(GENESIS_HEADER_HEX))
+        header_bytes[36] ^= 0xFF
+        self.assertFalse(check_header_pow(bytes(header_bytes)))
+
+    def test_short_header_raises(self):
+        with self.assertRaises(ValueError):
+            parse_header_merkle_root(b"\x00" * 40)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
- Confirmation checks, lock-tx depth is verified with merkle proofs and block PoW before it's used.
- Conservative defaults, unverified txs are treated as unconfirmed (depth 0) until proof passes.
- Cleaner spend detection, script watches wait for a confirmed height before acting.
- Safer funding, UTXOs are reserved per bid so concurrent swaps don't overlap inputs.
- Tests: test_merkle.py test_electrum_merkle_adversarial.py test_electrum_median_time.py test_electrum_server_selection.py, test_ads_spend_depth_gate.py, test_ads_swap_recovery.py.
- getChainMedianTime fails softly (cached fallback); time locks wait when MTP is unknown.
- Tor: With Tor on and onion servers configured, only .onion servers are used (no clearnet fallback).
- Happy-path completion: Lock spend must reach blocks_confirmed before SWAP_COMPLETED / redeem.
- Bid loop stability: swaps_in_progress iterated via snapshot to avoid concurrent mutation crashes.
- Block-lock offers: ABS_LOCK_BLOCKS_LEEWAY defined; absolute-block-lock accepts no longer crash.
- Coin B lock safety: publish is recorded in the DB before broadcast; after an unclean shutdown.
- Replayed messages: duplicate bid sig messages are rejected without erroring the bid; coin A lock only publishes in the expected bid state.
- Restart recovery: if the send-coin-B-lock action was lost on restart, it is re-created automatically.
- Refund reorg handling: lock refund tx depth is re-checked after confirmation; if a reorg drops it below required depth, the bid waits again.