### PR TITLE
Fix: Dictionary changed size during iteration in active swaps loops.

### DIFF
--- a/basicswap/basicswap.py
+++ b/basicswap/basicswap.py
@@ -2091,7 +2091,7 @@ class BasicSwap(BaseApp, BSXNetwork, UIApp):
             return result
 
         try:
-            for bid_id, swap in self.swaps_in_progress.items():
+            for bid_id, swap in list(self.swaps_in_progress.items()):
                 try:
                     bid, offer = swap
                     if offer.coin_from == coin_type or offer.coin_to == coin_type:
@@ -2201,7 +2201,7 @@ class BasicSwap(BaseApp, BSXNetwork, UIApp):
 
     def _checkRPCWalletEmpty(self, coin_type: Coins) -> dict:
         try:
-            for bid_id, swap in self.swaps_in_progress.items():
+            for bid_id, swap in list(self.swaps_in_progress.items()):
                 try:
                     if hasattr(swap, "coin_from") and swap.coin_from == coin_type:
                         return {
@@ -2249,7 +2249,7 @@ class BasicSwap(BaseApp, BSXNetwork, UIApp):
 
     def _checkElectrumWalletEmpty(self, coin_type: Coins) -> dict:
         try:
-            for bid_id, swap in self.swaps_in_progress.items():
+            for bid_id, swap in list(self.swaps_in_progress.items()):
                 try:
                     if hasattr(swap, "coin_from") and swap.coin_from == coin_type:
                         return {
@@ -2613,7 +2613,7 @@ class BasicSwap(BaseApp, BSXNetwork, UIApp):
     def _transferLiteWalletBalanceToRPC(self, coin_type: Coins) -> dict:
         try:
 
-            for bid_id, swap in self.swaps_in_progress.items():
+            for bid_id, swap in list(self.swaps_in_progress.items()):
                 try:
                     if hasattr(swap, "coin_from") and swap.coin_from == coin_type:
                         self.log.warning(
@@ -14125,7 +14125,7 @@ class BasicSwap(BaseApp, BSXNetwork, UIApp):
 
             to_remove = []
             if now - self._last_checked_progress >= self.check_progress_seconds:
-                for bid_id, v in self.swaps_in_progress.items():
+                for bid_id, v in list(self.swaps_in_progress.items()):
                     bid, offer = v
                     try:
                         if self.checkBidState(bid_id, bid, offer) is True:
@@ -14151,7 +14151,7 @@ class BasicSwap(BaseApp, BSXNetwork, UIApp):
                     self.deactivateBid(None, offer, bid)
 
                 if self._wallet_manager:
-                    for bid_id, v in self.swaps_in_progress.items():
+                    for bid_id, v in list(self.swaps_in_progress.items()):
                         bid, offer = v
                         try:
                             for coin_type in (


### PR DESCRIPTION
- Iterating over active swaps could crash with RuntimeError: dictionary changed size during iteration when a swap was added or removed by another thread mid-loop.
- The loops now iterate over a snapshot copy of the swap list, so concurrent changes can no longer interrupt them.