### PR TITLE
core: don't attempt to unlock coins that arent ours

### DIFF
--- a/basicswap/basicswap.py
+++ b/basicswap/basicswap.py
@@ -3609,11 +3609,12 @@ class BasicSwap(BaseApp, BSXNetwork, UIApp):
             # Unlock locked inputs (TODO)
             if offer.swap_type == SwapTypes.XMR_SWAP:
                 ci_leader = self.ci(offer.coin_to if reverse_bid else offer.coin_from)
+                we_are_leader: bool = bid.was_sent if reverse_bid else bid.was_received
                 rows = use_cursor.execute(
                     "SELECT a_lock_tx FROM xmr_swaps WHERE bid_id = :bid_id",
                     {"bid_id": bid.bid_id},
                 ).fetchall()
-                if len(rows) > 0:
+                if we_are_leader and len(rows) > 0:
                     xmr_swap_a_lock_tx = rows[0][0]
                     try:
                         ci_leader.unlockInputs(xmr_swap_a_lock_tx)


### PR DESCRIPTION
```
2026-07-02 12:57:58 DEBUG : checkBidState 000000006a465a2df445dc269c1ddf1a201cd33091ff69e3b09356f7 8                                                                                    
2026-07-02 12:58:00 DEBUG : Removing bid from in-progress: 000000006a465a2df445dc269c1ddf1a201cd33091ff69e3b09356f7                                                                     
2026-07-02 12:58:01 DEBUG : Removing watched output LTC 000000006a465a2df445dc269c1ddf1a201cd33091ff69e3b09356f7 T_None                                                                 
2026-07-02 12:58:01 DEBUG : Removed watched output LTC 000000006a465a2df445dc269c1ddf1a201cd33091ff69e3b09356f7 T_xxxx      
2026-07-02 12:58:01 DEBUG : Removing watched output XMR 000000006a465a2df445dc269c1ddf1a201cd33091ff69e3b09356f7 T_None                                                                 
2026-07-02 12:58:01 DEBUG : Removing watched script LTC {'000000006a465a2df445dc269c1ddf1a201cd33091ff69e3b09356f7'}                                                                    
2026-07-02 12:58:01 DEBUG : Removing watched script XMR {'000000006a465a2df445dc269c1ddf1a201cd33091ff69e3b09356f7'}                                                                    
2026-07-02 12:58:01 WARNING : unlockInputs failed RPC error {'code': -8, 'message': 'Invalid parameter, unknown transaction'} 
```

This is from an XMR -> LTC swap. I sent xmr as taker