### PR TITLE
offers: bypass legacy limit for standing/fixed/onetime offers

### DIFF
--- a/basicswap/basicswap.py
+++ b/basicswap/basicswap.py
@@ -11287,18 +11287,22 @@ class BasicSwap(BaseApp, BSXNetwork, UIApp):
                 offer, use_cursor
             )
 
-            total_bids_value_multiplier = opts.get("total_bids_value_multiplier", 1.0)
-            if total_bids_value_multiplier > 0.0:
-                if (
-                    total_bids_value + bid_amount
-                    > offer.amount_from * total_bids_value_multiplier
-                ):
-                    raise AutomationConstraint(
-                        "Over remaining offer value {}".format(
-                            offer.amount_from * total_bids_value_multiplier
-                            - total_bids_value
+            # Tracked offers are bounded by offer_budget_allows above.
+            if get_offer_tracking(self, offer.offer_id, use_cursor) is None:
+                total_bids_value_multiplier = opts.get(
+                    "total_bids_value_multiplier", 1.0
+                )
+                if total_bids_value_multiplier > 0.0:
+                    if (
+                        total_bids_value + bid_amount
+                        > offer.amount_from * total_bids_value_multiplier
+                    ):
+                        raise AutomationConstraint(
+                            "Over remaining offer value {}".format(
+                                offer.amount_from * total_bids_value_multiplier
+                                - total_bids_value
+                            )
                         )
-                    )
 
             num_not_completed = 0
             for active_bid in active_bids:


### PR DESCRIPTION
example: 
1. Set "standing" offer to sell 1 BTC with 0 floor, balance of 10 BTC, Offer valid for 48hrs
2. A user buys 1 BTC

before this change: the offer refuses to accept further bids.

after: it will continue to accept bids until hitting the wallet floor

This issue went unnoticed by myself, because my offers are typically 10minutes. I found it while doing some testing while i had offers set to 1hr, and couldnt take my offers more than once.


Notes:

for the amm, all of these cases are handled gracefully - fixed total will revoke and repost the offer, minus any settled or in-flight amounts. Standing will revoke and repost the offer with the remaining amount above the floor.

for the normal offers.. they misrepresent amounts already, so this is strictly an improvement. (i still think we should use the AMM backend for manual offers as well)