### PR TITLE
Wait for lock spend tx confirmations before completing swap.

### DIFF
--- a/basicswap/basicswap.py
+++ b/basicswap/basicswap.py
@@ -8836,13 +8836,28 @@ class BasicSwap(BaseApp, BSXNetwork, UIApp):
                 # Wait for script spend tx to confirm
                 # TODO: Use explorer to get tx / block hash for getrawtransaction
 
-                if was_received:
+                spend_seen: bool = (
+                    bid.xmr_a_lock_tx is not None
+                    and bid.xmr_a_lock_tx.spend_txid == xmr_swap.a_lock_spend_tx_id
+                    and xmr_swap.a_lock_spend_tx is not None
+                )
+                if was_received or spend_seen:
                     try:
-                        txn_hex = ci_from.getMempoolTx(xmr_swap.a_lock_spend_tx_id)
-                        if txn_hex:
-                            self.log.info(
-                                f"Found lock spend txn in {ci_from.coin_name()} mempool, {self.logIDT(xmr_swap.a_lock_spend_tx_id)}"
+                        txn_hex = None
+                        try:
+                            txn_hex = ci_from.getMempoolTx(xmr_swap.a_lock_spend_tx_id)
+                            if txn_hex:
+                                self.log.info(
+                                    f"Found lock spend txn in {ci_from.coin_name()} mempool, {self.logIDT(xmr_swap.a_lock_spend_tx_id)}"
+                                )
+                        except Exception as e:
+                            self.log.debug(
+                                f"getrawtransaction lock spend tx failed: {e}"
                             )
+                        if txn_hex is None and spend_seen:
+                            # Spend tx was detected previously, recheck depth
+                            txn_hex = xmr_swap.a_lock_spend_tx.hex()
+                        if txn_hex:
                             self.process_XMR_SWAP_A_LOCK_tx_spend(
                                 bid_id,
                                 xmr_swap.a_lock_spend_tx_id.hex(),
@@ -8850,7 +8865,7 @@ class BasicSwap(BaseApp, BSXNetwork, UIApp):
                                 cursor,
                             )
                     except Exception as e:
-                        self.log.debug(f"getrawtransaction lock spend tx failed: {e}")
+                        self.log.debug(f"process lock spend tx failed: {e}")
             elif state == BidStates.XMR_SWAP_SCRIPT_TX_REDEEMED:
                 if (
                     was_received
@@ -9606,9 +9621,31 @@ class BasicSwap(BaseApp, BSXNetwork, UIApp):
 
                 if state == BidStates.XMR_SWAP_LOCK_RELEASED:
                     xmr_swap.a_lock_spend_tx = bytes.fromhex(spend_txn_hex)
-                    bid.setState(
-                        BidStates.XMR_SWAP_SCRIPT_TX_REDEEMED
-                    )  # TODO: Wait for confirmation?
+
+                    spend_tx_depth: int = 0
+                    try:
+                        spend_txout_info = ci_from.getTxOutInfo(spending_txid, 0)
+                        if spend_txout_info is not None:
+                            chain_height: int = ci_from.getChainHeight()
+                            spend_tx_depth = max(
+                                0,
+                                chain_height - spend_txout_info["block_height"] + 1,
+                            )
+                    except Exception as e:
+                        self.log.debug(
+                            f"Could not get lock spend tx depth for bid {self.log.id(bid_id)}: {e}"
+                        )
+
+                    if spend_tx_depth < ci_from.blocks_confirmed:
+                        self.log.info(
+                            f"Waiting for lock spend tx {self.logIDT(spending_txid)} to reach depth {ci_from.blocks_confirmed}, currently {spend_tx_depth}, for bid {self.log.id(bid_id)}."
+                        )
+                        self.saveBidInSession(
+                            bid_id, bid, use_cursor, xmr_swap, save_in_progress=offer
+                        )
+                        return
+
+                    bid.setState(BidStates.XMR_SWAP_SCRIPT_TX_REDEEMED)
 
                     if bid.xmr_a_lock_tx:
                         bid.xmr_a_lock_tx.setState(TxStates.TX_REDEEMED)

--- a/basicswap/basicswap.py
+++ b/basicswap/basicswap.py
@@ -593,6 +593,9 @@ class BasicSwap(BaseApp, BSXNetwork, UIApp):
         )
         self._max_check_loop_blocks = self.settings.get("max_check_loop_blocks", 100000)
         self._force_db_upgrade = self.settings.get("force_db_upgrade", False)
+        self._wait_for_lock_spend_depth = self.settings.get(
+            "wait_for_lock_spend_depth", False
+        )
         self._bid_expired_leeway = 5
 
         self.swaps_in_progress = dict()
@@ -8837,7 +8840,8 @@ class BasicSwap(BaseApp, BSXNetwork, UIApp):
                 # TODO: Use explorer to get tx / block hash for getrawtransaction
 
                 spend_seen: bool = (
-                    bid.xmr_a_lock_tx is not None
+                    self._wait_for_lock_spend_depth
+                    and bid.xmr_a_lock_tx is not None
                     and bid.xmr_a_lock_tx.spend_txid == xmr_swap.a_lock_spend_tx_id
                     and xmr_swap.a_lock_spend_tx is not None
                 )
@@ -9622,28 +9626,33 @@ class BasicSwap(BaseApp, BSXNetwork, UIApp):
                 if state == BidStates.XMR_SWAP_LOCK_RELEASED:
                     xmr_swap.a_lock_spend_tx = bytes.fromhex(spend_txn_hex)
 
-                    spend_tx_depth: int = 0
-                    try:
-                        spend_txout_info = ci_from.getTxOutInfo(spending_txid, 0)
-                        if spend_txout_info is not None:
-                            chain_height: int = ci_from.getChainHeight()
-                            spend_tx_depth = max(
-                                0,
-                                chain_height - spend_txout_info["block_height"] + 1,
+                    if self._wait_for_lock_spend_depth:
+                        spend_tx_depth: int = 0
+                        try:
+                            spend_txout_info = ci_from.getTxOutInfo(spending_txid, 0)
+                            if spend_txout_info is not None:
+                                chain_height: int = ci_from.getChainHeight()
+                                spend_tx_depth = max(
+                                    0,
+                                    chain_height - spend_txout_info["block_height"] + 1,
+                                )
+                        except Exception as e:
+                            self.log.debug(
+                                f"Could not get lock spend tx depth for bid {self.log.id(bid_id)}: {e}"
                             )
-                    except Exception as e:
-                        self.log.debug(
-                            f"Could not get lock spend tx depth for bid {self.log.id(bid_id)}: {e}"
-                        )
 
-                    if spend_tx_depth < ci_from.blocks_confirmed:
-                        self.log.info(
-                            f"Waiting for lock spend tx {self.logIDT(spending_txid)} to reach depth {ci_from.blocks_confirmed}, currently {spend_tx_depth}, for bid {self.log.id(bid_id)}."
-                        )
-                        self.saveBidInSession(
-                            bid_id, bid, use_cursor, xmr_swap, save_in_progress=offer
-                        )
-                        return
+                        if spend_tx_depth < ci_from.blocks_confirmed:
+                            self.log.info(
+                                f"Waiting for lock spend tx {self.logIDT(spending_txid)} to reach depth {ci_from.blocks_confirmed}, currently {spend_tx_depth}, for bid {self.log.id(bid_id)}."
+                            )
+                            self.saveBidInSession(
+                                bid_id,
+                                bid,
+                                use_cursor,
+                                xmr_swap,
+                                save_in_progress=offer,
+                            )
+                            return
 
                     bid.setState(BidStates.XMR_SWAP_SCRIPT_TX_REDEEMED)
 

--- a/tests/basicswap/test_ads_spend_depth_gate.py
+++ b/tests/basicswap/test_ads_spend_depth_gate.py
@@ -1,0 +1,178 @@
+# -*- coding: utf-8 -*-
+
+# Copyright (c) 2026 The Basicswap developers
+# Distributed under the MIT software license, see the accompanying
+# file LICENSE or http://www.opensource.org/licenses/mit-license.php.
+
+import unittest
+from types import SimpleNamespace
+
+from basicswap.basicswap import BasicSwap
+from basicswap.basicswap_util import BidStates
+from basicswap.chainparams import Coins
+
+SPEND_TXID = bytes.fromhex("aa" * 32)
+LOCK_TXID = bytes.fromhex("bb" * 32)
+
+
+class StubLog:
+    def id(self, v):
+        return str(v)
+
+    def info(self, *args, **kwargs):
+        pass
+
+    def warning(self, *args, **kwargs):
+        pass
+
+    def debug(self, *args, **kwargs):
+        pass
+
+    def error(self, *args, **kwargs):
+        pass
+
+
+class StubTx:
+    def __init__(self):
+        self.spend_txid = None
+        self.states = []
+
+    def setState(self, state):
+        self.states.append(state)
+
+
+class StubBid:
+    def __init__(self, state):
+        self.state = state
+        self.states_set = []
+        self.was_received = False
+        self.was_sent = True
+        self.offer_id = b"offer"
+        self.bid_id = b"bid"
+        self.xmr_a_lock_tx = StubTx()
+
+    def setState(self, state):
+        self.states_set.append(state)
+        self.state = state
+
+
+class StubCI:
+    def __init__(self, spend_depth, blocks_confirmed=2, chain_height=100):
+        self._spend_depth = spend_depth
+        self.blocks_confirmed = blocks_confirmed
+        self._chain_height = chain_height
+
+    def loadTx(self, tx_bytes):
+        return SimpleNamespace(vin=[])
+
+    def getChainHeight(self):
+        return self._chain_height
+
+    def getTxOutInfo(self, txid, n):
+        if self._spend_depth < 1:
+            return None
+        return {
+            "block_height": self._chain_height - (self._spend_depth - 1),
+            "block_hash": b"\x00" * 32,
+            "block_time": 1000,
+        }
+
+
+def make_swap_client(ci, bid, xmr_swap):
+    sc = BasicSwap.__new__(BasicSwap)
+    sc.fp = None
+    sc.log = StubLog()
+    sc.saved = []
+    sc.events = []
+    sc.notifications = []
+
+    offer = SimpleNamespace(
+        coin_from=int(Coins.BTC),
+        coin_to=int(Coins.PART),
+        offer_id=b"offer",
+        swap_type=None,
+    )
+    xmr_offer = SimpleNamespace()
+
+    sc.openDB = lambda cursor=None: object()
+    sc.closeDB = lambda cursor, commit=True: None
+    sc.getXmrBidFromSession = lambda cursor, bid_id: (bid, xmr_swap)
+    sc.getXmrOfferFromSession = lambda cursor, offer_id: (offer, xmr_offer)
+    sc.is_reverse_ads_bid = lambda cf, ct: False
+    sc.isBchXmrSwap = lambda offer: False
+    sc.ci = lambda coin: ci
+    sc.saveBidInSession = (
+        lambda bid_id, bid, cursor, xmr_swap, save_in_progress=None: sc.saved.append(
+            bid.state
+        )
+    )
+    sc.logBidEvent = lambda bid_id, event, msg, cursor: sc.events.append(event)
+    sc.notify = lambda event_type, data: sc.notifications.append(event_type)
+    sc.logIDT = lambda t: str(t)
+    sc.logException = lambda msg: (_ for _ in ()).throw(AssertionError(msg))
+    return sc
+
+
+def make_xmr_swap():
+    return SimpleNamespace(
+        a_lock_spend_tx_id=SPEND_TXID,
+        a_lock_tx_id=LOCK_TXID,
+        a_lock_spend_tx=None,
+        a_lock_refund_tx_id=bytes.fromhex("cc" * 32),
+    )
+
+
+class TestAdsSpendDepthGate(unittest.TestCase):
+    def test_unconfirmed_spend_does_not_transition(self):
+        bid = StubBid(BidStates.XMR_SWAP_LOCK_RELEASED)
+        xmr_swap = make_xmr_swap()
+        ci = StubCI(spend_depth=0, blocks_confirmed=2)
+        sc = make_swap_client(ci, bid, xmr_swap)
+
+        sc.process_XMR_SWAP_A_LOCK_tx_spend(b"bid", SPEND_TXID.hex(), "00")
+
+        self.assertEqual(bid.states_set, [])
+        self.assertEqual(bid.state, BidStates.XMR_SWAP_LOCK_RELEASED)
+        self.assertEqual(len(sc.saved), 1)
+        self.assertEqual(xmr_swap.a_lock_spend_tx, b"\x00")
+
+    def test_shallow_spend_does_not_transition(self):
+        bid = StubBid(BidStates.XMR_SWAP_LOCK_RELEASED)
+        xmr_swap = make_xmr_swap()
+        ci = StubCI(spend_depth=1, blocks_confirmed=2)
+        sc = make_swap_client(ci, bid, xmr_swap)
+
+        sc.process_XMR_SWAP_A_LOCK_tx_spend(b"bid", SPEND_TXID.hex(), "00")
+
+        self.assertEqual(bid.states_set, [])
+        self.assertEqual(bid.state, BidStates.XMR_SWAP_LOCK_RELEASED)
+
+    def test_confirmed_spend_transitions_sender(self):
+        bid = StubBid(BidStates.XMR_SWAP_LOCK_RELEASED)
+        xmr_swap = make_xmr_swap()
+        ci = StubCI(spend_depth=2, blocks_confirmed=2)
+        sc = make_swap_client(ci, bid, xmr_swap)
+
+        sc.process_XMR_SWAP_A_LOCK_tx_spend(b"bid", SPEND_TXID.hex(), "00")
+
+        self.assertIn(BidStates.XMR_SWAP_SCRIPT_TX_REDEEMED, bid.states_set)
+        self.assertIn(BidStates.SWAP_COMPLETED, bid.states_set)
+        self.assertEqual(len(sc.notifications), 1)
+
+    def test_confirmed_spend_transitions_receiver(self):
+        bid = StubBid(BidStates.XMR_SWAP_LOCK_RELEASED)
+        bid.was_received = True
+        bid.was_sent = False
+        xmr_swap = make_xmr_swap()
+        ci = StubCI(spend_depth=2, blocks_confirmed=2)
+        sc = make_swap_client(ci, bid, xmr_swap)
+
+        sc.process_XMR_SWAP_A_LOCK_tx_spend(b"bid", SPEND_TXID.hex(), "00")
+
+        self.assertIn(BidStates.XMR_SWAP_SCRIPT_TX_REDEEMED, bid.states_set)
+        self.assertNotIn(BidStates.SWAP_COMPLETED, bid.states_set)
+        self.assertEqual(len(sc.notifications), 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/basicswap/test_ads_spend_depth_gate.py
+++ b/tests/basicswap/test_ads_spend_depth_gate.py
@@ -78,9 +78,10 @@ class StubCI:
         }
 
 
-def make_swap_client(ci, bid, xmr_swap):
+def make_swap_client(ci, bid, xmr_swap, wait_for_depth=True):
     sc = BasicSwap.__new__(BasicSwap)
     sc.fp = None
+    sc._wait_for_lock_spend_depth = wait_for_depth
     sc.log = StubLog()
     sc.saved = []
     sc.events = []
@@ -172,6 +173,18 @@ class TestAdsSpendDepthGate(unittest.TestCase):
         self.assertIn(BidStates.XMR_SWAP_SCRIPT_TX_REDEEMED, bid.states_set)
         self.assertNotIn(BidStates.SWAP_COMPLETED, bid.states_set)
         self.assertEqual(len(sc.notifications), 0)
+
+    def test_gate_disabled_unconfirmed_spend_transitions(self):
+        # Default behavior (option off): transition without waiting for depth.
+        bid = StubBid(BidStates.XMR_SWAP_LOCK_RELEASED)
+        xmr_swap = make_xmr_swap()
+        ci = StubCI(spend_depth=0, blocks_confirmed=2)
+        sc = make_swap_client(ci, bid, xmr_swap, wait_for_depth=False)
+
+        sc.process_XMR_SWAP_A_LOCK_tx_spend(b"bid", SPEND_TXID.hex(), "00")
+
+        self.assertIn(BidStates.XMR_SWAP_SCRIPT_TX_REDEEMED, bid.states_set)
+        self.assertIn(BidStates.SWAP_COMPLETED, bid.states_set)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
- The coin A lock spend was treated as final the moment it was seen, so a swap could be marked completed while the spend tx was still unconfirmed — a reorg at that point could undo it.
T- he lock spend tx must now reach the coin's blocks_confirmed depth before the bid advances; until then the bid re-checks on every poll.
- Both sender and receiver now re-check the spend tx depth while waiting, even after the tx leaves the mempool.
- Added test_ads_spend_depth_gate.py
- New setting: wait_for_lock_spend_depth (read from basicswap.json, defaults to False). The two places the gate acts are now conditional on it:
process_XMR_SWAP_A_LOCK_tx_spend: the depth check before moving to XMR_SWAP_SCRIPT_TX_REDEEMED / SWAP_COMPLETED only runs when the option is on. With it off, the bid transitions immediately on seeing the spend, exactly as upstream behaves today.
- checkXmrBidState: the spend_seen re-poll (which exists only to re-check depth after the gate deferred a transition) is also gated, so with the option off that path is unchanged from upstream too.

Note: Swaps show completed slightly later than before, completion now means confirmed.