### PR TITLE
core: initialize bid_changed to false

### DIFF
--- a/basicswap/basicswap.py
+++ b/basicswap/basicswap.py
@@ -8763,6 +8763,7 @@ class BasicSwap(BaseApp, BSXNetwork, UIApp):
                 BidStates.XMR_SWAP_SCRIPT_COIN_LOCKED,
                 BidStates.XMR_SWAP_SCRIPT_TX_PREREFUND,
             ):
+                bid_changed: bool = False
                 try:
                     bid_changed = self.findTxB(ci_to, xmr_swap, bid, cursor, was_sent)
                 except Exception as e:


### PR DESCRIPTION
transient error under script coin locked causes error

mirror bid_change initialization from script lock spend msg tx