### PR TITLE
fix(xmr): make the Monero wallet work on --testnet (wallet nettype + address prefixes)

### DIFF
--- a/basicswap/interface/xmr/chainparams.py
+++ b/basicswap/interface/xmr/chainparams.py
@@ -26,8 +26,8 @@ params = {
         "walletrpcport": 28082,
         "min_amount": 1000000000,
         "max_amount": 10000000 * XMR_COIN,
-        "address_prefix": 18,
-        "subaddress_prefix": 42,
+        "address_prefix": 53,
+        "subaddress_prefix": 63,
     },
     "regtest": {
         "rpcport": 18081,

--- a/basicswap/interface/xmr/core.py
+++ b/basicswap/interface/xmr/core.py
@@ -215,6 +215,9 @@ class XMRPrepare(CoinPrepareModule):
                 )
                 config_datadir = "/data"
 
+            if chain == "testnet":
+                fp.write("testnet=1\n")
+
             fp.write("no-dns=1\n")
             fp.write("rpc-bind-port={}\n".format(core_settings["walletrpcport"]))
             fp.write("rpc-bind-ip={}\n".format(ctx.rpcbind_ip))


### PR DESCRIPTION
Two independent bugs make the **XMR wallet unusable on `--testnet`**. Both were found on a fresh install and each is fixed by a one-line-ish change; regtest and mainnet behaviour are unchanged.

Setup used: `basicswap-prepare --datadir=/coindata --testnet --withcoin=bitcoin --withcoin=monero --light` on Debian 12 / Docker, then `basicswap-run --datadir=/coindata --testnet`.

### 1. `monero_wallet.conf` is missing `testnet=1`

`XMRPrepare.prepareDataDir()` writes `testnet=1` into `monerod.conf` when `chain == "testnet"`, but not into the generated `monero_wallet.conf`. `monero-wallet-rpc` is also started without a nettype flag (`bin/run.py` only passes `--trusted-daemon/--untrusted-daemon`, `--daemon-address` and optionally `--daemon-login`), so it comes up on **mainnet** while `monerod` runs on **testnet**.

Observed on a fresh testnet install, in a loop:

```
wallet.wallet2  res.status != CORE_RPC_STATUS_OK. THROW EXCEPTION: error::get_blocks_error
wallet.wallet2  pull_blocks failed, try_count=3
wallet.rpc      Exception at while refreshing, what=failed to get blocks
```

and then, in monerod's log:

```
I Host 127.0.0.1 blocked.
```

i.e. the daemon eventually bans its own wallet and the XMR wallet stays unavailable in the UI/API. Adding `testnet=1` to the generated wallet config fixes it.

### 2. XMR testnet chainparams carry the mainnet address prefixes

`basicswap/interface/xmr/chainparams.py` uses `address_prefix: 18` / `subaddress_prefix: 42` for **all** networks. Monero's testnet prefixes are **53 / 63** (`src/cryptonote_config.h`), so every address BasicSwap encodes for testnet comes out as a mainnet address.

Effect: `initialiseWallet()` (and `Reseed Wallet` / `POST /json/wallets/xmr/reseed`) fails on testnet with

```
{"error": "Wallet RPC error: {'code': -1, 'message': 'Failed to parse public address'}"}
```

because the address handed to `generate_from_keys` doesn't match the wallet's nettype.

Verified against a live testnet wallet created by `monero-wallet-rpc` itself:

```python
import basicswap.util_xmr as xu
addr = "<deposit address of the live testnet wallet>"
xu.decode_address(addr, 18)  # Prefix mismatch
xu.decode_address(addr, 42)  # Prefix mismatch
xu.decode_address(addr, 53)  # Prefix mismatch
xu.decode_address(addr, 63)  # OK  -> testnet subaddress prefix

xu.encode_address(kv, ks, 53)[:2]  # "9t..."  -> testnet standard format
xu.encode_address(kv, ks, 18)[:2]  # "42..."  -> mainnet format
```

**regtest is deliberately left untouched**: monerod's regtest/fakechain mode runs with the mainnet nettype, so the existing prefixes are correct there — which is also why the test suite never hit this.

### After the fixes

With both patches applied on the same box: XMR testnet wallet initialises, syncs to 100% and reports a proper testnet address; BTC (electrum, `--light`) and the JSON API behave normally. Atomic swaps themselves were exercised separately on the regtest harness (`tests/basicswap/test_persistent.py`), where a BTC↔XMR bid reached `Completed` on both sides with funds delivered — unaffected by these changes.

Happy to split this into two PRs if you prefer.
