### PR TITLE
Electrum: Use onion servers only when Tor is enabled.

### DIFF
--- a/basicswap/interface/electrumx.py
+++ b/basicswap/interface/electrumx.py
@@ -571,7 +571,7 @@ class ElectrumServer:
         self._using_default_servers = not user_clearnet and not user_onion
 
         if use_tor:
-            if user_onion and not user_clearnet:
+            if user_onion:
                 final_clearnet = []
             else:
                 final_clearnet = (

--- a/tests/basicswap/test_electrum_server_selection.py
+++ b/tests/basicswap/test_electrum_server_selection.py
@@ -1,0 +1,69 @@
+# -*- coding: utf-8 -*-
+
+# Copyright (c) 2026 The Basicswap developers
+# Distributed under the MIT software license, see the accompanying
+# file LICENSE or http://www.opensource.org/licenses/mit-license.php.
+
+import unittest
+
+from basicswap.interface.electrumx import ElectrumServer
+
+ONION = "abcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefab.onion:50001:false"
+CLEARNET = "electrum.example.com:50002:true"
+
+
+class TestElectrumServerSelection(unittest.TestCase):
+    def test_tor_with_onion_only_uses_onion(self):
+        server = ElectrumServer(
+            "bitcoin",
+            onion_servers=[ONION],
+            proxy_host="127.0.0.1",
+            proxy_port=9050,
+        )
+        hosts = [s["host"] for s in server._servers]
+        self.assertEqual(len(hosts), 1)
+        self.assertTrue(hosts[0].endswith(".onion"))
+
+    def test_tor_with_onion_and_clearnet_uses_onion_only(self):
+        server = ElectrumServer(
+            "bitcoin",
+            clearnet_servers=[CLEARNET],
+            onion_servers=[ONION],
+            proxy_host="127.0.0.1",
+            proxy_port=9050,
+        )
+        hosts = [s["host"] for s in server._servers]
+        self.assertEqual(len(hosts), 1)
+        self.assertTrue(hosts[0].endswith(".onion"))
+
+    def test_tor_without_onion_falls_back_to_clearnet(self):
+        server = ElectrumServer(
+            "bitcoin",
+            clearnet_servers=[CLEARNET],
+            proxy_host="127.0.0.1",
+            proxy_port=9050,
+        )
+        hosts = [s["host"] for s in server._servers]
+        self.assertIn("electrum.example.com", hosts)
+
+    def test_tor_without_any_config_uses_default_clearnet(self):
+        server = ElectrumServer(
+            "bitcoin",
+            proxy_host="127.0.0.1",
+            proxy_port=9050,
+        )
+        self.assertGreater(len(server._servers), 0)
+
+    def test_no_tor_uses_clearnet_only(self):
+        server = ElectrumServer(
+            "bitcoin",
+            clearnet_servers=[CLEARNET],
+            onion_servers=[ONION],
+        )
+        hosts = [s["host"] for s in server._servers]
+        self.assertNotIn(ONION.split(":")[0], hosts)
+        self.assertIn("electrum.example.com", hosts)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
- With Tor enabled and onion servers configured, only .onion servers are used, no clearnet fallback.
- Previously clearnet servers were still mixed in unless the clearnet list was empty.
- New tests: test_electrum_server_selection.py (onion-only, onion+clearnet, Tor without onion, defaults, no Tor).