### PR TITLE
header: go to the correct bids page

### DIFF
--- a/basicswap/static/js/pages/bids-tab-navigation.js
+++ b/basicswap/static/js/pages/bids-tab-navigation.js
@@ -41,15 +41,14 @@
                     if (window.location.pathname === '/bids') {
                         navigateToTabDirectly(targetTabId);
                     } else {
-                        localStorage.setItem('bidsTabToActivate', targetTabId.replace('#', ''));
-                        window.location.href = '/bids';
+                        window.location.href = '/bids' + targetTabId;
                     }
                 }
             });
         });
 
         window.bidsTabNavigationInitialized = true;
-        
+
     }
 
     function handleInitialNavigation() {
@@ -57,13 +56,7 @@
             return;
         }
 
-        const tabToActivate = localStorage.getItem('bidsTabToActivate');
-
-        if (tabToActivate) {
-
-            localStorage.removeItem('bidsTabToActivate');
-            activateTabWithRetry('#' + tabToActivate);
-        } else if (window.location.hash) {
+        if (window.location.hash) {
 
             activateTabWithRetry(window.location.hash);
         } else {
@@ -209,8 +202,7 @@
         if (window.location.pathname === '/bids') {
             navigateToTabDirectly('#' + tabId);
         } else {
-            localStorage.setItem('bidsTabToActivate', tabId);
-            window.location.href = '/bids';
+            window.location.href = '/bids#' + tabId;
         }
     };
 })();

--- a/basicswap/templates/bids.html
+++ b/basicswap/templates/bids.html
@@ -132,8 +132,8 @@
         </optgroup>
        </select>
       </div>
-     </div> 
-     
+     </div>
+
      <!-- todo
      <div class="w-full md:w-auto p-1.5">
       <div class="relative">
@@ -453,7 +453,6 @@
   </div>
  </div>
 
-<script src="/static/js/pages/bids-tab-navigation.js"></script>
 <script src="/static/js/pages/bids-page.js"></script>
 <script src="/static/js/pages/bids-export.js"></script>
 

--- a/basicswap/templates/header.html
+++ b/basicswap/templates/header.html
@@ -116,6 +116,7 @@
   <script src="/static/js/modules/memory-manager.js"></script>
   <!-- Main application script -->
   <script src="/static/js/global.js"></script>
+  <script src="/static/js/pages/bids-tab-navigation.js"></script>
 
 </head>
 <body class="dark:bg-gray-700">


### PR DESCRIPTION
Fixes issue: When clicking on "bids" or the arrows it is supposed to take you to all, sent, or received tabs, but this only worked when already on the /bids page

change gets rid of the localstorage and directs user to /bids#sent etc instead (so browser navigation survives) , moves the import from the /bids page to the header (so that it works on every page)