### PR TITLE
Ads: Swap reliability and recovery.

### DIFF
--- a/basicswap/basicswap.py
+++ b/basicswap/basicswap.py
@@ -2580,6 +2580,7 @@ class BasicSwap(BaseApp, BSXNetwork, UIApp):
     def _transferLiteWalletBalanceToRPC(self, coin_type: Coins) -> dict:
         try:
 
+            for bid_id, swap in list(self.swaps_in_progress.items()):
                 try:
                     if hasattr(swap, "coin_from") and swap.coin_from == coin_type:
                         self.log.warning(

--- a/basicswap/basicswap.py
+++ b/basicswap/basicswap.py
@@ -2058,7 +2058,7 @@ class BasicSwap(BaseApp, BSXNetwork, UIApp):
             return result
 
         try:
-            for bid_id, swap in self.swaps_in_progress.items():
+            for bid_id, swap in list(self.swaps_in_progress.items()):
                 try:
                     bid, offer = swap
                     if offer.coin_from == coin_type or offer.coin_to == coin_type:
@@ -2168,7 +2168,7 @@ class BasicSwap(BaseApp, BSXNetwork, UIApp):
 
     def _checkRPCWalletEmpty(self, coin_type: Coins) -> dict:
         try:
-            for bid_id, swap in self.swaps_in_progress.items():
+            for bid_id, swap in list(self.swaps_in_progress.items()):
                 try:
                     if hasattr(swap, "coin_from") and swap.coin_from == coin_type:
                         return {
@@ -2216,7 +2216,7 @@ class BasicSwap(BaseApp, BSXNetwork, UIApp):
 
     def _checkElectrumWalletEmpty(self, coin_type: Coins) -> dict:
         try:
-            for bid_id, swap in self.swaps_in_progress.items():
+            for bid_id, swap in list(self.swaps_in_progress.items()):
                 try:
                     if hasattr(swap, "coin_from") and swap.coin_from == coin_type:
                         return {
@@ -2580,7 +2580,6 @@ class BasicSwap(BaseApp, BSXNetwork, UIApp):
     def _transferLiteWalletBalanceToRPC(self, coin_type: Coins) -> dict:
         try:
 
-            for bid_id, swap in self.swaps_in_progress.items():
                 try:
                     if hasattr(swap, "coin_from") and swap.coin_from == coin_type:
                         self.log.warning(
@@ -8173,39 +8172,35 @@ class BasicSwap(BaseApp, BSXNetwork, UIApp):
                 refund_tx = bid.txns[TxTypes.XMR_SWAP_A_LOCK_REFUND]
 
                 # Track the depth of the lock refund tx.
-                refund_tx_depth: int = 0
-                if refund_tx.state == TxStates.TX_CONFIRMED:
-                    refund_tx_depth = ci_from.blocks_confirmed
-                else:
-                    refund_tx_chain_info = ci_from.getLockTxHeight(
-                        refund_tx.txid,
-                        ci_from.getSCLockScriptAddress(
-                            xmr_swap.a_lock_refund_tx_script
-                        ),
-                        ci_from.getLockRefundTxSwapOutputValue(bid, xmr_swap),
-                        bid.chain_a_height_start,
-                        vout=refund_tx.vout,
-                    )
-                    if refund_tx_chain_info is not None:
-                        bid_changed: bool = False
-                        refund_tx_depth = refund_tx_chain_info.get("depth", 0)
-                        if (
-                            refund_tx.state
-                            in (None, TxStates.TX_NONE, TxStates.TX_SENT)
-                            and refund_tx_chain_info["height"] == 0
-                        ):
-                            refund_tx.setState(TxStates.TX_IN_MEMPOOL)
-                            bid_changed = True
-                        if (
-                            not refund_tx.block_height
-                            and refund_tx_chain_info["height"] != 0
-                        ):
-                            self.setTxBlockInfoFromHeight(
-                                ci_from, refund_tx, refund_tx_chain_info["height"]
-                            )
-                            refund_tx.setState(TxStates.TX_IN_CHAIN)
-                            bid_changed = True
-                        if refund_tx_depth >= ci_from.blocks_confirmed:
+                was_confirmed: bool = refund_tx.state == TxStates.TX_CONFIRMED
+                refund_tx_depth: int = ci_from.blocks_confirmed if was_confirmed else 0
+                refund_tx_chain_info = ci_from.getLockTxHeight(
+                    refund_tx.txid,
+                    ci_from.getSCLockScriptAddress(xmr_swap.a_lock_refund_tx_script),
+                    ci_from.getLockRefundTxSwapOutputValue(bid, xmr_swap),
+                    bid.chain_a_height_start,
+                    vout=refund_tx.vout,
+                )
+                if refund_tx_chain_info is not None:
+                    bid_changed: bool = False
+                    refund_tx_depth = refund_tx_chain_info.get("depth", 0)
+                    if (
+                        refund_tx.state in (None, TxStates.TX_NONE, TxStates.TX_SENT)
+                        and refund_tx_chain_info["height"] == 0
+                    ):
+                        refund_tx.setState(TxStates.TX_IN_MEMPOOL)
+                        bid_changed = True
+                    if (
+                        not refund_tx.block_height
+                        and refund_tx_chain_info["height"] != 0
+                    ):
+                        self.setTxBlockInfoFromHeight(
+                            ci_from, refund_tx, refund_tx_chain_info["height"]
+                        )
+                        refund_tx.setState(TxStates.TX_IN_CHAIN)
+                        bid_changed = True
+                    if refund_tx_depth >= ci_from.blocks_confirmed:
+                        if not was_confirmed:
                             self.logBidEvent(
                                 bid.bid_id,
                                 EventLogTypes.LOCK_TX_A_REFUND_TX_CONFIRMED,
@@ -8214,9 +8209,19 @@ class BasicSwap(BaseApp, BSXNetwork, UIApp):
                             )
                             refund_tx.setState(TxStates.TX_CONFIRMED)
                             bid_changed = True
-                        if bid_changed:
-                            self.add(refund_tx, cursor, upsert=True)
-                            self.commitDB()
+                    elif was_confirmed:
+                        self.log.warning(
+                            f"Lock refund tx {self.logIDT(refund_tx.txid)} dropped below depth {ci_from.blocks_confirmed} (now {refund_tx_depth}) for bid {self.log.id(bid_id)}."
+                        )
+                        refund_tx.setState(
+                            TxStates.TX_IN_CHAIN
+                            if refund_tx_chain_info["height"] != 0
+                            else TxStates.TX_IN_MEMPOOL
+                        )
+                        bid_changed = True
+                    if bid_changed:
+                        self.add(refund_tx, cursor, upsert=True)
+                        self.commitDB()
 
                 if was_received:
                     if bid.debug_ind == DebugTypes.BID_DONT_SPEND_COIN_A_LOCK_REFUND:
@@ -8709,6 +8714,24 @@ class BasicSwap(BaseApp, BSXNetwork, UIApp):
                         raise
 
                 if (
+                    was_sent
+                    and state == BidStates.XMR_SWAP_SCRIPT_COIN_LOCKED
+                    and bid.xmr_b_lock_tx is None
+                    and self.countQueuedActions(
+                        cursor, bid_id, ActionTypes.SEND_XMR_SWAP_LOCK_TX_B
+                    )
+                    < 1
+                ):
+                    delay = self.get_delay_event_seconds()
+                    self.log.info(
+                        f"Re-queueing adaptor-sig swap chain B lock tx for bid {self.log.id(bid_id)} in {delay} seconds."
+                    )
+                    self.createActionInSession(
+                        delay, ActionTypes.SEND_XMR_SWAP_LOCK_TX_B, bid_id, cursor
+                    )
+                    self.commitDB()
+
+                if (
                     bid.xmr_b_lock_tx
                     and bid.xmr_b_lock_tx.chain_height is not None
                     and bid.xmr_b_lock_tx.chain_height > 0
@@ -8783,13 +8806,28 @@ class BasicSwap(BaseApp, BSXNetwork, UIApp):
                 # Wait for script spend tx to confirm
                 # TODO: Use explorer to get tx / block hash for getrawtransaction
 
-                if was_received:
+                spend_seen: bool = (
+                    bid.xmr_a_lock_tx is not None
+                    and bid.xmr_a_lock_tx.spend_txid == xmr_swap.a_lock_spend_tx_id
+                    and xmr_swap.a_lock_spend_tx is not None
+                )
+                if was_received or spend_seen:
                     try:
-                        txn_hex = ci_from.getMempoolTx(xmr_swap.a_lock_spend_tx_id)
-                        if txn_hex:
-                            self.log.info(
-                                f"Found lock spend txn in {ci_from.coin_name()} mempool, {self.logIDT(xmr_swap.a_lock_spend_tx_id)}"
+                        txn_hex = None
+                        try:
+                            txn_hex = ci_from.getMempoolTx(xmr_swap.a_lock_spend_tx_id)
+                            if txn_hex:
+                                self.log.info(
+                                    f"Found lock spend txn in {ci_from.coin_name()} mempool, {self.logIDT(xmr_swap.a_lock_spend_tx_id)}"
+                                )
+                        except Exception as e:
+                            self.log.debug(
+                                f"getrawtransaction lock spend tx failed: {e}"
                             )
+                        if txn_hex is None and spend_seen:
+                            # Spend tx was detected previously, recheck depth
+                            txn_hex = xmr_swap.a_lock_spend_tx.hex()
+                        if txn_hex:
                             self.process_XMR_SWAP_A_LOCK_tx_spend(
                                 bid_id,
                                 xmr_swap.a_lock_spend_tx_id.hex(),
@@ -8797,7 +8835,7 @@ class BasicSwap(BaseApp, BSXNetwork, UIApp):
                                 cursor,
                             )
                     except Exception as e:
-                        self.log.debug(f"getrawtransaction lock spend tx failed: {e}")
+                        self.log.debug(f"process lock spend tx failed: {e}")
             elif state == BidStates.XMR_SWAP_SCRIPT_TX_REDEEMED:
                 if (
                     was_received
@@ -9553,9 +9591,31 @@ class BasicSwap(BaseApp, BSXNetwork, UIApp):
 
                 if state == BidStates.XMR_SWAP_LOCK_RELEASED:
                     xmr_swap.a_lock_spend_tx = bytes.fromhex(spend_txn_hex)
-                    bid.setState(
-                        BidStates.XMR_SWAP_SCRIPT_TX_REDEEMED
-                    )  # TODO: Wait for confirmation?
+
+                    spend_tx_depth: int = 0
+                    try:
+                        spend_txout_info = ci_from.getTxOutInfo(spending_txid, 0)
+                        if spend_txout_info is not None:
+                            chain_height: int = ci_from.getChainHeight()
+                            spend_tx_depth = max(
+                                0,
+                                chain_height - spend_txout_info["block_height"] + 1,
+                            )
+                    except Exception as e:
+                        self.log.debug(
+                            f"Could not get lock spend tx depth for bid {self.log.id(bid_id)}: {e}"
+                        )
+
+                    if spend_tx_depth < ci_from.blocks_confirmed:
+                        self.log.info(
+                            f"Waiting for lock spend tx {self.logIDT(spending_txid)} to reach depth {ci_from.blocks_confirmed}, currently {spend_tx_depth}, for bid {self.log.id(bid_id)}."
+                        )
+                        self.saveBidInSession(
+                            bid_id, bid, use_cursor, xmr_swap, save_in_progress=offer
+                        )
+                        return
+
+                    bid.setState(BidStates.XMR_SWAP_SCRIPT_TX_REDEEMED)
 
                     if bid.xmr_a_lock_tx:
                         bid.xmr_a_lock_tx.setState(TxStates.TX_REDEEMED)
@@ -12216,6 +12276,12 @@ class BasicSwap(BaseApp, BSXNetwork, UIApp):
         ensure(bid, f"Bid not found: {self.log.id(bid_id)}.")
         ensure(xmr_swap, f"Adaptor-sig swap not found: {self.log.id(bid_id)}.")
 
+        if bid.state != BidStates.XMR_SWAP_MSG_SCRIPT_LOCK_TX_SIGS:
+            self.log.warning(
+                f"Not sending coin A lock tx for adaptor-sig bid {self.log.id(bid_id)}, unexpected bid state: {strBidState(bid.state)}."
+            )
+            return
+
         offer, xmr_offer = self.getXmrOfferFromSession(cursor, bid.offer_id)
         ensure(offer, f"Offer not found: {self.log.id(bid.offer_id)}.")
         ensure(xmr_offer, f"Adaptor-sig offer not found: {self.log.id(bid.offer_id)}.")
@@ -12426,6 +12492,32 @@ class BasicSwap(BaseApp, BSXNetwork, UIApp):
             TxTypes.PTX_PRE_FUNDED,
             cursor=cursor,
         )
+
+        num_publish_started = self.countBidEvents(
+            bid, EventLogTypes.LOCK_TX_B_PUBLISH_STARTED, cursor
+        )
+        num_published = self.countBidEvents(
+            bid, EventLogTypes.LOCK_TX_B_PUBLISHED, cursor
+        )
+        num_publish_failed = self.countBidEvents(
+            bid, EventLogTypes.FAILED_TX_B_LOCK_PUBLISH, cursor
+        )
+        if num_publish_started > num_published + num_publish_failed:
+            error_msg = f"A previous coin B lock tx publish attempt for bid {self.log.id(bid_id)} may have broadcast before an unclean shutdown. Not republishing, check the {ci_to.coin_name()} wallet."
+            self.log.error(error_msg)
+            self.setBidError(
+                bid,
+                "Possible coin B lock tx broadcast before crash, manual intervention required.",
+                save_bid=False,
+                cursor=cursor,
+            )
+            self.saveBidInSession(bid_id, bid, cursor, xmr_swap, save_in_progress=offer)
+            return
+
+        self.logBidEvent(
+            bid.bid_id, EventLogTypes.LOCK_TX_B_PUBLISH_STARTED, "", cursor
+        )
+        self.commitDB()
 
         try:
             b_lock_vout = None
@@ -13072,16 +13164,17 @@ class BasicSwap(BaseApp, BSXNetwork, UIApp):
         ensure(msg["to"] == addr_sent_to, "Received on incorrect address")
         ensure(msg["from"] == addr_sent_from, "Sent from incorrect address")
 
+        allowed_states = [
+            BidStates.BID_ACCEPTED,
+        ]
+        if bid.was_sent and offer.was_sent:
+            allowed_states.append(BidStates.XMR_SWAP_MSG_SCRIPT_LOCK_TX_SIGS)
+        ensure(
+            bid.state in allowed_states,
+            "Invalid state for bid {}".format(bid.state),
+        )
+
         try:
-            allowed_states = [
-                BidStates.BID_ACCEPTED,
-            ]
-            if bid.was_sent and offer.was_sent:
-                allowed_states.append(BidStates.XMR_SWAP_MSG_SCRIPT_LOCK_TX_SIGS)
-            ensure(
-                bid.state in allowed_states,
-                "Invalid state for bid {}".format(bid.state),
-            )
             xmr_swap.af_lock_refund_spend_tx_esig = (
                 msg_data.af_lock_refund_spend_tx_esig
             )
@@ -14041,7 +14134,7 @@ class BasicSwap(BaseApp, BSXNetwork, UIApp):
 
             to_remove = []
             if now - self._last_checked_progress >= self.check_progress_seconds:
-                for bid_id, v in self.swaps_in_progress.items():
+                for bid_id, v in list(self.swaps_in_progress.items()):
                     bid, offer = v
                     try:
                         if self.checkBidState(bid_id, bid, offer) is True:
@@ -14067,7 +14160,7 @@ class BasicSwap(BaseApp, BSXNetwork, UIApp):
                     self.deactivateBid(None, offer, bid)
 
                 if self._wallet_manager:
-                    for bid_id, v in self.swaps_in_progress.items():
+                    for bid_id, v in list(self.swaps_in_progress.items()):
                         bid, offer = v
                         try:
                             for coin_type in (

--- a/basicswap/basicswap_util.py
+++ b/basicswap/basicswap_util.py
@@ -220,6 +220,7 @@ class EventLogTypes(IntEnum):
     LOCK_TX_B_REFUND_TX_SEEN = auto()
     LOCK_TX_A_INVALID = auto()
     LOCK_TX_A_REFUND_TX_CONFIRMED = auto()
+    LOCK_TX_B_PUBLISH_STARTED = auto()
 
 
 class XmrSplitMsgTypes(IntEnum):
@@ -450,6 +451,8 @@ def describeEventEntry(event_type, event_msg):
         return "Lock tx A published"
     if event_type == EventLogTypes.LOCK_TX_B_PUBLISHED:
         return "Lock tx B published"
+    if event_type == EventLogTypes.LOCK_TX_B_PUBLISH_STARTED:
+        return "Lock tx B publish started"
     if event_type == EventLogTypes.FAILED_TX_B_SPEND:
         return "Failed to publish lock tx B spend: " + event_msg
     if event_type == EventLogTypes.LOCK_TX_A_IN_MEMPOOL:

--- a/basicswap/protocols/atomic_swap_1.py
+++ b/basicswap/protocols/atomic_swap_1.py
@@ -24,6 +24,7 @@ from . import ProtocolInterface
 
 INITIATE_TX_TIMEOUT = 40 * 60  # TODO: make variable per coin
 ABS_LOCK_TIME_LEEWAY = 10 * 60
+ABS_LOCK_BLOCKS_LEEWAY = 4
 
 
 def buildContractScript(

--- a/tests/basicswap/test_ads_spend_depth_gate.py
+++ b/tests/basicswap/test_ads_spend_depth_gate.py
@@ -1,0 +1,178 @@
+# -*- coding: utf-8 -*-
+
+# Copyright (c) 2026 The Basicswap developers
+# Distributed under the MIT software license, see the accompanying
+# file LICENSE or http://www.opensource.org/licenses/mit-license.php.
+
+import unittest
+from types import SimpleNamespace
+
+from basicswap.basicswap import BasicSwap
+from basicswap.basicswap_util import BidStates
+from basicswap.chainparams import Coins
+
+SPEND_TXID = bytes.fromhex("aa" * 32)
+LOCK_TXID = bytes.fromhex("bb" * 32)
+
+
+class StubLog:
+    def id(self, v):
+        return str(v)
+
+    def info(self, *args, **kwargs):
+        pass
+
+    def warning(self, *args, **kwargs):
+        pass
+
+    def debug(self, *args, **kwargs):
+        pass
+
+    def error(self, *args, **kwargs):
+        pass
+
+
+class StubTx:
+    def __init__(self):
+        self.spend_txid = None
+        self.states = []
+
+    def setState(self, state):
+        self.states.append(state)
+
+
+class StubBid:
+    def __init__(self, state):
+        self.state = state
+        self.states_set = []
+        self.was_received = False
+        self.was_sent = True
+        self.offer_id = b"offer"
+        self.bid_id = b"bid"
+        self.xmr_a_lock_tx = StubTx()
+
+    def setState(self, state):
+        self.states_set.append(state)
+        self.state = state
+
+
+class StubCI:
+    def __init__(self, spend_depth, blocks_confirmed=2, chain_height=100):
+        self._spend_depth = spend_depth
+        self.blocks_confirmed = blocks_confirmed
+        self._chain_height = chain_height
+
+    def loadTx(self, tx_bytes):
+        return SimpleNamespace(vin=[])
+
+    def getChainHeight(self):
+        return self._chain_height
+
+    def getTxOutInfo(self, txid, n):
+        if self._spend_depth < 1:
+            return None
+        return {
+            "block_height": self._chain_height - (self._spend_depth - 1),
+            "block_hash": b"\x00" * 32,
+            "block_time": 1000,
+        }
+
+
+def make_swap_client(ci, bid, xmr_swap):
+    sc = BasicSwap.__new__(BasicSwap)
+    sc.fp = None
+    sc.log = StubLog()
+    sc.saved = []
+    sc.events = []
+    sc.notifications = []
+
+    offer = SimpleNamespace(
+        coin_from=int(Coins.BTC),
+        coin_to=int(Coins.PART),
+        offer_id=b"offer",
+        swap_type=None,
+    )
+    xmr_offer = SimpleNamespace()
+
+    sc.openDB = lambda cursor=None: object()
+    sc.closeDB = lambda cursor, commit=True: None
+    sc.getXmrBidFromSession = lambda cursor, bid_id: (bid, xmr_swap)
+    sc.getXmrOfferFromSession = lambda cursor, offer_id: (offer, xmr_offer)
+    sc.is_reverse_ads_bid = lambda cf, ct: False
+    sc.isBchXmrSwap = lambda offer: False
+    sc.ci = lambda coin: ci
+    sc.saveBidInSession = (
+        lambda bid_id, bid, cursor, xmr_swap, save_in_progress=None: sc.saved.append(
+            bid.state
+        )
+    )
+    sc.logBidEvent = lambda bid_id, event, msg, cursor: sc.events.append(event)
+    sc.notify = lambda event_type, data: sc.notifications.append(event_type)
+    sc.logIDT = lambda t: str(t)
+    sc.logException = lambda msg: (_ for _ in ()).throw(AssertionError(msg))
+    return sc
+
+
+def make_xmr_swap():
+    return SimpleNamespace(
+        a_lock_spend_tx_id=SPEND_TXID,
+        a_lock_tx_id=LOCK_TXID,
+        a_lock_spend_tx=None,
+        a_lock_refund_tx_id=bytes.fromhex("cc" * 32),
+    )
+
+
+class TestAdsSpendDepthGate(unittest.TestCase):
+    def test_unconfirmed_spend_does_not_transition(self):
+        bid = StubBid(BidStates.XMR_SWAP_LOCK_RELEASED)
+        xmr_swap = make_xmr_swap()
+        ci = StubCI(spend_depth=0, blocks_confirmed=2)
+        sc = make_swap_client(ci, bid, xmr_swap)
+
+        sc.process_XMR_SWAP_A_LOCK_tx_spend(b"bid", SPEND_TXID.hex(), "00")
+
+        self.assertEqual(bid.states_set, [])
+        self.assertEqual(bid.state, BidStates.XMR_SWAP_LOCK_RELEASED)
+        self.assertEqual(len(sc.saved), 1)
+        self.assertEqual(xmr_swap.a_lock_spend_tx, b"\x00")
+
+    def test_shallow_spend_does_not_transition(self):
+        bid = StubBid(BidStates.XMR_SWAP_LOCK_RELEASED)
+        xmr_swap = make_xmr_swap()
+        ci = StubCI(spend_depth=1, blocks_confirmed=2)
+        sc = make_swap_client(ci, bid, xmr_swap)
+
+        sc.process_XMR_SWAP_A_LOCK_tx_spend(b"bid", SPEND_TXID.hex(), "00")
+
+        self.assertEqual(bid.states_set, [])
+        self.assertEqual(bid.state, BidStates.XMR_SWAP_LOCK_RELEASED)
+
+    def test_confirmed_spend_transitions_sender(self):
+        bid = StubBid(BidStates.XMR_SWAP_LOCK_RELEASED)
+        xmr_swap = make_xmr_swap()
+        ci = StubCI(spend_depth=2, blocks_confirmed=2)
+        sc = make_swap_client(ci, bid, xmr_swap)
+
+        sc.process_XMR_SWAP_A_LOCK_tx_spend(b"bid", SPEND_TXID.hex(), "00")
+
+        self.assertIn(BidStates.XMR_SWAP_SCRIPT_TX_REDEEMED, bid.states_set)
+        self.assertIn(BidStates.SWAP_COMPLETED, bid.states_set)
+        self.assertEqual(len(sc.notifications), 1)
+
+    def test_confirmed_spend_transitions_receiver(self):
+        bid = StubBid(BidStates.XMR_SWAP_LOCK_RELEASED)
+        bid.was_received = True
+        bid.was_sent = False
+        xmr_swap = make_xmr_swap()
+        ci = StubCI(spend_depth=2, blocks_confirmed=2)
+        sc = make_swap_client(ci, bid, xmr_swap)
+
+        sc.process_XMR_SWAP_A_LOCK_tx_spend(b"bid", SPEND_TXID.hex(), "00")
+
+        self.assertIn(BidStates.XMR_SWAP_SCRIPT_TX_REDEEMED, bid.states_set)
+        self.assertNotIn(BidStates.SWAP_COMPLETED, bid.states_set)
+        self.assertEqual(len(sc.notifications), 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/basicswap/test_ads_swap_recovery.py
+++ b/tests/basicswap/test_ads_swap_recovery.py
@@ -1,0 +1,465 @@
+# -*- coding: utf-8 -*-
+
+# Copyright (c) 2026 The Basicswap developers
+# Distributed under the MIT software license, see the accompanying
+# file LICENSE or http://www.opensource.org/licenses/mit-license.php.
+
+"""
+Unit tests for adaptor-sig swap resilience: crash recovery, message replays,
+lost queued actions, and chain reorg handling.
+"""
+
+import unittest
+from types import SimpleNamespace
+
+from basicswap.basicswap import BasicSwap
+from basicswap.basicswap_util import (
+    ActionTypes,
+    BidStates,
+    DebugTypes,
+    EventLogTypes,
+    TxStates,
+)
+from basicswap.chainparams import Coins
+from basicswap.messages_npb import XmrBidLockTxSigsMessage
+
+BID_ID = b"b" * 28
+REFUND_TXID = bytes.fromhex("cc" * 32)
+
+
+class StubLog:
+    def id(self, v):
+        return str(v)
+
+    def info(self, *args, **kwargs):
+        pass
+
+    def warning(self, *args, **kwargs):
+        pass
+
+    def debug(self, *args, **kwargs):
+        pass
+
+    def error(self, *args, **kwargs):
+        pass
+
+
+class StubTx:
+    def __init__(self, state=None, txid=REFUND_TXID, vout=0, block_height=10):
+        self.state = state
+        self.txid = txid
+        self.vout = vout
+        self.block_height = block_height
+        self.states_set = []
+
+    def setState(self, state):
+        self.states_set.append(state)
+        self.state = state
+
+
+def base_swap_client():
+    sc = BasicSwap.__new__(BasicSwap)
+    sc.fp = None
+    sc.log = StubLog()
+    sc.event_log = []  # (event_type, msg)
+    sc.commits = []
+    sc.saved = []
+    sc.bid_errors = []
+    sc.created_actions = []
+
+    sc.openDB = lambda cursor=None: object()
+    sc.closeDB = lambda cursor, commit=True: None
+    sc.commitDB = lambda: sc.commits.append(len(sc.event_log))
+    sc.logBidEvent = lambda bid_id, event, msg, cursor: sc.event_log.append(
+        (event, msg)
+    )
+    sc.countBidEvents = lambda bid, event, cursor: sum(
+        1 for e, _ in sc.event_log if e == event
+    )
+    sc.setBidError = lambda bid, msg, save_bid=True, xmr_swap=None, cursor=None: sc.bid_errors.append(
+        msg
+    )
+    sc.saveBidInSession = lambda bid_id, bid, cursor, xmr_swap=None, save_in_progress=None: sc.saved.append(
+        bid.state
+    )
+    sc.createActionInSession = (
+        lambda delay, action_type, bid_id, cursor: sc.created_actions.append(
+            action_type
+        )
+    )
+    sc.get_delay_event_seconds = lambda: 1
+    sc.is_reverse_ads_bid = lambda cf, ct: False
+    sc.isBchXmrSwap = lambda offer: False
+    sc.logIDT = lambda t: str(t)
+    sc.logIDM = lambda t: str(t)
+    return sc
+
+
+def make_offer():
+    return SimpleNamespace(
+        coin_from=int(Coins.BTC),
+        coin_to=int(Coins.PART),
+        offer_id=b"offer",
+        swap_type=None,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Coin B lock publish recovery
+# ---------------------------------------------------------------------------
+
+
+class StubCIB:
+    def __init__(self, calls):
+        self.calls = calls
+
+    def coin_name(self):
+        return "PART"
+
+    def publishBLockTx(self, vkbv, pkbs, amount, fee_rate, unlock_time=0):
+        self.calls.append("publish")
+        return bytes.fromhex("dd" * 32)
+
+
+def make_b_lock_client(bid):
+    sc = base_swap_client()
+    calls = []
+    sc.calls = calls
+    sc.commitDB = lambda: calls.append("commit")
+
+    orig_log = sc.logBidEvent
+    sc.logBidEvent = lambda bid_id, event, msg, cursor: (
+        sc.event_log.append((event, msg)),
+        calls.append(event),
+    )
+    assert orig_log  # silence lint
+
+    xmr_swap = SimpleNamespace(vkbv=b"v", pkbs=b"p", b_lock_tx_id=None)
+    offer = make_offer()
+    xmr_offer = SimpleNamespace(a_fee_rate=1, b_fee_rate=1)
+
+    sc.getXmrBidFromSession = lambda cursor, bid_id: (bid, xmr_swap)
+    sc.getXmrOfferFromSession = lambda cursor, offer_id: (offer, xmr_offer)
+    sc.findTxB = lambda ci, xmr_swap, bid, cursor, was_sent: False
+    sc.getPreFundedTx = lambda concept, bid_id, tx_type, cursor=None: None
+    sc.ci = lambda coin: StubCIB(calls)
+    return sc
+
+
+def make_b_lock_bid():
+    return SimpleNamespace(
+        bid_id=BID_ID,
+        offer_id=b"offer",
+        was_sent=True,
+        was_received=False,
+        debug_ind=DebugTypes.NONE,
+        xmr_b_lock_tx=None,
+        amount_to=1000,
+        state=BidStates.XMR_SWAP_SCRIPT_COIN_LOCKED,
+        setState=lambda s: None,
+    )
+
+
+class TestAdsSwapRecoveryCoinBLock(unittest.TestCase):
+    def test_write_ahead_marker_committed_before_broadcast(self):
+        bid = make_b_lock_bid()
+        sc = make_b_lock_client(bid)
+
+        sc.sendXmrBidCoinBLockTx(BID_ID, object())
+
+        calls = sc.calls
+        self.assertIn("publish", calls)
+        started_idx = calls.index(EventLogTypes.LOCK_TX_B_PUBLISH_STARTED)
+        commit_idx = calls.index("commit")
+        publish_idx = calls.index("publish")
+        published_idx = calls.index(EventLogTypes.LOCK_TX_B_PUBLISHED)
+        self.assertLess(started_idx, commit_idx)
+        self.assertLess(commit_idx, publish_idx)
+        self.assertLess(publish_idx, published_idx)
+        self.assertEqual(len(sc.bid_errors), 0)
+
+    def test_unmatched_marker_blocks_rebroadcast(self):
+        bid = make_b_lock_bid()
+        sc = make_b_lock_client(bid)
+        # Simulate a crash after the marker was committed but before the
+        # publish outcome was recorded.
+        sc.event_log.append((EventLogTypes.LOCK_TX_B_PUBLISH_STARTED, ""))
+
+        sc.sendXmrBidCoinBLockTx(BID_ID, object())
+
+        self.assertNotIn("publish", sc.calls)
+        self.assertEqual(len(sc.bid_errors), 1)
+
+    def test_failed_attempt_allows_retry(self):
+        bid = make_b_lock_bid()
+        sc = make_b_lock_client(bid)
+        # A previous attempt that failed cleanly must not block the retry.
+        sc.event_log.append((EventLogTypes.LOCK_TX_B_PUBLISH_STARTED, ""))
+        sc.event_log.append((EventLogTypes.FAILED_TX_B_LOCK_PUBLISH, "err"))
+
+        sc.sendXmrBidCoinBLockTx(BID_ID, object())
+
+        self.assertIn("publish", sc.calls)
+        self.assertEqual(len(sc.bid_errors), 0)
+
+
+# ---------------------------------------------------------------------------
+# Replayed bid message and coin A lock state gate
+# ---------------------------------------------------------------------------
+
+
+class TestAdsSwapRecoveryReplayedSigs(unittest.TestCase):
+    def make_sigs_msg_client(self, bid):
+        sc = base_swap_client()
+        xmr_swap = SimpleNamespace()
+        offer = make_offer()
+        offer.addr_from = "addr_offerer"
+        offer.was_sent = False
+        xmr_offer = SimpleNamespace()
+
+        msg_buf = XmrBidLockTxSigsMessage(
+            bid_msg_id=BID_ID,
+            af_lock_refund_spend_tx_esig=b"\x01" * 32,
+            af_lock_refund_tx_sig=b"\x02" * 32,
+        )
+        msg = {
+            "msgid": "aa" * 28,
+            "to": "addr_offerer",
+            "from": "addr_bidder",
+            "hex": "00" + msg_buf.to_bytes().hex() + "00",
+        }
+        sc.getSmsgMsgBytes = lambda m: msg_buf.to_bytes()
+        sc.getXmrBid = lambda bid_id: (bid, xmr_swap)
+        sc.getXmrOffer = lambda offer_id: (offer, xmr_offer)
+        sc.ci = lambda coin: SimpleNamespace(curve_type=lambda: None)
+        return sc, msg
+
+    def test_replayed_message_does_not_error_bid(self):
+        # Bid has already progressed past BID_ACCEPTED.
+        bid = SimpleNamespace(
+            bid_id=BID_ID,
+            offer_id=b"offer",
+            state=BidStates.XMR_SWAP_MSG_SCRIPT_LOCK_TX_SIGS,
+            was_sent=False,
+            was_received=True,
+            bid_addr="addr_bidder",
+        )
+        sc, msg = self.make_sigs_msg_client(bid)
+
+        with self.assertRaises(ValueError):
+            sc.processXmrBidCoinALockSigs(msg)
+
+        # The state guard must reject the replay without erroring the bid.
+        self.assertEqual(len(sc.bid_errors), 0)
+        self.assertEqual(bid.state, BidStates.XMR_SWAP_MSG_SCRIPT_LOCK_TX_SIGS)
+
+
+class TestAdsSwapRecoveryCoinALockGate(unittest.TestCase):
+    def test_errored_bid_does_not_publish_coin_a(self):
+        sc = base_swap_client()
+        bid = SimpleNamespace(
+            bid_id=BID_ID,
+            offer_id=b"offer",
+            state=BidStates.BID_ERROR,
+        )
+        xmr_swap = SimpleNamespace()
+        sc.getXmrBidFromSession = lambda cursor, bid_id: (bid, xmr_swap)
+
+        def fail_offer_lookup(cursor, offer_id):
+            raise AssertionError("Should have returned before the offer lookup")
+
+        sc.getXmrOfferFromSession = fail_offer_lookup
+
+        sc.sendXmrBidCoinALockTx(BID_ID, object())
+        self.assertEqual(len(sc.bid_errors), 0)
+
+    def test_expected_state_proceeds(self):
+        sc = base_swap_client()
+        bid = SimpleNamespace(
+            bid_id=BID_ID,
+            offer_id=b"offer",
+            state=BidStates.XMR_SWAP_MSG_SCRIPT_LOCK_TX_SIGS,
+        )
+        xmr_swap = SimpleNamespace()
+        sc.getXmrBidFromSession = lambda cursor, bid_id: (bid, xmr_swap)
+
+        sentinel = RuntimeError("reached offer lookup")
+
+        def offer_lookup(cursor, offer_id):
+            raise sentinel
+
+        sc.getXmrOfferFromSession = offer_lookup
+
+        with self.assertRaises(RuntimeError):
+            sc.sendXmrBidCoinALockTx(BID_ID, object())
+
+
+# ---------------------------------------------------------------------------
+# Bid state polling recovery
+# ---------------------------------------------------------------------------
+
+
+class StubCIA:
+    def __init__(
+        self, blocks_confirmed=2, refund_chain_info=None, have_signed_refund=False
+    ):
+        self.blocks_confirmed = blocks_confirmed
+        self.coin_ticker = "BTC"
+        self._refund_chain_info = refund_chain_info
+        self._have_signed_refund = have_signed_refund
+
+    def getSCLockScriptAddress(self, script):
+        return "addr"
+
+    def getLockRefundTxSwapOutputValue(self, bid, xmr_swap):
+        return 1000
+
+    def getLockTxHeight(self, txid, dest_address, bid_amount, rescan_from, vout=None):
+        return self._refund_chain_info
+
+    def haveSignedLockRefundTx(self, xmr_swap):
+        return self._have_signed_refund
+
+    def isCsvLockMature(self, lock_type, lock_time, block_height, block_time):
+        return False
+
+
+def make_check_state_client(ci, bid, xmr_swap):
+    sc = base_swap_client()
+    xmr_offer = SimpleNamespace(lock_time_1=10, lock_time_2=10)
+    sc.queryOne = lambda model, cursor, filters: (
+        xmr_offer if model.__name__ == "XmrOffer" else xmr_swap
+    )
+    sc.ci = lambda coin: ci
+    sc.add = lambda obj, cursor, upsert=False: sc.saved.append(obj)
+    sc.setTxBlockInfoFromHeight = lambda ci_, tx, height: None
+    sc.findTxB = lambda ci_, xmr_swap_, bid_, cursor, was_sent: False
+    sc.countQueuedActions = lambda cursor, bid_id, action_type: 0
+    sc.haveDebugInd = lambda bid_id, ind: False
+    return sc
+
+
+def make_refund_bid(state, refund_tx):
+    from basicswap.basicswap_util import TxTypes
+
+    return SimpleNamespace(
+        bid_id=BID_ID,
+        offer_id=b"offer",
+        state=state,
+        was_sent=False,
+        was_received=False,
+        chain_a_height_start=1,
+        txns={TxTypes.XMR_SWAP_A_LOCK_REFUND: refund_tx},
+        xmr_a_lock_tx=None,
+        xmr_b_lock_tx=None,
+        debug_ind=DebugTypes.NONE,
+    )
+
+
+class TestAdsSwapRecoveryRefundDepth(unittest.TestCase):
+    def run_check(self, refund_tx, chain_info):
+        xmr_swap = SimpleNamespace(a_lock_refund_tx_script=b"script")
+        bid = make_refund_bid(BidStates.SWAP_COMPLETED, refund_tx)
+        ci = StubCIA(blocks_confirmed=2, refund_chain_info=chain_info)
+        sc = make_check_state_client(ci, bid, xmr_swap)
+        offer = make_offer()
+        sc.checkXmrBidState(BID_ID, bid, offer)
+        return sc
+
+    def test_reorged_refund_reverts_cached_state(self):
+        refund_tx = StubTx(state=TxStates.TX_CONFIRMED)
+        sc = self.run_check(refund_tx, {"height": 100, "depth": 1})
+
+        self.assertEqual(refund_tx.state, TxStates.TX_IN_CHAIN)
+        self.assertEqual(refund_tx.states_set, [TxStates.TX_IN_CHAIN])
+        assert sc is not None
+
+    def test_evicted_refund_reverts_to_mempool_state(self):
+        refund_tx = StubTx(state=TxStates.TX_CONFIRMED)
+        self.run_check(refund_tx, {"height": 0, "depth": 0})
+
+        self.assertEqual(refund_tx.state, TxStates.TX_IN_MEMPOOL)
+
+    def test_still_confirmed_no_state_change(self):
+        refund_tx = StubTx(state=TxStates.TX_CONFIRMED)
+        sc = self.run_check(refund_tx, {"height": 100, "depth": 5})
+
+        self.assertEqual(refund_tx.state, TxStates.TX_CONFIRMED)
+        self.assertEqual(refund_tx.states_set, [])
+        # No duplicate confirmed event.
+        self.assertEqual(
+            sum(
+                1
+                for e, _ in sc.event_log
+                if e == EventLogTypes.LOCK_TX_A_REFUND_TX_CONFIRMED
+            ),
+            0,
+        )
+
+    def test_query_failure_keeps_confirmed_state(self):
+        refund_tx = StubTx(state=TxStates.TX_CONFIRMED)
+        self.run_check(refund_tx, None)
+
+        self.assertEqual(refund_tx.state, TxStates.TX_CONFIRMED)
+        self.assertEqual(refund_tx.states_set, [])
+
+    def test_fresh_confirmation_still_recorded(self):
+        refund_tx = StubTx(state=TxStates.TX_IN_CHAIN)
+        sc = self.run_check(refund_tx, {"height": 100, "depth": 2})
+
+        self.assertEqual(refund_tx.state, TxStates.TX_CONFIRMED)
+        self.assertEqual(
+            sum(
+                1
+                for e, _ in sc.event_log
+                if e == EventLogTypes.LOCK_TX_A_REFUND_TX_CONFIRMED
+            ),
+            1,
+        )
+
+
+class TestAdsSwapRecoveryRequeueLockTxB(unittest.TestCase):
+    def run_check(self, bid, queued_count=0):
+        xmr_swap = SimpleNamespace(a_lock_refund_tx_script=b"script")
+        ci = StubCIA(blocks_confirmed=2)
+        sc = make_check_state_client(ci, bid, xmr_swap)
+        sc.countQueuedActions = lambda cursor, bid_id, action_type: queued_count
+        offer = make_offer()
+        sc.checkXmrBidState(BID_ID, bid, offer)
+        return sc
+
+    def make_bid(self, state):
+        return SimpleNamespace(
+            bid_id=BID_ID,
+            offer_id=b"offer",
+            state=state,
+            was_sent=True,
+            was_received=False,
+            chain_a_height_start=1,
+            txns={},
+            xmr_a_lock_tx=None,
+            xmr_b_lock_tx=None,
+            debug_ind=DebugTypes.NONE,
+        )
+
+    def test_purged_action_is_recreated(self):
+        bid = self.make_bid(BidStates.XMR_SWAP_SCRIPT_COIN_LOCKED)
+        sc = self.run_check(bid, queued_count=0)
+
+        self.assertIn(ActionTypes.SEND_XMR_SWAP_LOCK_TX_B, sc.created_actions)
+
+    def test_existing_action_not_duplicated(self):
+        bid = self.make_bid(BidStates.XMR_SWAP_SCRIPT_COIN_LOCKED)
+        sc = self.run_check(bid, queued_count=1)
+
+        self.assertNotIn(ActionTypes.SEND_XMR_SWAP_LOCK_TX_B, sc.created_actions)
+
+    def test_not_recreated_in_prerefund_state(self):
+        bid = self.make_bid(BidStates.XMR_SWAP_SCRIPT_TX_PREREFUND)
+        sc = self.run_check(bid, queued_count=0)
+
+        self.assertNotIn(ActionTypes.SEND_XMR_SWAP_LOCK_TX_B, sc.created_actions)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
- Lock spend must reach blocks_confirmed before SWAP_COMPLETED / redeem.
- swaps_in_progress iterated via snapshot to avoid concurrent mutation crashes.
- ABS_LOCK_BLOCKS_LEEWAY defined; absolute-block-lock accepts no longer crash.
- Coin B lock won't double-broadcast after an unclean shutdown (publish tracked in DB before broadcast).
- Replayed bid sig messages rejected without erroring the bid; coin A lock only publishes in the correct state.
- Lost send-coin-B-lock action re-created automatically on restart.
- Lock refund tx depth re-checked after confirmation to catch reorgs.
- New tests: test_ads_spend_depth_gate.py, test_ads_swap_recovery.py