### PR TITLE
offers: fix in-flight early revoke

### DIFF
--- a/basicswap/basicswap.py
+++ b/basicswap/basicswap.py
@@ -77,6 +77,7 @@ from .offer_tracking import (
     get_offer_tracking,
     init_offer_tracking,
     offer_budget_allows,
+    offer_has_negotiating_bid,
     offer_in_flight_amount,
     offer_tracking_is_exhausted,
     offer_tracking_remaining,
@@ -4483,7 +4484,9 @@ class BasicSwap(BaseApp, BSXNetwork, UIApp):
 
         return offer_id
 
-    def revokeOffer(self, offer_id, security_token=None) -> None:
+    def revokeOffer(
+        self, offer_id, security_token=None, refuse_if_negotiating: bool = False
+    ) -> None:
         self.log.info(f"Revoking offer {self.log.id(offer_id)}")
 
         cursor = self.openDB()
@@ -4492,6 +4495,12 @@ class BasicSwap(BaseApp, BSXNetwork, UIApp):
             ensure(offer, f"Offer not found: {self.log.id(offer_id)}.")
             ensure(offer.expire_at > self.getTime(), "Offer has expired")
             ensure(offer.active_ind == 1, "Offer not active")
+            # Don't revoke if negotiating
+            if refuse_if_negotiating:
+                ensure(
+                    offer_has_negotiating_bid(cursor, offer_id) is False,
+                    "Offer has a bid in negotiation",
+                )
 
             if (
                 offer.security_token is not None

--- a/basicswap/js_server.py
+++ b/basicswap/js_server.py
@@ -884,7 +884,11 @@ def js_revokeoffer(self, url_split, post_string, is_json) -> bytes:
     swap_client.checkSystemStatus()
     offer_id = bytes.fromhex(url_split[3])
     ensure(len(offer_id) == 28, "Invalid offer id size")
-    swap_client.revokeOffer(offer_id)
+    post_data = {} if post_string == "" else getFormData(post_string, is_json)
+    refuse_if_negotiating: bool = toBool(
+        get_data_entry_or(post_data, "refuse_if_negotiating", False)
+    )
+    swap_client.revokeOffer(offer_id, refuse_if_negotiating=refuse_if_negotiating)
     return bytes(json.dumps({"revoked_offer": offer_id.hex()}), "UTF-8")
 
 

--- a/basicswap/offer_tracking.py
+++ b/basicswap/offer_tracking.py
@@ -8,7 +8,21 @@ import time
 
 from enum import IntEnum
 
+from .basicswap_util import ActionTypes, BidStates
 from .db import OfferTracking
+
+# Accepted, but the counterparty can still walk away without committing anything.
+NEGOTIATING_STATES = (
+    BidStates.BID_ACCEPTED,
+    BidStates.SWAP_DELAYING,
+    BidStates.BID_REQUEST_ACCEPTED,
+)
+
+ACCEPT_ACTION_TYPES = (
+    ActionTypes.ACCEPT_BID,
+    ActionTypes.ACCEPT_XMR_BID,
+    ActionTypes.ACCEPT_AS_REV_BID,
+)
 
 
 class OfferTrackingModes(IntEnum):
@@ -178,6 +192,21 @@ def offer_in_flight_amount(
             continue
         total += amount if amount else 0
     return total
+
+
+def offer_has_negotiating_bid(cursor, offer_id: bytes) -> bool:
+    state_in = ", ".join(str(int(s)) for s in NEGOTIATING_STATES)
+    action_in = ", ".join(str(int(a)) for a in ACCEPT_ACTION_TYPES)
+    query = f"""SELECT 1 FROM bids
+           WHERE bids.active_ind = 1 AND bids.offer_id = :offer_id
+           AND bids.state IN ({state_in})
+           UNION
+           SELECT 1 FROM bids
+           JOIN actions ON actions.linked_id = bids.bid_id AND actions.active_ind = 1 AND actions.action_type IN ({action_in})
+           WHERE bids.active_ind = 1 AND bids.offer_id = :offer_id
+           LIMIT 1
+        """
+    return cursor.execute(query, {"offer_id": offer_id}).fetchone() is not None
 
 
 def complete_offer_fill(self, offer_id: bytes, amount: int, cursor) -> bool:

--- a/scripts/createoffers.py
+++ b/scripts/createoffers.py
@@ -97,6 +97,19 @@ _wallet_info_cache = {}
 _fee_reserve_cache = {}
 
 
+def revoke_offer(offer_id, args, refuse_if_negotiating: bool = False) -> bool:
+    result = read_json_api(
+        f"revokeoffer/{offer_id}", {"refuse_if_negotiating": refuse_if_negotiating}
+    )
+    if args.debug:
+        print("revokeoffer", result)
+    error = result.get("error") if isinstance(result, dict) else None
+    if error:
+        print(f"Offer {offer_id} not revoked: {error}")
+        return False
+    return True
+
+
 def get_wallet_info(coin_ticker):
     if coin_ticker not in _wallet_info_cache:
         _wallet_info_cache[coin_ticker] = read_json_api_wallet(f"wallets/{coin_ticker}")
@@ -893,17 +906,14 @@ def process_offers(args, config, script_state) -> None:
                     print(
                         f"Revoking offer {offer_id}, offer amount {offer_amount_from:.8f} > wallet balance {wallet_balance:.8f}"
                     )
-                    result = read_json_api(f"revokeoffer/{offer_id}", {})
-                    if args.debug:
-                        print("revokeoffer", result)
-                    else:
+                    if revoke_offer(offer_id, args):
                         print("Offer revoked, will repost with accurate amount")
-                    for i, prev_offer in enumerate(prev_template_offers):
-                        if prev_offer.get("offer_id") == offer_id:
-                            del prev_template_offers[i]
-                            break
-                    write_state(args.statefile, script_state)
-                    offers_found -= 1
+                        for i, prev_offer in enumerate(prev_template_offers):
+                            if prev_offer.get("offer_id") == offer_id:
+                                del prev_template_offers[i]
+                                break
+                        write_state(args.statefile, script_state)
+                        offers_found -= 1
                 elif template_fixed_remaining is not None and (
                     float(offer.get("tracking_filled_amount", 0))
                     + float(offer.get("tracking_in_flight_amount", 0))
@@ -916,20 +926,15 @@ def process_offers(args, config, script_state) -> None:
                         f"Revoking offer {offer_id}, budget changed, "
                         f"reposting with remaining {template_fixed_remaining:.8f}"
                     )
-                    result = read_json_api(f"revokeoffer/{offer_id}", {})
-                    if args.debug:
-                        print("revokeoffer", result)
-                    offers_found -= 1
+                    if revoke_offer(offer_id, args, refuse_if_negotiating=True):
+                        offers_found -= 1
                 elif wallet_balance <= min_coin_from_amt:
                     print(
                         "Revoking offer {}, wallet from balance below minimum".format(
                             offer_id
                         )
                     )
-                    result = read_json_api(f"revokeoffer/{offer_id}", {})
-                    if args.debug:
-                        print("revokeoffer", result)
-                    else:
+                    if revoke_offer(offer_id, args):
                         print("Offer revoked successfully")
             else:
                 coin_from_match = offer.get("coin_from") == coin_from_data["id"]


### PR DESCRIPTION
Fixes regression from https://github.com/basicswap/basicswap/pull/628
Or
https://github.com/basicswap/basicswap/pull/556

same behavior as https://github.com/basicswap/basicswap/issues/508, but 508 precedes either of those PRs (still not sure the cause of 508)

What is happening here, is a fixed-total offer is being revoked during negotiation states, which causes the bidder to be unable to move beyond the negotiation. The change here adds an arg to revoke offers, where it will refuse to revoke if during negotiation for fixed-total offers.