### PR TITLE
amm: fix autostart when htmlhost is 0.0.0.0

### DIFF
--- a/basicswap/basicswap.py
+++ b/basicswap/basicswap.py
@@ -1745,7 +1745,12 @@ class BasicSwap(BaseApp, BSXNetwork, UIApp):
             self.log.info("Waiting 2 seconds for BasicSwap to fully initialize...")
             time.sleep(2)
 
-            amm_host = self.settings.get("htmlhost", "127.0.0.1")
+            basicswap_host = self.settings.get("htmlhost", "127.0.0.1")
+            amm_host = (
+                "127.0.0.1"
+                if basicswap_host in ("0.0.0.0", "::", "")
+                else basicswap_host
+            )
             amm_port = self.settings.get("htmlport", 12700)
             amm_debug = False
 


### PR DESCRIPTION
same fix as in https://github.com/basicswap/basicswap/pull/575, but for autostart