### PR TITLE
fix: dns rebinding fixes

### DIFF
--- a/basicswap/basicswap.py
+++ b/basicswap/basicswap.py
@@ -117,7 +117,11 @@ from .util.address import (
 )
 from .util.crypto import sha256
 from .util.logging import LogCategories as LC
-from .util.network import is_private_ip_address, is_origin_allowed
+from .util.network import (
+    is_private_ip_address,
+    is_origin_allowed,
+    normalize_allowed_hosts,
+)
 from .util.smsg import smsgGetID
 from .interface.base import Curves
 from .interface.part.part import PARTInterface, PARTInterfaceAnon, PARTInterfaceBlind
@@ -461,6 +465,11 @@ class BasicSwap(BaseApp, BSXNetwork, UIApp):
         self.check_delayed_auto_accept_seconds = self.get_int_setting(
             "check_delayed_auto_accept_seconds", 60, 1, 20 * 60
         )
+        if "allowed_hosts" in self.settings:
+            self.settings["allowed_hosts"] = normalize_allowed_hosts(
+                self.settings["allowed_hosts"]
+            )
+
         self.debug_ui = self.settings.get("debug_ui", False)
         self._debug_cases = []
         self._last_checked_actions = 0

--- a/basicswap/ui/page_amm.py
+++ b/basicswap/ui/page_amm.py
@@ -607,7 +607,9 @@ def page_amm(self, _, post_string):
     basicswap_port = swap_client.settings.get("htmlport", 12700)
 
     if amm_host == "127.0.0.1" and amm_port == 12700:
-        amm_host = basicswap_host
+        amm_host = (
+            "127.0.0.1" if basicswap_host in ("0.0.0.0", "::", "") else basicswap_host
+        )
         amm_port = basicswap_port
 
     amm_dir = ensure_amm_dir(swap_client)

--- a/basicswap/util/network.py
+++ b/basicswap/util/network.py
@@ -82,6 +82,13 @@ def _normalize_origin(value):
     return (scheme, host, port)
 
 
+def normalize_allowed_hosts(value):
+    # Promote a bare string to a list so readers don't iterate it char by char.
+    if isinstance(value, str):
+        return [value] if value else []
+    return value or []
+
+
 def allowed_entry_hostname(entry):
     # Extract the bare hostname from an allowed_hosts entry, which may be a bare
     # host ("host"), a host:port, or a full origin ("scheme://host[:port]").

--- a/tests/basicswap/test_other.py
+++ b/tests/basicswap/test_other.py
@@ -662,6 +662,20 @@ class Test(unittest.TestCase):
         for url, is_public in test_urls:
             assert is_public_url(url) is is_public
 
+    def test_normalize_allowed_hosts(self):
+        from basicswap.util.network import normalize_allowed_hosts
+
+        self.assertEqual(normalize_allowed_hosts("*"), ["*"])
+        self.assertEqual(
+            normalize_allowed_hosts("swap.example.com"), ["swap.example.com"]
+        )
+        self.assertEqual(normalize_allowed_hosts(""), [])
+        self.assertEqual(normalize_allowed_hosts(None), [])
+        self.assertEqual(
+            normalize_allowed_hosts(["swap.example.com"]), ["swap.example.com"]
+        )
+        self.assertEqual(normalize_allowed_hosts([]), [])
+
     def test_is_origin_allowed(self):
         # (origin, html_host, html_port, allowed_hosts, expected)
         cases = [


### PR DESCRIPTION
- amm on docker (where htmlhost is set to 0.0.0.0) fails due to the 0.0.0.0 -> amm uses 127.0.0.1 now
- strings in allowed_host were read 1 character at a time -> now read as a list