### PR TITLE
offers: allow retrying acceptance due to transient err

### DIFF
--- a/basicswap/base.py
+++ b/basicswap/base.py
@@ -307,7 +307,8 @@ class BaseApp(DBMethods):
         return out[0].decode("utf-8").strip()
 
     transient_error_markers = (
-        "read timed out",
+        "timed out",
+        "socket error",
         "no connection to daemon",
         # Connection-class faults, daemon restarting or briefly unreachable.
         "connection refused",

--- a/basicswap/basicswap.py
+++ b/basicswap/basicswap.py
@@ -10790,9 +10790,7 @@ class BasicSwap(BaseApp, BSXNetwork, UIApp):
                     )
                     # Don't error the bid on a transient failure, keep the
                     # action alive and retry.
-                    if not accepting_bid and self.isBidTransientError(
-                        bid_id, ex, cursor
-                    ):
+                    if self.isBidTransientError(bid_id, ex, cursor):
                         self.log.warning(
                             f"Retrying action type {action_type} for bid {self.log.id(bid_id)} after transient error: {ex}"
                         )


### PR DESCRIPTION
Not sure if the right place, but a swap went into error state at acceptance due to a timeout error connecting to the node.

States:
- Bid Received
- Bid Delaying
- Bid Error

Events:
- Auto accepting
- Error: checkQueuedActions failed: Node(j) RPC Server Error: Socket error: timed out