### PR TITLE
firo: bump to v0.14.17.2 [mandatory]

### DIFF
--- a/basicswap/interface/firo/core.py
+++ b/basicswap/interface/firo/core.py
@@ -16,7 +16,7 @@ from basicswap.interface.prepare_util import (
     generate_salt,
 )
 
-FIRO_VERSION = os.getenv("FIRO_VERSION", "0.14.16.1")
+FIRO_VERSION = os.getenv("FIRO_VERSION", "0.14.17.2")
 FIRO_VERSION_TAG = os.getenv("FIRO_VERSION_TAG", "")
 firo_signers = {"reuben": ("0186454D63E83D85EF91DE4E1290A1D0FA7EE109",)}
 


### PR DESCRIPTION
spark vuln fix

```
This release temporarily restricts each Spark spend transaction to a single Spark coin. Spark minting and existing Spark balances remain available. A follow-up release is planned to restore multi-input Spark spends.

If a payment does not fit within one Spark coin, Firo Core can split it into several transactions. Each transaction pays its own fee.

Credits to @carter-0 for the responsible disclosure.
```