### PR TITLE
ltc: bump to v0.21.5.6 [mandatory]

### DIFF
--- a/basicswap/interface/ltc/core.py
+++ b/basicswap/interface/ltc/core.py
@@ -14,7 +14,7 @@ from basicswap.interface.prepare_util import (
     getOSDirNames,
 )
 
-LITECOIN_VERSION = os.getenv("LITECOIN_VERSION", "0.21.5.5")
+LITECOIN_VERSION = os.getenv("LITECOIN_VERSION", "0.21.5.6")
 LITECOIN_VERSION_TAG = os.getenv("LITECOIN_VERSION_TAG", "")
 litecoin_signers = {"davidburkett38": ("D35621D53A1CC6A3456758D03620E9D387E55666",)}
 


### PR DESCRIPTION
> This is an urgent maintenance release that strengthens MWEB transaction,
block, and P2P-service validation. Upgrading is strongly recommended for all
users. 

### Consensus change
> At mainnet height 3,154,440, nodes running 0.21.5.6 will reject an MWEB
block containing a kernel that signals a pegout while carrying an empty pegout
list. This is a soft-forking consensus rule. The height is approximately one
week (4,032 blocks) after height 3,150,408.