### PR TITLE
amm: remove redundant check fixed-total offers

### DIFF
--- a/scripts/createoffers.py
+++ b/scripts/createoffers.py
@@ -818,13 +818,6 @@ def process_offers(args, config, script_state) -> None:
                 template_fixed_remaining = round(
                     total_to_sell - total_sold - template_in_flight, 8
                 )
-                if template_fixed_remaining < 0.001:
-                    print(
-                        f"Template {offer_template['name']} exhausted "
-                        f"(fixed_total, sold {total_sold} of {total_to_sell}"
-                        f", in-flight {template_in_flight}), not reposting"
-                    )
-                    continue
 
             if template_exhausted:
                 template_tracking["exhausted"] = True


### PR DESCRIPTION
https://github.com/basicswap/basicswap/commit/4762e2c83ebb80e62820b0839b1852ee71f720ad made it so that an an in-flight offer would be revoked and reposted with remaining amount.

the check being removed in this pr functions to skip reposting of the offer if the in-flight + filled amount = exhausted, but it leaves the stale offer live (it prevents the above revoke from being hit). Instead if adding another revoke here, its best to just remove this check since it is redundant now.

the revoke https://github.com/basicswap/basicswap/commit/4762e2c83ebb80e62820b0839b1852ee71f720ad fully supercedes the removed check. If the offer is in-flight and doesnt have enough funds left, it wont repost. if it does have enough funds, it will post the adjusted offer. If it is exhausted, it falls through to the fully filled check.