### PR TITLE
clientauth: enhance, fix, add to gui, and auto-apply to amm

### DIFF
--- a/basicswap/__init__.py
+++ b/basicswap/__init__.py
@@ -2,4 +2,4 @@ name = "basicswap"
 
 __version__ = "0.17.5"
 GUI_VERSION = "4.0.0"
-AMM_VERSION = "0.5.1"
+AMM_VERSION = "0.5.2"

--- a/basicswap/basicswap.py
+++ b/basicswap/basicswap.py
@@ -14663,6 +14663,34 @@ class BasicSwap(BaseApp, BSXNetwork, UIApp):
                     settings_copy["notifications_swap_completed"] = new_value
                     settings_changed = True
 
+            if "client_auth_hash" in data:
+                new_value = data["client_auth_hash"]
+                if new_value:
+                    ensure(
+                        isinstance(new_value, str),
+                        "New client_auth_hash value not a string",
+                    )
+                    if settings_copy.get("client_auth_hash") != new_value:
+                        settings_copy["client_auth_hash"] = new_value
+                        settings_changed = True
+                elif "client_auth_hash" in settings_copy:
+                    settings_copy.pop("client_auth_hash")
+                    settings_changed = True
+
+            if "session_timeout_minutes" in data:
+                new_value = data["session_timeout_minutes"]
+                ensure(
+                    isinstance(new_value, int),
+                    "New session_timeout_minutes value not integer",
+                )
+                ensure(
+                    1 <= new_value <= 10080,
+                    "session_timeout_minutes must be between 1 and 10080 minutes",
+                )
+                if settings_copy.get("session_timeout_minutes", 60) != new_value:
+                    settings_copy["session_timeout_minutes"] = new_value
+                    settings_changed = True
+
             if "notifications_duration" in data:
                 new_value = data["notifications_duration"]
                 ensure(

--- a/basicswap/http_server.py
+++ b/basicswap/http_server.py
@@ -988,8 +988,11 @@ class HttpHandler(BaseHTTPRequestHandler):
                 decoded_creds = base64.b64decode(encoded_creds).decode("utf-8")
                 _, password = decoded_creds.split(":", 1)
 
+                amm_token = getattr(swap_client, "_amm_api_token", None)
                 client_auth_hash = swap_client.settings.get("client_auth_hash")
-                if client_auth_hash and verify_rfc2440_password(
+                if amm_token and hmac.compare_digest(password, amm_token):
+                    basic_auth_ok = True
+                elif client_auth_hash and verify_rfc2440_password(
                     client_auth_hash, password
                 ):
                     basic_auth_ok = True

--- a/basicswap/http_server.py
+++ b/basicswap/http_server.py
@@ -263,7 +263,7 @@ class HttpHandler(BaseHTTPRequestHandler):
         ):
             cookie[SESSION_COOKIE_NAME]["secure"] = True
         expires = datetime.now(timezone.utc) + timedelta(
-            minutes=SESSION_DURATION_MINUTES
+            minutes=self._session_timeout_minutes()
         )
         cookie[SESSION_COOKIE_NAME]["expires"] = expires.strftime(
             "%a, %d %b %Y %H:%M:%S GMT"
@@ -303,6 +303,21 @@ class HttpHandler(BaseHTTPRequestHandler):
         cookie[LOGIN_NEXT_COOKIE_NAME]["path"] = "/"
         cookie[LOGIN_NEXT_COOKIE_NAME]["expires"] = "Thu, 01 Jan 1970 00:00:00 GMT"
         return ("Set-Cookie", cookie.output(header="").strip())
+
+    def _create_session(self):
+        session_id = secrets.token_urlsafe(32)
+        expires = datetime.now(timezone.utc) + timedelta(
+            minutes=self._session_timeout_minutes()
+        )
+        with self.server.session_lock:
+            self.server.active_sessions[session_id] = {"expires": expires}
+        return session_id, self._set_session_cookie(session_id)
+
+    def _drop_other_sessions(self, keep_session_id):
+        with self.server.session_lock:
+            for sid in list(self.server.active_sessions):
+                if sid != keep_session_id:
+                    del self.server.active_sessions[sid]
 
     def is_authenticated(self):
         swap_client = self.server.swap_client
@@ -604,13 +619,7 @@ class HttpHandler(BaseHTTPRequestHandler):
                 and password is not None
                 and verify_rfc2440_password(client_auth_hash, password)
             ):
-                session_id = secrets.token_urlsafe(32)
-                expires = datetime.now(timezone.utc) + timedelta(
-                    minutes=SESSION_DURATION_MINUTES
-                )
-                with self.server.session_lock:
-                    self.server.active_sessions[session_id] = {"expires": expires}
-                cookie_header = self._set_session_cookie(session_id)
+                session_id, cookie_header = self._create_session()
 
                 if is_json_request:
                     response_data = {"success": True, "session_id": session_id}

--- a/basicswap/http_server.py
+++ b/basicswap/http_server.py
@@ -80,6 +80,7 @@ from .ui.page_smsgaddresses import page_smsgaddresses
 from .ui.page_debug import page_debug
 
 SESSION_COOKIE_NAME = "basicswap_session_id"
+LOGIN_NEXT_COOKIE_NAME = "basicswap_login_next"
 SESSION_DURATION_MINUTES = 60
 
 env = Environment(
@@ -213,6 +214,19 @@ class HttpHandler(BaseHTTPRequestHandler):
                 return cookie[SESSION_COOKIE_NAME].value
         return None
 
+    def _session_timeout_minutes(self):
+        return self.server.swap_client.settings.get(
+            "session_timeout_minutes", SESSION_DURATION_MINUTES
+        )
+
+    def _safe_next_path(self, value):
+        # Only allow same-site absolute paths as a redirect target (open-redirect guard).
+        if not value or not value.startswith("/") or value.startswith("//"):
+            return None
+        if "\\" in value or "://" in value or "\n" in value or "\r" in value:
+            return None
+        return value
+
     def _set_session_cookie(self, session_id):
         cookie = SimpleCookie()
         cookie[SESSION_COOKIE_NAME] = session_id
@@ -243,6 +257,32 @@ class HttpHandler(BaseHTTPRequestHandler):
         cookie[SESSION_COOKIE_NAME]["path"] = "/"
         cookie[SESSION_COOKIE_NAME]["httponly"] = True
         cookie[SESSION_COOKIE_NAME]["expires"] = "Thu, 01 Jan 1970 00:00:00 GMT"
+        return ("Set-Cookie", cookie.output(header="").strip())
+
+    def _set_login_next_cookie(self, next_path):
+        cookie = SimpleCookie()
+        cookie[LOGIN_NEXT_COOKIE_NAME] = parse.quote(next_path, safe="")
+        cookie[LOGIN_NEXT_COOKIE_NAME]["path"] = "/"
+        cookie[LOGIN_NEXT_COOKIE_NAME]["samesite"] = "Lax"
+        forwarded_proto = self.headers.get("X-Forwarded-Proto", "").lower()
+        if forwarded_proto == "https" or self.server.swap_client.settings.get(
+            "secure_cookies", cfg.DEFAULT_SECURE_COOKIES
+        ):
+            cookie[LOGIN_NEXT_COOKIE_NAME]["secure"] = True
+        return ("Set-Cookie", cookie.output(header="").strip())
+
+    def _get_login_next_cookie(self):
+        if "Cookie" in self.headers:
+            cookie = SimpleCookie(self.headers["Cookie"])
+            if LOGIN_NEXT_COOKIE_NAME in cookie:
+                return parse.unquote(cookie[LOGIN_NEXT_COOKIE_NAME].value)
+        return None
+
+    def _clear_login_next_cookie(self):
+        cookie = SimpleCookie()
+        cookie[LOGIN_NEXT_COOKIE_NAME] = ""
+        cookie[LOGIN_NEXT_COOKIE_NAME]["path"] = "/"
+        cookie[LOGIN_NEXT_COOKIE_NAME]["expires"] = "Thu, 01 Jan 1970 00:00:00 GMT"
         return ("Set-Cookie", cookie.output(header="").strip())
 
     def is_authenticated(self):
@@ -561,8 +601,14 @@ class HttpHandler(BaseHTTPRequestHandler):
                     return json.dumps(response_data).encode("utf-8")
                 else:
                     self.send_response(302)
-                    self.send_header("Location", "/offers")
+                    self.send_header(
+                        "Location",
+                        self._safe_next_path(self._get_login_next_cookie())
+                        or "/offers",
+                    )
                     self.send_header(cookie_header[0], cookie_header[1])
+                    clear_next = self._clear_login_next_cookie()
+                    self.send_header(clear_next[0], clear_next[1])
                     self.end_headers()
                     return b""
             else:
@@ -580,7 +626,12 @@ class HttpHandler(BaseHTTPRequestHandler):
             and self.is_authenticated()
         ):
             self.send_response(302)
-            self.send_header("Location", "/offers")
+            self.send_header(
+                "Location",
+                self._safe_next_path(self._get_login_next_cookie()) or "/offers",
+            )
+            clear_next = self._clear_login_next_cookie()
+            self.send_header(clear_next[0], clear_next[1])
             self.end_headers()
             return b""
 
@@ -945,6 +996,16 @@ class HttpHandler(BaseHTTPRequestHandler):
                 else:
                     self.send_response(302)
                     self.send_header("Location", "/login")
+                    if (
+                        self.command == "GET"
+                        and self.headers.get("Sec-Fetch-Dest", "document") == "document"
+                        and parsed.path not in ("", "/", "/login")
+                    ):
+                        next_target = parsed.path
+                        if parsed.query:
+                            next_target += "?" + parsed.query
+                        next_cookie = self._set_login_next_cookie(next_target)
+                        self.send_header(next_cookie[0], next_cookie[1])
                 clear_cookie_header = self._clear_session_cookie()
                 self.send_header(clear_cookie_header[0], clear_cookie_header[1])
                 self.end_headers()

--- a/basicswap/http_server.py
+++ b/basicswap/http_server.py
@@ -81,7 +81,7 @@ from .ui.page_debug import page_debug
 
 SESSION_COOKIE_NAME = "basicswap_session_id"
 LOGIN_NEXT_COOKIE_NAME = "basicswap_login_next"
-SESSION_DURATION_MINUTES = 60
+SESSION_DURATION_MINUTES = 15
 
 env = Environment(
     loader=PackageLoader("basicswap", "templates"),
@@ -227,6 +227,25 @@ class HttpHandler(BaseHTTPRequestHandler):
             return None
         return value
 
+    def page_heartbeat(self):
+        session_id = self._get_session_cookie()
+        slid = False
+        if session_id:
+            now = datetime.now(timezone.utc)
+            with self.server.session_lock:
+                session_data = self.server.active_sessions.get(session_id)
+                if session_data and session_data["expires"] > now:
+                    session_data["expires"] = now + timedelta(
+                        minutes=self._session_timeout_minutes()
+                    )
+                    slid = True
+        if slid:
+            cookie_header = self._set_session_cookie(session_id)
+            self.putHeaders(200, "application/json", extra_headers=[cookie_header])
+            return json.dumps({"success": True}).encode("utf-8")
+        self.putHeaders(401, "application/json")
+        return json.dumps({"error": "Unauthorized"}).encode("utf-8")
+
     def _set_session_cookie(self, session_id):
         cookie = SimpleCookie()
         cookie[SESSION_COOKIE_NAME] = session_id
@@ -299,9 +318,6 @@ class HttpHandler(BaseHTTPRequestHandler):
         with self.server.session_lock:
             session_data = self.server.active_sessions.get(session_id)
             if session_data and session_data["expires"] > datetime.now(timezone.utc):
-                session_data["expires"] = datetime.now(timezone.utc) + timedelta(
-                    minutes=SESSION_DURATION_MINUTES
-                )
                 return True
 
             if session_id in self.server.active_sessions:
@@ -500,6 +516,11 @@ class HttpHandler(BaseHTTPRequestHandler):
             args_dict["static_v"] = "{}-{}".format(version, max(mtimes))
         except Exception:
             args_dict["static_v"] = version
+
+        args_dict["client_auth_enabled"] = bool(
+            swap_client.settings.get("client_auth_hash")
+        )
+        args_dict["session_timeout_minutes"] = self._session_timeout_minutes()
 
         self.putHeaders(status_code, "text/html", extra_headers=extra_headers)
         return bytes(
@@ -1026,6 +1047,11 @@ class HttpHandler(BaseHTTPRequestHandler):
         get_string = parsed.query
 
         if page == "json":
+            if len(url_split) > 2 and url_split[2] == "heartbeat":
+                if self.command != "POST":
+                    self.putHeaders(405, "application/json")
+                    return json.dumps({"error": "POST required"}).encode("utf-8")
+                return self.page_heartbeat()
             if self.command != "POST" and json_requires_post(url_split):
                 self.putHeaders(405, "application/json")
                 return json.dumps({"error": "POST required"}).encode("utf-8")

--- a/basicswap/static/js/global.js
+++ b/basicswap/static/js/global.js
@@ -5,6 +5,7 @@
             if (response.status === 401) {
                 const urlStr = typeof url === 'string' ? url : (url && url.url) || '';
                 if (urlStr.startsWith('/json/') || urlStr.startsWith('/json')) {
+                    document.cookie = 'basicswap_login_next=' + encodeURIComponent(window.location.pathname + window.location.search) + '; path=/; samesite=lax';
                     window.location.href = '/login';
                     return new Response(JSON.stringify({error: 'Session expired'}), {
                         status: 401,

--- a/basicswap/static/js/modules/session-heartbeat.js
+++ b/basicswap/static/js/modules/session-heartbeat.js
@@ -1,0 +1,40 @@
+(function () {
+  var timeoutMin = window.BSX_SESSION_TIMEOUT_MIN || 15;
+  var throttleMs = Math.max(10000, Math.floor((timeoutMin * 60 * 1000) / 3));
+  var lastSent = 0;
+
+  function sendHeartbeat() {
+    lastSent = Date.now();
+    fetch("/json/heartbeat", {
+      method: "POST",
+      credentials: "same-origin",
+      keepalive: true,
+    })
+      .then(function (r) {
+        if (r.status === 401) {
+          document.cookie =
+            "basicswap_login_next=" +
+            encodeURIComponent(
+              window.location.pathname + window.location.search
+            ) +
+            "; path=/; samesite=lax";
+          window.location.href = "/login";
+        }
+      })
+      .catch(function () {});
+  }
+
+  function onActivity() {
+    if (document.hidden) {
+      return;
+    }
+    if (Date.now() - lastSent >= throttleMs) {
+      sendHeartbeat();
+    }
+  }
+
+  var events = ["mousedown", "keydown", "touchstart", "scroll", "wheel"];
+  events.forEach(function (ev) {
+    window.addEventListener(ev, onActivity, { passive: true, capture: true });
+  });
+})();

--- a/basicswap/static/js/pages/settings-page.js
+++ b/basicswap/static/js/pages/settings-page.js
@@ -10,6 +10,7 @@
 
     init: function() {
       this.setupTabs();
+      this.setupPasswordToggles();
       this.setupCoinHeaders();
       this.setupConfirmModal();
       this.setupNotificationSettings();
@@ -42,6 +43,23 @@
       tabButtons.forEach(btn => {
         btn.addEventListener('click', () => {
           switchTab(btn.dataset.tab);
+        });
+      });
+    },
+
+    setupPasswordToggles: function() {
+      document.querySelectorAll('.password-toggle').forEach(btn => {
+        const input = document.getElementById(btn.dataset.target);
+        if (!input) return;
+        const eyeOpen = btn.querySelector('.eye-open');
+        const eyeClosed = btn.querySelector('.eye-closed');
+        btn.addEventListener('mousedown', e => e.preventDefault());
+        btn.addEventListener('click', e => {
+          e.preventDefault();
+          const isPassword = input.type === 'password';
+          input.type = isPassword ? 'text' : 'password';
+          if (eyeOpen) eyeOpen.classList.toggle('hidden', isPassword);
+          if (eyeClosed) eyeClosed.classList.toggle('hidden', !isPassword);
         });
       });
     },

--- a/basicswap/templates/amm.html
+++ b/basicswap/templates/amm.html
@@ -406,16 +406,6 @@
                   </div>
                 </div>
 
-                <div class="p-4 bg-gray-50 dark:bg-gray-700 rounded-lg">
-                  <h5 class="mb-3 text-base font-medium text-gray-900 dark:text-white">Settings</h5>
-                  <div class="grid grid-cols-1 gap-4">
-                    <div>
-                      <label for="auth" class="block mb-2 text-sm font-medium text-gray-700 dark:text-gray-300">Authentication</label>
-                      <input type="text" id="auth" name="auth" class="bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500">
-                    </div>
-                  </div>
-                </div>
-
                 <div class="flex justify-end">
                   <button type="submit" name="save_global_settings" value="true" class="px-4 py-2.5 bg-blue-500 hover:bg-blue-600 font-medium text-sm text-white border border-blue-500 rounded-md shadow-button focus:ring-0 focus:outline-none">Save Settings</button>
                 </div>
@@ -456,7 +446,7 @@
                     <p class="text-sm font-medium text-gray-700 dark:text-gray-300"><strong>Script Behavior</strong></p>
                     <ul class="mt-2 space-y-2 text-sm text-gray-600 dark:text-gray-400">
                       <li class="break-words"><span class="font-semibold">main_loop_delay:</span> Seconds between main loop iterations (10-1000)</li>
-                      <li class="break-words"><span class="font-semibold">auth:</span> Basicswap API auth string, e.g., "admin:password". Ignored if client auth is not enabled.</li>
+                      <li class="break-words"><span class="font-semibold">auth:</span> Basicswap API auth string, e.g., "admin:password", for running createoffers.py standalone. Ignored when the AMM is started by BasicSwap (it uses a temporary token) or if client auth is not enabled.</li>
                       <li class="break-words"><span class="font-semibold">wallet_port_override:</span> If needed, uncomment and set to override wallet API port (for testing only)</li>
                     </ul>
                   </div>

--- a/basicswap/templates/header.html
+++ b/basicswap/templates/header.html
@@ -113,6 +113,10 @@
   {% if current_page == 'wallets' or current_page == 'wallet' %}
   <script src="/static/js/modules/wallet-manager.js"></script>
   {% endif %}
+  {% if client_auth_enabled %}
+  <script>window.BSX_SESSION_TIMEOUT_MIN = {{ session_timeout_minutes }};</script>
+  <script src="/static/js/modules/session-heartbeat.js"></script>
+  {% endif %}
   <!-- Memory management -->
   <script src="/static/js/modules/memory-manager.js"></script>
   <!-- Main application script -->

--- a/basicswap/templates/settings.html
+++ b/basicswap/templates/settings.html
@@ -659,6 +659,7 @@
            <li>Password only: API clients may send any username (e.g. admin), which is ignored.</li>
            <li>Web sessions stay unlocked until the session timeout above is reached with no activity. The API is stateless and re-checks the password on every request.</li>
            <li>Can be reset from the config file if forgotten.</li>
+           <li>The AMM authenticates with a temporary token issued when it starts.</li>
           </ul>
           <p class="mt-4 text-sm text-gray-600 dark:text-gray-400">Separate from your wallet encryption password, set on the <a href="/changepassword" class="underline">Change Password</a> page.</p>
          </div>

--- a/basicswap/templates/settings.html
+++ b/basicswap/templates/settings.html
@@ -42,6 +42,9 @@
       <button class="tab-button border-b-2 border-transparent text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300 hover:border-gray-300 dark:hover:border-gray-600 py-4 px-1 text-sm font-medium focus:outline-none focus:ring-0" data-tab="general" id="general-tab">
        General
       </button>
+      <button class="tab-button border-b-2 border-transparent text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300 hover:border-gray-300 dark:hover:border-gray-600 py-4 px-1 text-sm font-medium focus:outline-none focus:ring-0" data-tab="security" id="security-tab">
+       Security
+      </button>
       <button class="tab-button border-b-2 border-transparent text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300 hover:border-gray-300 dark:hover:border-gray-600 py-4 px-1 text-sm font-medium focus:outline-none focus:ring-0" data-tab="notifications" id="notifications-tab">
        Notifications
       </button>
@@ -55,7 +58,7 @@
  </section>
 
  <div class="container px-4 mx-auto">
-  
+
   <div class="tab-content" id="coins" role="tabpanel" aria-labelledby="coins-tab">
    <form method="post" id="coins-form">
     <div class="space-y-6">
@@ -99,7 +102,7 @@
 
       <div class="coin-details hidden" id="details-{{ c.name }}">
        <div class="px-6 py-6">
-        
+
         {% if c.connection_type %}
         <div class="mb-6">
          <h4 class="text-sm font-medium text-gray-900 dark:text-white mb-4">
@@ -591,6 +594,96 @@
     </div>
     <input type="hidden" name="formid" value="{{ form_id }}">
    </form>
+  </div>
+
+  <div class="tab-content hidden" id="security" role="tabpanel" aria-labelledby="security-tab">
+   <div class="space-y-6">
+
+     <div class="bg-coolGray-100 dark:bg-gray-500 rounded-xl">
+      <div class="px-6 py-4">
+       <h3 class="text-lg font-semibold text-gray-900 dark:text-white">
+        Client Authentication
+       </h3>
+       <p class="mt-1 text-sm text-gray-600 dark:text-gray-300">
+        {% if security_settings.client_auth_enabled %}A password is required to access the web interface and the API.{% else %}No password is set. The web interface and API are open to anyone who can reach this server.{% endif %}
+       </p>
+      </div>
+
+      <div class="px-6 py-6">
+       <form method="post" id="session-timeout-form">
+       <div class="border-b border-gray-300 dark:border-gray-600 pb-6 mb-6">
+        <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">Session Timeout (minutes)</label>
+        <div class="relative max-w-xs">
+         <input type="number" name="session_timeout_minutes" autocomplete="off" min="1" max="10080" value="{{ security_settings.session_timeout_minutes }}" {% if not security_settings.client_auth_enabled %}disabled{% endif %} class="hover:border-blue-500 bg-gray-50 text-gray-900 appearance-none dark:bg-gray-700 dark:text-white border border-gray-300 dark:border-gray-600 dark:placeholder-gray-400 text-sm rounded-lg outline-none focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5 focus:ring-1 focus:outline-none disabled:opacity-50 disabled:cursor-not-allowed">
+        </div>
+        <p class="text-xs text-gray-500 dark:text-gray-400 mt-1">{% if security_settings.client_auth_enabled %}How long a web session stays valid before the password is required again{% else %}Enable client authentication below to use a session timeout{% endif %}</p>
+        <div class="flex justify-end pt-6 mt-6">
+         <button name="apply_security" value="Apply" type="submit" {% if not security_settings.client_auth_enabled %}disabled{% endif %} class="bg-blue-600 hover:bg-blue-700 text-white font-medium py-2 px-4 rounded-lg transition-colors focus:outline-none disabled:opacity-50 disabled:cursor-not-allowed">
+          Save Timeout
+         </button>
+        </div>
+       </div>
+       <input type="hidden" name="formid" value="{{ form_id }}">
+       </form>
+
+       <form method="post" id="client-auth-form" autocomplete="off">
+       <div class="grid grid-cols-1 lg:grid-cols-2 gap-8">
+        <div class="space-y-6">
+         <div>
+          <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">New Password</label>
+          <div class="relative">
+           <input type="password" id="new_password" name="new_password" autocomplete="new-password" placeholder="Enter a password" class="hover:border-blue-500 bg-gray-50 text-gray-900 appearance-none pr-10 dark:bg-gray-700 dark:text-white border border-gray-300 dark:border-gray-600 dark:placeholder-gray-400 text-sm rounded-lg outline-none focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5 focus:ring-1 focus:outline-none">
+           <button type="button" class="password-toggle absolute inset-y-0 right-0 flex items-center pr-3 text-gray-400 hover:text-gray-600 dark:text-gray-500 dark:hover:text-gray-300 transition-colors" data-target="new_password" aria-label="Toggle password visibility">
+            <svg class="eye-open w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"></path><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z"></path></svg>
+            <svg class="eye-closed w-5 h-5 hidden" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13.875 18.825A10.05 10.05 0 0112 19c-4.478 0-8.268-2.943-9.543-7a9.97 9.97 0 011.563-3.029m5.858.908a3 3 0 114.243 4.243M9.878 9.878l4.242 4.242M9.878 9.878L3 3m6.878 6.878L21 21"></path></svg>
+           </button>
+          </div>
+         </div>
+         <div>
+          <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">Confirm Password</label>
+          <div class="relative">
+           <input type="password" id="confirm_password" name="confirm_password" autocomplete="new-password" placeholder="Re-enter the password" class="hover:border-blue-500 bg-gray-50 text-gray-900 appearance-none pr-10 dark:bg-gray-700 dark:text-white border border-gray-300 dark:border-gray-600 dark:placeholder-gray-400 text-sm rounded-lg outline-none focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5 focus:ring-1 focus:outline-none">
+           <button type="button" class="password-toggle absolute inset-y-0 right-0 flex items-center pr-3 text-gray-400 hover:text-gray-600 dark:text-gray-500 dark:hover:text-gray-300 transition-colors" data-target="confirm_password" aria-label="Toggle password visibility">
+            <svg class="eye-open w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"></path><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z"></path></svg>
+            <svg class="eye-closed w-5 h-5 hidden" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13.875 18.825A10.05 10.05 0 0112 19c-4.478 0-8.268-2.943-9.543-7a9.97 9.97 0 011.563-3.029m5.858.908a3 3 0 114.243 4.243M9.878 9.878l4.242 4.242M9.878 9.878L3 3m6.878 6.878L21 21"></path></svg>
+           </button>
+          </div>
+         </div>
+        </div>
+
+        <div class="space-y-6">
+         <div class="bg-gray-50 dark:bg-gray-600 rounded-lg p-6">
+          <h3 class="text-lg font-medium text-gray-900 dark:text-white mb-4">About client authentication</h3>
+          <ul class="space-y-3 text-sm text-gray-600 dark:text-gray-400 list-disc list-outside pl-5">
+           <li>Required for both the web interface and the API.</li>
+           <li>Password only: API clients may send any username (e.g. admin), which is ignored.</li>
+           <li>Web sessions stay unlocked until the session timeout above is reached with no activity. The API is stateless and re-checks the password on every request.</li>
+           <li>Can be reset from the config file if forgotten.</li>
+          </ul>
+          <p class="mt-4 text-sm text-gray-600 dark:text-gray-400">Separate from your wallet encryption password, set on the <a href="/changepassword" class="underline">Change Password</a> page.</p>
+         </div>
+        </div>
+       </div>
+
+       <div class="mt-8 flex justify-end gap-3">
+        {% if security_settings.client_auth_enabled %}
+        <button name="apply_client_auth" value="set" type="submit" class="bg-blue-600 hover:bg-blue-700 text-white font-medium py-2 px-4 rounded-lg transition-colors focus:outline-none">
+         Change Password
+        </button>
+        <button name="apply_client_auth" value="disable" type="submit" class="bg-red-600 hover:bg-red-700 text-white font-medium py-2 px-4 rounded-lg transition-colors focus:outline-none">
+         Disable Password
+        </button>
+        {% else %}
+        <button name="apply_client_auth" value="set" type="submit" class="bg-blue-600 hover:bg-blue-700 text-white font-medium py-2 px-4 rounded-lg transition-colors focus:outline-none">
+         Enable Password
+        </button>
+        {% endif %}
+       </div>
+       <input type="hidden" name="formid" value="{{ form_id }}">
+       </form>
+      </div>
+     </div>
+    </div>
   </div>
 
   <div class="tab-content hidden" id="notifications" role="tabpanel" aria-labelledby="notifications-tab">

--- a/basicswap/ui/page_amm.py
+++ b/basicswap/ui/page_amm.py
@@ -8,6 +8,7 @@
 import os
 import json
 import time
+import secrets
 import subprocess
 import threading
 import traceback
@@ -282,6 +283,11 @@ def start_amm_process(
     if debug:
         cmd.append("--debug")
 
+    # Give the AMM an ephemeral API token via the environment so its login
+    # credential never has to be written to disk.
+    amm_api_token = secrets.token_urlsafe(32)
+    swap_client._amm_api_token = amm_api_token
+
     try:
         amm_process = subprocess.Popen(
             cmd,
@@ -289,7 +295,11 @@ def start_amm_process(
             stderr=subprocess.STDOUT,
             universal_newlines=True,
             bufsize=1,
-            env=dict(os.environ, PYTHONUNBUFFERED="1"),
+            env=dict(
+                os.environ,
+                PYTHONUNBUFFERED="1",
+                BSX_API_AUTH="amm:" + amm_api_token,
+            ),
         )
 
         with amm_log_lock:
@@ -366,6 +376,9 @@ def stop_amm_process(swap_client=None):
             amm_log_buffer.append(f"Stopped: {', '.join(stopped_processes)}")
         if errors:
             amm_log_buffer.append(f"Errors: {', '.join(errors)}")
+
+    if swap_client is not None:
+        swap_client._amm_api_token = None
 
     amm_process = None
 

--- a/basicswap/ui/page_amm.py
+++ b/basicswap/ui/page_amm.py
@@ -857,9 +857,6 @@ def page_amm(self, _, post_string):
                         except ValueError:
                             pass
 
-                    if "auth" in form_data:
-                        current_config["auth"] = form_data.get("auth", [""])[0]
-
                     if swap_client.debug_ui:
                         if "min_seconds_between_bids" in form_data:
                             try:

--- a/basicswap/ui/page_settings.py
+++ b/basicswap/ui/page_settings.py
@@ -22,6 +22,7 @@ from basicswap.basicswap_util import (
 from basicswap.chainparams import (
     Coins,
 )
+from basicswap.util.rfc2440 import rfc2440_hash_password
 
 
 def page_settings(self, url_split, post_string):
@@ -31,6 +32,7 @@ def page_settings(self, url_split, post_string):
 
     messages = []
     err_messages = []
+    extra_headers = []
     active_tab = "default"
     form_data = self.checkForm(post_string, "settings", err_messages)
     if form_data:
@@ -45,6 +47,53 @@ def page_settings(self, url_split, post_string):
                     ),
                 }
                 swap_client.editGeneralSettings(data)
+            elif have_data_entry(form_data, "apply_security"):
+                active_tab = "security"
+                data = {
+                    "session_timeout_minutes": int(
+                        get_data_entry_or(form_data, "session_timeout_minutes", "15")
+                    ),
+                }
+                swap_client.editGeneralSettings(data)
+                session_id = self._get_session_cookie()
+                if session_id:
+                    extra_headers.append(self._set_session_cookie(session_id))
+                messages.append("Security settings applied.")
+            elif have_data_entry(form_data, "apply_client_auth"):
+                active_tab = "security"
+                action = get_data_entry(form_data, "apply_client_auth")
+                auth_enabled = bool(swap_client.settings.get("client_auth_hash"))
+                if action == "disable":
+                    allowed_hosts = swap_client.settings.get("allowed_hosts", []) or []
+                    if "*" in allowed_hosts and not swap_client.settings.get(
+                        "unsafe_allow_any_host_without_auth"
+                    ):
+                        err_messages.append(
+                            "Cannot disable the password while 'allowed_hosts' contains '*' (DNS-rebinding protection)."
+                        )
+                    else:
+                        swap_client.editGeneralSettings({"client_auth_hash": ""})
+                        messages.append("Client Authentication disabled.")
+                else:
+                    new_password = get_data_entry_or(form_data, "new_password", "")
+                    confirm_password = get_data_entry_or(
+                        form_data, "confirm_password", ""
+                    )
+                    if new_password == "":
+                        err_messages.append("Password must not be empty.")
+                    elif new_password != confirm_password:
+                        err_messages.append("Passwords do not match.")
+                    else:
+                        swap_client.editGeneralSettings(
+                            {"client_auth_hash": rfc2440_hash_password(new_password)}
+                        )
+                        if auth_enabled:
+                            self._drop_other_sessions(self._get_session_cookie())
+                            messages.append("Client Authentication password changed.")
+                        else:
+                            _, cookie_header = self._create_session()
+                            extra_headers.append(cookie_header)
+                            messages.append("Client Authentication enabled.")
             elif have_data_entry(form_data, "apply_chart"):
                 active_tab = "general"
                 data = {
@@ -348,6 +397,13 @@ def page_settings(self, url_split, post_string):
         "enabled_chart_coins": swap_client.settings.get("enabled_chart_coins", ""),
     }
 
+    security_settings = {
+        "session_timeout_minutes": swap_client.settings.get(
+            "session_timeout_minutes", 15
+        ),
+        "client_auth_enabled": bool(swap_client.settings.get("client_auth_hash")),
+    }
+
     notification_settings = {
         "notifications_new_offers": swap_client.settings.get(
             "notifications_new_offers", False
@@ -396,8 +452,10 @@ def page_settings(self, url_split, post_string):
             "chains": chains_formatted,
             "general_settings": general_settings,
             "chart_settings": chart_settings,
+            "security_settings": security_settings,
             "notification_settings": notification_settings,
             "tor_settings": tor_settings,
             "active_tab": active_tab,
         },
+        extra_headers=extra_headers,
     )

--- a/scripts/createoffers.py
+++ b/scripts/createoffers.py
@@ -85,7 +85,7 @@ import urllib.error
 import base64
 from urllib.request import urlopen
 
-__version__ = "0.5.1"
+__version__ = "0.5.2"
 
 delay_event = threading.Event()
 shutdown_in_progress = False
@@ -2101,7 +2101,7 @@ def main():
         print(f"Error reading config file {args.configfile}: {e}")
         return 1
 
-    auth_info = initial_config.get("auth")
+    auth_info = os.environ.get("BSX_API_AUTH") or initial_config.get("auth")
 
     read_json_api = make_json_api_func(args.host, args.port, auth_info)
     wallet_api_port_override = initial_config.get("wallet_port_override")
@@ -2167,6 +2167,16 @@ def main():
         while not delay_event.is_set():
             # Read config each iteration so it can be modified without restarting
             config = readConfig(args, known_coins)
+
+            # Hot-reload auth so a password change needs no restart.
+            new_auth = os.environ.get("BSX_API_AUTH") or config.get("auth")
+            if new_auth != auth_info:
+                auth_info = new_auth
+                read_json_api = make_json_api_func(args.host, args.port, auth_info)
+                if wallet_api_port_override:
+                    read_json_api_wallet_auth = make_json_api_func(
+                        args.host, int(wallet_api_port_override), auth_info
+                    )
 
             # override wallet api calls for testing
             if "wallet_port_override" in config:


### PR DESCRIPTION
- add clientauth to settings
- make the static 60min timeout configurable
- add heartbeat to extend the timeout on activity
- auto apply to amm
- avoid storing password in plain text by using a token for amm
- bump amm version to 0.5.2

TODO: 
- [x] remove auth section from amm gui page
- [x] maybe change lock timeout default to a more sensible 15min

builds on top of #605 and #606