### PR TITLE
core: sc_lock timeout fixes and default change

### DIFF
--- a/basicswap/basicswap.py
+++ b/basicswap/basicswap.py
@@ -513,10 +513,10 @@ class BasicSwap(BaseApp, BSXNetwork, UIApp):
             "expire_db_records_after", 7 * 86400, 0, 31 * 86400
         )  # Seconds
         self._sc_lock_tx_timeout = self.get_int_setting(
-            "sc_lock_tx_timeout", 48 * 3600, 3600, 6 * 3600
+            "sc_lock_tx_timeout", 6 * 3600, 3600, 48 * 3600
         )  # Seconds
         self._sc_lock_tx_mempool_timeout = self.get_int_setting(
-            "sc_lock_tx_mempool_timeout", 48 * 3600, 3600, 12 * 3600
+            "sc_lock_tx_mempool_timeout", 12 * 3600, 3600, 48 * 3600
         )  # Seconds
 
         self._max_logfile_bytes = self.settings.get(

--- a/basicswap/basicswap.py
+++ b/basicswap/basicswap.py
@@ -513,7 +513,7 @@ class BasicSwap(BaseApp, BSXNetwork, UIApp):
             "expire_db_records_after", 7 * 86400, 0, 31 * 86400
         )  # Seconds
         self._sc_lock_tx_timeout = self.get_int_setting(
-            "sc_lock_tx_timeout", 6 * 3600, 3600, 48 * 3600
+            "sc_lock_tx_timeout", 1200, 1200, 48 * 3600
         )  # Seconds
         self._sc_lock_tx_mempool_timeout = self.get_int_setting(
             "sc_lock_tx_mempool_timeout", 12 * 3600, 3600, 48 * 3600

--- a/basicswap/basicswap.py
+++ b/basicswap/basicswap.py
@@ -10671,8 +10671,8 @@ class BasicSwap(BaseApp, BSXNetwork, UIApp):
         now: int = self.getTime()
         cursor = self.openDB()
 
-        respond_grace_period: int = 60 * 60
-        # Time for transaction to be mined into the chain
+        # Time for transaction to be mined into the chain, measured from the last
+        # state change so the bidder's chosen expiry can't extend it.
         # Only timeout waiting for the tx to be mined if not the sending the tx.
         tx_grace_period: int = self._sc_lock_tx_timeout
         tx_mempool_grace_period: int = self._sc_lock_tx_mempool_timeout
@@ -10681,16 +10681,13 @@ class BasicSwap(BaseApp, BSXNetwork, UIApp):
             query_str = (
                 "SELECT b.bid_id FROM bids AS b, bidstates AS s "
                 + "WHERE b.active_ind = 1 AND s.state_id = b.state "
-                + " AND ((b.state = :accepted_state AND b.expire_at + :respond_grace_period <= :now) "
-                + "  OR (s.can_timeout AND b.expire_at + (CASE WHEN EXISTS(SELECT event_id FROM eventlog WHERE linked_type = :event_linked_type AND linked_id = b.bid_id AND event_type = :tx_mempool_event_type) THEN :tx_mempool_grace_period ELSE :tx_grace_period END) <= :now)) "
+                + " AND s.can_timeout AND b.state_time + (CASE WHEN EXISTS(SELECT event_id FROM eventlog WHERE linked_type = :event_linked_type AND linked_id = b.bid_id AND event_type = :tx_mempool_event_type) THEN :tx_mempool_grace_period ELSE :tx_grace_period END) <= :now "
                 + " AND NOT EXISTS(SELECT event_id FROM eventlog WHERE linked_type = :event_linked_type AND linked_id = b.bid_id AND event_type = :tx_sent_event_type)"
             )
             q = cursor.execute(
                 query_str,
                 {
-                    "accepted_state": int(BidStates.BID_ACCEPTED),
                     "now": now,
-                    "respond_grace_period": respond_grace_period,
                     "tx_grace_period": tx_grace_period,
                     "tx_mempool_grace_period": tx_mempool_grace_period,
                     "event_linked_type": int(Concepts.BID),


### PR DESCRIPTION
- default and max were flipped (default 48hrs, but max set to 6hr etc)
- reduced default non-mempool timeout to 20 min (6hrs is a long time to wait for a swap stuck in negotiation, an it ties up max concurrent bids on automation). i typically see the tx in mempool within 5-6 mins
- `respond_grace_period` wasnt functional for reverse ads, and is (i think) redundant to sc_lock_* . Removed it
- a malicious bidder can set an abnoxious bid expiry, which is the base that the timeouts are extended upon. So a 20min timeout on a 24hr bid, is really 24hr20min. Dropped the addition of expiry. Let the maker choose how long theyd like to wait beyond the previous state change