### PR TITLE
bids: clamp to the offer rate when omitted

### DIFF
--- a/basicswap/basicswap.py
+++ b/basicswap/basicswap.py
@@ -5567,7 +5567,11 @@ class BasicSwap(BaseApp, BSXNetwork, UIApp):
                     "Fixed-rate offer bids should set amount to instead of bid rate."
                 )
         else:
-            amount_to: int = offer.amount_to
+            amount_to: int = (
+                offer.amount_to
+                if amount == offer.amount_from
+                else (amount * offer.rate) // ci_from.COIN()
+            )
         bid_rate: int = ci_from.make_int(amount_to / amount, r=1)
 
         if offer.amount_negotiable and not offer.rate_negotiable:


### PR DESCRIPTION
`offer.amount_to` is the full offer amount.

Only bids sent via API (including createoffers.py incl AMM GUI bidding) can hit this, and requires bidding against a rate negotiable offer - of which there are 0/485k in my db. Normal GUI bids are already mitigated, and AMM GUI bids are behind debug_ui.