### PR TITLE
xmr: treat 'not enough money' as transient

### DIFF
--- a/basicswap/interface/xmr/xmr.py
+++ b/basicswap/interface/xmr/xmr.py
@@ -91,6 +91,7 @@ class XMRInterface(CoinInterface):
             for response in [
                 "failed to get earliest fork height",
                 "failed to get output distribution",
+                "not enough money",
                 "request-sent",
                 "idle",
                 "busy",


### PR DESCRIPTION
Occasionally, with multiple swaps in progress, some funds may be locked in contract or yet to arrive for other reasons.

instead of stranding the A side, allow time for the wallet to be funded