### PR TITLE
btc: support Core 30 wallet balance RPC changes

### DIFF
--- a/basicswap/interface/btc/btc.py
+++ b/basicswap/interface/btc/btc.py
@@ -902,6 +902,18 @@ class BTCInterface(FeeValidator, Secp256k1Interface):
             }
 
         rv = self.rpc_wallet("getwalletinfo")
+        if self.coin_type() == Coins.BTC and any(
+            field not in rv
+            for field in ("balance", "unconfirmed_balance", "immature_balance")
+        ):
+            # Bitcoin Core 30 removed these fields from getwalletinfo.
+            balances = self.rpc_wallet("getbalances")["mine"]
+            rv.setdefault("balance", balances["trusted"])
+            rv.setdefault(
+                "unconfirmed_balance", balances["untrusted_pending"]
+            )
+            rv.setdefault("immature_balance", balances["immature"])
+
         rv["encrypted"] = "unlocked_until" in rv
         rv["locked"] = rv.get("unlocked_until", 1) <= 0
         rv["locked_utxos"] = len(self.rpc_wallet("listlockunspent"))

--- a/tests/basicswap/test_other.py
+++ b/tests/basicswap/test_other.py
@@ -97,6 +97,59 @@ class Test(unittest.TestCase):
         xmr_coin_settings.update(REQUIRED_SETTINGS)
         return XMRInterface(xmr_coin_settings, "regtest")
 
+    def test_btc_wallet_info_balance_compatibility(self):
+        ci = self.ci_btc()
+
+        # Bitcoin Core < 30: getwalletinfo still returns balance fields.
+        calls = []
+
+        def legacy_rpc(method, params=None):
+            calls.append(method)
+            if method == "getwalletinfo":
+                return {
+                    "balance": 1.25,
+                    "unconfirmed_balance": 0.5,
+                    "immature_balance": 0.25,
+                }
+            if method == "listlockunspent":
+                return []
+            raise ValueError(f"Unexpected RPC call: {method}")
+
+        ci.rpc_wallet = legacy_rpc
+        wallet_info = ci.getWalletInfo()
+
+        assert wallet_info["balance"] == 1.25
+        assert wallet_info["unconfirmed_balance"] == 0.5
+        assert wallet_info["immature_balance"] == 0.25
+        assert "getbalances" not in calls
+
+        # Bitcoin Core >= 30: balance fields moved to getbalances.
+        calls.clear()
+
+        def core30_rpc(method, params=None):
+            calls.append(method)
+            if method == "getwalletinfo":
+                return {"walletname": "bsx_wallet"}
+            if method == "getbalances":
+                return {
+                    "mine": {
+                        "trusted": 1.25,
+                        "untrusted_pending": 0.5,
+                        "immature": 0.25,
+                    }
+                }
+            if method == "listlockunspent":
+                return []
+            raise ValueError(f"Unexpected RPC call: {method}")
+
+        ci.rpc_wallet = core30_rpc
+        wallet_info = ci.getWalletInfo()
+
+        assert wallet_info["balance"] == 1.25
+        assert wallet_info["unconfirmed_balance"] == 0.5
+        assert wallet_info["immature_balance"] == 0.25
+        assert calls.count("getbalances") == 1
+
     def test_serialise_num(self):
         def test_case(v, nb=None):
             b = SerialiseNum(v)


### PR DESCRIPTION
Adapt Bitcoin wallet balance handling for Bitcoin Core 30+.

Bitcoin Core 30 removed `balance`, `unconfirmed_balance`, and
`immature_balance` from `getwalletinfo`. When those fields are absent,
BasicSwap now obtains the corresponding values from `getbalances` and maps
them into its existing wallet info structure.

The fallback is feature-detected rather than version-gated, so older Bitcoin
Core versions continue using the existing `getwalletinfo` fields without an
additional RPC call.

The change is limited to `Coins.BTC`, leaving subclasses of `BTCInterface`,
such as Litecoin, unchanged.