### PR TITLE
amm: track by id instead of name + migrate

### DIFF
--- a/basicswap/static/js/pages/amm-tables.js
+++ b/basicswap/static/js/pages/amm-tables.js
@@ -276,7 +276,7 @@ const AmmTablesManager = (function() {
 
             const amountToReceive = amount * minrate;
 
-            const runtime = templateRuntime[name] || {};
+            const runtime = templateRuntime[offer.id] || {};
             const offerMode = offer.offer_mode || 'standing';
             const exhausted = runtime.exhausted === true;
             const offerIds = Array.isArray(runtime.offer_ids) ? runtime.offer_ids : [];
@@ -365,7 +365,13 @@ const AmmTablesManager = (function() {
                             <span class="mt-1 inline-flex items-center px-3 py-1 text-xs font-medium rounded-full bg-orange-100 text-orange-800 dark:bg-orange-900 dark:text-orange-300">
                                 Exhausted
                             </span>` : ''}
-                            ${staleBadge}
+                            ${activeOffersCount > 0 ? '' : staleBadge}
+                            ${offerMode === 'one_time' || offerMode === 'fixed_total' ? `
+                            <button type="button" class="reset-amm-item mt-1 inline-flex items-center gap-1 px-3 py-1 text-xs font-medium rounded-full bg-gray-100 text-gray-700 hover:bg-gray-200 dark:bg-gray-700 dark:text-gray-300 dark:hover:bg-gray-600 focus:ring-0 focus:outline-none"
+                                title="Reset budget (start fresh)" data-type="offer" data-id="${offer.id || ''}" data-name="${name}">
+                                <svg class="w-3.5 h-3.5" fill="currentColor" viewBox="0 0 20 20"><path fill-rule="evenodd" d="M4 2a1 1 0 011 1v2.101a7.002 7.002 0 0111.601 2.566 1 1 0 11-1.885.666A5.002 5.002 0 005.999 7H9a1 1 0 010 2H4a1 1 0 01-1-1V3a1 1 0 011-1zm.008 9.057a1 1 0 011.276.61A5.002 5.002 0 0014.001 13H11a1 1 0 110-2h5a1 1 0 011 1v5a1 1 0 11-2 0v-2.101a7.002 7.002 0 01-11.601-2.566 1 1 0 01.61-1.276z" clip-rule="evenodd"></path></svg>
+                                Reset
+                            </button>` : ''}
                         </div>
                     </td>
                     <td class="py-3 px-4 text-center">
@@ -442,7 +448,7 @@ const AmmTablesManager = (function() {
             const minCoinToBalance = parseFloat(bid.min_coin_to_balance || 0);
             const maxConcurrent = parseInt(bid.max_concurrent || 1);
             const amountToSend = amount * maxRate;
-            const bidRt = bidRuntime[name] || {};
+            const bidRt = bidRuntime[bid.id] || {};
             const bidIds = Array.isArray(bidRt.bid_ids) ? bidRt.bid_ids : [];
             const activeBidsCount = bidRt.active_bid_count !== undefined
                 ? bidRt.active_bid_count
@@ -1371,6 +1377,25 @@ const AmmTablesManager = (function() {
         }
 
         document.addEventListener('click', function(e) {
+            if (e.target && (e.target.classList.contains('reset-amm-item') || e.target.closest('.reset-amm-item'))) {
+                const button = e.target.classList.contains('reset-amm-item') ? e.target : e.target.closest('.reset-amm-item');
+                const type = button.getAttribute('data-type');
+                const id = button.getAttribute('data-id');
+                const name = button.getAttribute('data-name');
+
+                if (window.showConfirmModal) {
+                    window.showConfirmModal(
+                        'Reset budget',
+                        `Reset tracked progress for "${name || 'Unnamed'}"?\n\nThis clears the sold total so the ${type} starts fresh.`,
+                        function() {
+                            resetAmmItem(type, id);
+                        }
+                    );
+                } else if (confirm(`Reset tracked progress for this ${type}?`)) {
+                    resetAmmItem(type, id);
+                }
+            }
+
             if (e.target && (e.target.classList.contains('delete-amm-item') || e.target.closest('.delete-amm-item'))) {
                 const button = e.target.classList.contains('delete-amm-item') ? e.target : e.target.closest('.delete-amm-item');
                 const type = button.getAttribute('data-type');
@@ -2490,7 +2515,7 @@ const AmmTablesManager = (function() {
                 }
                 notify(`${name || type} ${newEnabled ? 'enabled' : 'disabled'}.`, 'success');
                 if (type === 'offer' && !newEnabled) {
-                    (templateRuntime[name] || {}).offer_ids?.forEach(function(offerId) {
+                    (templateRuntime[list[index].id] || {}).offer_ids?.forEach(function(offerId) {
                         fetch(`/json/revokeoffer/${offerId}`, { method: 'POST' });
                     });
                 }
@@ -2504,6 +2529,51 @@ const AmmTablesManager = (function() {
         }).catch(function(error) {
             setConfigTextarea(configTextarea, previousConfigText);
             if (toggleEl) toggleEl.checked = !newEnabled;
+            notify(`Failed to save the configuration: ${error.message}`, 'error');
+        });
+    }
+
+    function resetAmmItem(type, id) {
+        const configTextarea = document.querySelector('textarea[name="config_content"]');
+        if (!configTextarea) {
+            alert('Error: Could not find the configuration textarea.');
+            return;
+        }
+
+        let config;
+        try {
+            config = JSON.parse(configTextarea.value.trim());
+        } catch (error) {
+            notify('Configuration is not valid JSON.', 'error');
+            return;
+        }
+
+        const list = type === 'offer' ? config.offers : config.bids;
+        const item = Array.isArray(list) ? list.find(i => i && i.id === id) : null;
+        if (!item) {
+            notify(`Could not find the ${type} to reset.`, 'error');
+            return;
+        }
+
+        item.id = `${type}_${Date.now()}`;
+
+        const previousConfigText = configTextarea.value;
+        setConfigTextarea(configTextarea, JSON.stringify(config, null, 4));
+
+        persistConfig(config).then(function(data) {
+            if (data && data.success) {
+                if (window.ammTablesConfig) {
+                    window.ammTablesConfig.configData = data.config_data || config;
+                }
+                fetchAmmState();
+                refreshAfterSave();
+                notify(`${type.charAt(0).toUpperCase() + type.slice(1)} budget reset.`, 'success');
+            } else {
+                setConfigTextarea(configTextarea, previousConfigText);
+                notify((data && data.error) || 'Failed to save the configuration.', 'error');
+            }
+        }).catch(function(error) {
+            setConfigTextarea(configTextarea, previousConfigText);
             notify(`Failed to save the configuration: ${error.message}`, 'error');
         });
     }

--- a/basicswap/ui/page_amm.py
+++ b/basicswap/ui/page_amm.py
@@ -436,11 +436,11 @@ def get_amm_active_count(swap_client, debug_override=False):
 
             for offer in config_data.get("offers", []):
                 if offer.get("enabled", False):
-                    enabled_offers.add(offer.get("name", ""))
+                    enabled_offers.add(offer.get("id", ""))
 
             for bid in config_data.get("bids", []):
                 if bid.get("enabled", False):
-                    enabled_bids.add(bid.get("name", ""))
+                    enabled_bids.add(bid.get("id", ""))
 
         except Exception as e:
             if debug_enabled:
@@ -531,8 +531,8 @@ def get_amm_active_count(swap_client, debug_override=False):
                     swap_client.log.error(traceback.format_exc())
 
         if "offers" in state_data:
-            for template_name, offers in state_data["offers"].items():
-                if enabled_offers is None or template_name in enabled_offers:
+            for template_id, offers in state_data["offers"].items():
+                if enabled_offers is None or template_id in enabled_offers:
                     active_offer_count = 0
                     for offer in offers:
                         if (
@@ -544,8 +544,8 @@ def get_amm_active_count(swap_client, debug_override=False):
                     amm_count += active_offer_count
 
         if "bids" in state_data:
-            for template_name, bids in state_data["bids"].items():
-                if enabled_bids is None or template_name in enabled_bids:
+            for template_id, bids in state_data["bids"].items():
+                if enabled_bids is None or template_id in enabled_bids:
                     active_bid_count = 0
                     for bid in bids:
                         if "bid_id" in bid and bid.get("active", False):
@@ -561,7 +561,7 @@ def get_amm_active_count(swap_client, debug_override=False):
             most_recent_time = 0
             most_recent_offer = None
 
-            for template_name, offers in state_data["offers"].items():
+            for template_id, offers in state_data["offers"].items():
                 for offer in offers:
                     if "time" in offer and offer["time"] > most_recent_time:
                         most_recent_time = offer["time"]
@@ -1579,11 +1579,11 @@ def get_amm_template_runtime(swap_client, config_data=None, state_data=None):
     template_tracking = state_data.get("template_tracking", {})
 
     for offer in config_data.get("offers", []):
-        name = offer.get("name")
-        if not name:
+        template_id = offer.get("id")
+        if not template_id:
             continue
 
-        posted = state_offers.get(name, [])
+        posted = state_offers.get(template_id, [])
         offer_ids = [
             o.get("offer_id")
             for o in posted
@@ -1594,7 +1594,7 @@ def get_amm_template_runtime(swap_client, config_data=None, state_data=None):
             swap_client, offer_ids
         )
 
-        tracking = template_tracking.get(name, {})
+        tracking = template_tracking.get(template_id, {})
         sold_by_offer = tracking.get("sold_by_offer", {})
 
         entry = {
@@ -1622,7 +1622,7 @@ def get_amm_template_runtime(swap_client, config_data=None, state_data=None):
             ):
                 entry["exhausted"] = True
 
-        runtime[name] = entry
+        runtime[template_id] = entry
 
     return runtime
 
@@ -1655,18 +1655,18 @@ def get_amm_bid_runtime(swap_client, config_data=None, state_data=None):
     state_bids = state_data.get("bids", {})
 
     for bid in config_data.get("bids", []):
-        name = bid.get("name")
-        if not name:
+        template_id = bid.get("id")
+        if not template_id:
             continue
 
-        posted = state_bids.get(name, [])
+        posted = state_bids.get(template_id, [])
         active_bid_ids = [
             b.get("bid_id")
             for b in posted
             if isinstance(b, dict) and b.get("bid_id") and b.get("active", False)
         ]
 
-        runtime[name] = {
+        runtime[template_id] = {
             "active_bid_count": len(active_bid_ids),
             "bid_ids": active_bid_ids,
         }

--- a/scripts/createoffers.py
+++ b/scripts/createoffers.py
@@ -80,6 +80,7 @@ import sys
 import threading
 import time
 import traceback
+import uuid
 import urllib
 import urllib.error
 import base64
@@ -278,6 +279,7 @@ def readConfig(args, known_coins):
 
     offer_templates = config["offers"]
     offer_templates_map = {}
+    offer_ids_map = {}
     num_enabled = 0
     for i, offer_template in enumerate(offer_templates):
         num_enabled += 1 if offer_template.get("enabled", True) else 0
@@ -294,6 +296,15 @@ def readConfig(args, known_coins):
             offer_template["name"] = f"{original_name}_{offset}"
             num_changes += 1
         offer_templates_map[offer_template["name"]] = offer_template
+
+        if not offer_template.get("id"):
+            offer_template["id"] = f"offer_{uuid.uuid4().hex[:12]}"
+            num_changes += 1
+        elif offer_template["id"] in offer_ids_map:
+            print("Reassigning duplicate id for offer template", offer_template["name"])
+            offer_template["id"] = f"offer_{uuid.uuid4().hex[:12]}"
+            num_changes += 1
+        offer_ids_map[offer_template["id"]] = offer_template
 
         if "enabled" not in offer_template:
             offer_template["enabled"] = True
@@ -410,6 +421,7 @@ def readConfig(args, known_coins):
 
     bid_templates = config["bids"]
     bid_templates_map = {}
+    bid_ids_map = {}
     num_enabled = 0
     for i, bid_template in enumerate(bid_templates):
         num_enabled += 1 if bid_template.get("enabled", True) else 0
@@ -426,6 +438,15 @@ def readConfig(args, known_coins):
             bid_template["name"] = f"{original_name}_{offset}"
             num_changes += 1
         bid_templates_map[bid_template["name"]] = bid_template
+
+        if not bid_template.get("id"):
+            bid_template["id"] = f"bid_{uuid.uuid4().hex[:12]}"
+            num_changes += 1
+        elif bid_template["id"] in bid_ids_map:
+            print("Reassigning duplicate id for bid template", bid_template["name"])
+            bid_template["id"] = f"bid_{uuid.uuid4().hex[:12]}"
+            num_changes += 1
+        bid_ids_map[bid_template["id"]] = bid_template
 
         if bid_template.get("min_swap_amount", 0.0) < min_swap_size:
             print("Setting min_swap_amount for bid template", bid_template["name"])
@@ -762,14 +783,14 @@ def process_offers(args, config, script_state) -> None:
             continue
 
         created_offers = script_state.get("offers", {})
-        prev_template_offers = created_offers.get(offer_template["name"], [])
+        prev_template_offers = created_offers.get(offer_template["id"], [])
 
         template_offer_mode = offer_template.get("offer_mode", "standing")
         template_fixed_remaining = None
         if template_offer_mode in ("one_time", "fixed_total"):
             tracking_states = script_state.setdefault("template_tracking", {})
             template_tracking = tracking_states.setdefault(
-                offer_template["name"], {"exhausted": False, "sold_by_offer": {}}
+                offer_template["id"], {"exhausted": False, "sold_by_offer": {}}
             )
             if template_tracking.get("exhausted"):
                 if args.debug:
@@ -1446,10 +1467,10 @@ def process_offers(args, config, script_state) -> None:
             print(f"New offer created with ID: {new_offer['offer_id']}")
             if "offers" not in script_state:
                 script_state["offers"] = {}
-            template_name = offer_template["name"]
-            if template_name not in script_state["offers"]:
-                script_state["offers"][template_name] = []
-            script_state["offers"][template_name].append(
+            template_id = offer_template["id"]
+            if template_id not in script_state["offers"]:
+                script_state["offers"][template_id] = []
+            script_state["offers"][template_id].append(
                 {"offer_id": new_offer["offer_id"], "time": int(time.time())}
             )
         except Exception as e:
@@ -1506,10 +1527,10 @@ def process_bids(args, config, script_state) -> None:
         max_concurrent = bid_template.get("max_concurrent", 1)
         if "bids" not in script_state:
             script_state["bids"] = {}
-        template_name = bid_template["name"]
-        if template_name not in script_state["bids"]:
-            script_state["bids"][template_name] = []
-        previous_bids = script_state["bids"][template_name]
+        template_id = bid_template["id"]
+        if template_id not in script_state["bids"]:
+            script_state["bids"][template_id] = []
+        previous_bids = script_state["bids"][template_id]
 
         bids_in_progress: int = 0
         for previous_bid in previous_bids:
@@ -1957,7 +1978,7 @@ def process_bids(args, config, script_state) -> None:
                         print(f"Failed to create bid on offer {offer['offer_id']}")
                     continue
 
-            script_state["bids"][template_name].append(
+            script_state["bids"][template_id].append(
                 {"bid_id": bid_id, "time": int(time.time()), "active": True}
             )
 
@@ -1981,6 +2002,46 @@ def process_bids(args, config, script_state) -> None:
             break
 
 
+def reconcile_state_keys(config, script_state):
+    """Re-key state to template ids and drop state for templates the config no longer has.
+
+    Migrates legacy name-keyed state to id keys, and clears entries whose template
+    was deleted or whose id was regenerated (a reset), so a reused name starts clean.
+    """
+    changed: bool = False
+    sections = (
+        (config.get("offers", []), ("offers", "template_tracking")),
+        (config.get("bids", []), ("bids",)),
+    )
+    for templates, section_names in sections:
+        name_to_id = {}
+        valid_ids = set()
+        for template in templates:
+            template_id = template.get("id")
+            if not template_id:
+                continue
+            valid_ids.add(template_id)
+            name = template.get("name")
+            if name:
+                name_to_id[name] = template_id
+
+        for section_name in section_names:
+            section = script_state.get(section_name)
+            if not isinstance(section, dict):
+                continue
+            for key in list(section.keys()):
+                if key in valid_ids:
+                    continue
+                target_id = name_to_id.get(key)
+                if target_id is not None and target_id not in section:
+                    section[target_id] = section.pop(key)
+                    changed = True
+                else:
+                    del section[key]
+                    changed = True
+    return changed
+
+
 def prune_script_state(now, args, config, script_state):
     if shutdown_in_progress:
         return
@@ -1993,7 +2054,7 @@ def prune_script_state(now, args, config, script_state):
 
     max_ttl: int = config["prune_state_after_seconds"]
     if "offers" in script_state:
-        for template_name, template_group in script_state["offers"].items():
+        for template_id, template_group in script_state["offers"].items():
             offers_to_remove = []
             for offer in template_group:
                 if now - offer["time"] > max_ttl:
@@ -2007,7 +2068,7 @@ def prune_script_state(now, args, config, script_state):
                         break
 
     if "bids" in script_state:
-        for template_name, template_group in script_state["bids"].items():
+        for template_id, template_group in script_state["bids"].items():
             bids_to_remove = []
             for bid in template_group:
                 if now - bid["time"] > max_ttl:
@@ -2189,6 +2250,9 @@ def main():
             # Skip processing if shutdown is in progress
             if not shutdown_in_progress:
                 try:
+                    if reconcile_state_keys(config, script_state):
+                        write_state(args.statefile, script_state)
+
                     process_offers(args, config, script_state)
 
                     process_bids(args, config, script_state)

--- a/tests/basicswap/test_amm_config_api.py
+++ b/tests/basicswap/test_amm_config_api.py
@@ -128,12 +128,14 @@ class AmmTemplateRuntimeTest(unittest.TestCase):
         config_data = {
             "offers": [
                 {
+                    "id": "ft",
                     "name": "ft",
                     "offer_mode": "fixed_total",
                     "amount": 10,
                     "total_to_sell": 100,
                 },
                 {
+                    "id": "std",
                     "name": "std",
                     "offer_mode": "standing",
                     "amount": 5,
@@ -165,7 +167,9 @@ class AmmTemplateRuntimeTest(unittest.TestCase):
 
     def test_runtime_exhausted_flag(self):
         config_data = {
-            "offers": [{"name": "once", "offer_mode": "one_time", "amount": 5}]
+            "offers": [
+                {"id": "once", "name": "once", "offer_mode": "one_time", "amount": 5}
+            ]
         }
         state_data = {
             "offers": {},
@@ -182,8 +186,8 @@ class AmmBidRuntimeTest(unittest.TestCase):
     def test_bid_runtime_counts_only_active(self):
         config_data = {
             "bids": [
-                {"name": "bid_a"},
-                {"name": "bid_b"},
+                {"id": "bid_a", "name": "bid_a"},
+                {"id": "bid_b", "name": "bid_b"},
             ]
         }
         state_data = {
@@ -245,6 +249,7 @@ class AmmLiveFillsTest(unittest.TestCase):
         config_data = {
             "offers": [
                 {
+                    "id": "ft",
                     "name": "ft",
                     "offer_mode": "fixed_total",
                     "amount": 10,
@@ -272,6 +277,7 @@ class AmmLiveFillsTest(unittest.TestCase):
         config_data = {
             "offers": [
                 {
+                    "id": "ft",
                     "name": "ft",
                     "offer_mode": "fixed_total",
                     "amount": 10,
@@ -298,6 +304,7 @@ class AmmLiveFillsTest(unittest.TestCase):
         config_data = {
             "offers": [
                 {
+                    "id": "ft",
                     "name": "ft",
                     "offer_mode": "fixed_total",
                     "amount": 10,
@@ -361,7 +368,9 @@ class ClassifyOfferIdsTest(unittest.TestCase):
 
     def test_runtime_uses_active_count(self):
         config_data = {
-            "offers": [{"name": "std", "offer_mode": "standing", "amount": 5}]
+            "offers": [
+                {"id": "std", "name": "std", "offer_mode": "standing", "amount": 5}
+            ]
         }
         state_data = {
             "offers": {"std": [{"offer_id": "0a"}, {"offer_id": "0b"}]},

--- a/tests/basicswap/test_createoffers_state.py
+++ b/tests/basicswap/test_createoffers_state.py
@@ -1,0 +1,71 @@
+# -*- coding: utf-8 -*-
+
+# Copyright (c) 2026 The Basicswap developers
+# Distributed under the MIT software license, see the accompanying
+# file LICENSE or http://www.opensource.org/licenses/mit-license.php.
+
+import importlib.util
+import os
+import unittest
+
+_SCRIPT_PATH = os.path.join(
+    os.path.dirname(__file__), "..", "..", "scripts", "createoffers.py"
+)
+_spec = importlib.util.spec_from_file_location("createoffers", _SCRIPT_PATH)
+createoffers = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(createoffers)
+
+reconcile_state_keys = createoffers.reconcile_state_keys
+
+
+class ReconcileStateKeysTest(unittest.TestCase):
+    def test_migrates_legacy_name_keys_to_id(self):
+        config = {"offers": [{"id": "offer_1", "name": "Foo"}]}
+        state = {
+            "offers": {"Foo": [{"offer_id": "aa"}]},
+            "template_tracking": {"Foo": {"sold_by_offer": {"aa": 5}}},
+        }
+        changed = reconcile_state_keys(config, state)
+        self.assertTrue(changed)
+        self.assertEqual(state["offers"], {"offer_1": [{"offer_id": "aa"}]})
+        self.assertEqual(
+            state["template_tracking"], {"offer_1": {"sold_by_offer": {"aa": 5}}}
+        )
+
+    def test_keeps_valid_id_keys_untouched(self):
+        config = {"offers": [{"id": "offer_1", "name": "Foo"}]}
+        state = {"offers": {"offer_1": [{"offer_id": "aa"}]}}
+        changed = reconcile_state_keys(config, state)
+        self.assertFalse(changed)
+        self.assertEqual(state["offers"], {"offer_1": [{"offer_id": "aa"}]})
+
+    def test_drops_state_for_reset_or_deleted_template(self):
+        # A regenerated id (reset) or removed template leaves state matching neither
+        # a current id nor a current name -> dropped.
+        config = {"offers": [{"id": "offer_new", "name": "Foo"}]}
+        state = {"template_tracking": {"offer_old": {"sold_by_offer": {"aa": 5}}}}
+        changed = reconcile_state_keys(config, state)
+        self.assertTrue(changed)
+        self.assertEqual(state["template_tracking"], {})
+
+    def test_migration_does_not_clobber_existing_id_entry(self):
+        config = {"offers": [{"id": "offer_1", "name": "Foo"}]}
+        state = {
+            "offers": {
+                "offer_1": [{"offer_id": "new"}],
+                "Foo": [{"offer_id": "stale"}],
+            }
+        }
+        reconcile_state_keys(config, state)
+        self.assertEqual(state["offers"], {"offer_1": [{"offer_id": "new"}]})
+
+    def test_reconciles_bids(self):
+        config = {"bids": [{"id": "bid_1", "name": "B"}]}
+        state = {"bids": {"B": [{"bid_id": "aa", "active": True}]}}
+        changed = reconcile_state_keys(config, state)
+        self.assertTrue(changed)
+        self.assertEqual(state["bids"], {"bid_1": [{"bid_id": "aa", "active": True}]})
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Also add manual reset (churns the id)

fixes: if you deleted an offer, then created a new one with the same name, it would follow the old tracking state.

since the GUI already assigns and "id" param, i added this behavior to the backend, so users who run standalone also inherit id tracking and new id generation per offer. only modifies the id if it is missing, so i didnt remove it from the gui.