### PR TITLE
Define missing ABS_LOCK_BLOCKS_LEEWAY constant.

### DIFF
--- a/basicswap/protocols/atomic_swap_1.py
+++ b/basicswap/protocols/atomic_swap_1.py
@@ -24,6 +24,7 @@ from . import ProtocolInterface
 
 INITIATE_TX_TIMEOUT = 40 * 60  # TODO: make variable per coin
 ABS_LOCK_TIME_LEEWAY = 10 * 60
+ABS_LOCK_BLOCKS_LEEWAY = 4
 
 
 def buildContractScript(


### PR DESCRIPTION
- Bid validation references atomic_swap_1.ABS_LOCK_BLOCKS_LEEWAY when checking offers that use block-height locktimes, but the constant was never defined, causing an AttributeError.
- Added ABS_LOCK_BLOCKS_LEEWAY = 4 next to the existing ABS_LOCK_TIME_LEEWAY.