### PR TITLE
electrum: select coins from every signable address

### DIFF
--- a/basicswap/interface/btc/btc.py
+++ b/basicswap/interface/btc/btc.py
@@ -2132,12 +2132,7 @@ class BTCInterface(FeeValidator, Secp256k1Interface):
         parsed_tx = self.loadTx(tx, allow_witness=False)
         total_output = sum(out.nValue for out in parsed_tx.vout)
 
-        funded_addresses = wm.getFundedAddresses(self.coin_type())
-        addr_to_sh = (
-            funded_addresses
-            if funded_addresses
-            else wm.getSignableAddresses(self.coin_type())
-        )
+        addr_to_sh = wm.getSignableAddresses(self.coin_type())
 
         if not addr_to_sh:
             raise ValueError("No addresses available")

--- a/basicswap/wallet_backend.py
+++ b/basicswap/wallet_backend.py
@@ -8,6 +8,8 @@ import time
 from abc import ABC, abstractmethod
 from typing import Dict, List, Optional
 
+from .util import TemporaryError
+
 
 class WalletBackend(ABC):
 
@@ -758,57 +760,40 @@ class ElectrumBackend(WalletBackend):
         except Exception:
             return []
 
-    def getBatchBalance(self, scripthashes: List[str]) -> Dict[str, int]:
-        result = {}
-        for sh in scripthashes:
-            result[sh] = 0
-
-        try:
-            calls = [("blockchain.scripthash.get_balance", [sh]) for sh in scripthashes]
-            responses = self._call_batch(calls)
-            for sh, balance in zip(scripthashes, responses):
-                if balance:
-                    confirmed = balance.get("confirmed", 0)
-                    unconfirmed = balance.get("unconfirmed", 0)
-                    result[sh] = confirmed + unconfirmed
-        except Exception as e:
-            self._log.warning(f"ElectrumBackend.getBatchBalance error: {e}")
-
-        return result
-
     def getBatchUnspent(
         self, scripthashes: List[str], min_confirmations: int = 0
     ) -> Dict[str, List[dict]]:
+        # A partial or failed result must never read as "no UTXOs": callers size
+        # spends against this and would treat it as an empty wallet.
+        if not scripthashes:
+            return {}
+
+        current_height = self.getBlockHeight()
+        responses = self._split_batch_call(
+            scripthashes, "blockchain.scripthash.listunspent"
+        )
+        if len(responses) != len(scripthashes):
+            raise TemporaryError(
+                f"listunspent returned {len(responses)} of {len(scripthashes)} results"
+            )
+
         result = {}
-        for sh in scripthashes:
+        for sh, utxos in zip(scripthashes, responses):
+            if utxos is None:
+                raise TemporaryError(f"listunspent failed for scripthash {sh}")
             result[sh] = []
-
-        try:
-            current_height = self.getBlockHeight()
-
-            calls = [("blockchain.scripthash.listunspent", [sh]) for sh in scripthashes]
-            responses = self._call_batch(calls)
-            for sh, utxos in zip(scripthashes, responses):
-                if utxos:
-                    for utxo in utxos:
-                        height = utxo.get("height", 0)
-                        if height <= 0:
-                            confirmations = 0
-                        else:
-                            confirmations = current_height - height + 1
-
-                        if confirmations >= min_confirmations:
-                            result[sh].append(
-                                {
-                                    "txid": utxo.get("tx_hash"),
-                                    "vout": utxo.get("tx_pos"),
-                                    "value": utxo.get("value", 0),
-                                    "confirmations": confirmations,
-                                }
-                            )
-        except Exception as e:
-            self._log.warning(f"ElectrumBackend.getBatchUnspent error: {e}")
-
+            for utxo in utxos:
+                height = utxo.get("height", 0)
+                confirmations = 0 if height <= 0 else current_height - height + 1
+                if confirmations >= min_confirmations:
+                    result[sh].append(
+                        {
+                            "txid": utxo.get("tx_hash"),
+                            "vout": utxo.get("tx_pos"),
+                            "value": utxo.get("value", 0),
+                            "confirmations": confirmations,
+                        }
+                    )
         return result
 
     def enableRealtimeNotifications(self, callback) -> None:

--- a/basicswap/wallet_manager.py
+++ b/basicswap/wallet_manager.py
@@ -473,30 +473,6 @@ class WalletManager:
         except Exception:
             return []
 
-    def getFundedAddresses(self, coin_type: Coins) -> Dict[str, str]:
-        try:
-            conn = sqlite3.connect(self._swap_client.sqlite_file)
-            cursor = conn.cursor()
-            funded = {}
-            cursor.execute(
-                "SELECT address, scripthash FROM wallet_addresses WHERE coin_type = ? AND is_funded = 1",
-                (int(coin_type),),
-            )
-            funded.update(
-                {row[0]: row[1] for row in cursor.fetchall() if row[0] and row[1]}
-            )
-            cursor.execute(
-                "SELECT address, scripthash FROM wallet_watch_only WHERE coin_type = ? AND is_funded = 1 AND private_key_encrypted IS NOT NULL AND private_key_encrypted != ''",
-                (int(coin_type),),
-            )
-            funded.update(
-                {row[0]: row[1] for row in cursor.fetchall() if row[0] and row[1]}
-            )
-            conn.close()
-            return funded
-        except Exception:
-            return {}
-
     def getExistingInternalAddress(self, coin_type: Coins) -> Optional[str]:
         try:
             conn = sqlite3.connect(self._swap_client.sqlite_file)
@@ -850,6 +826,16 @@ class WalletManager:
                 (int(coin_type),),
             )
             result = {row[0]: row[1] for row in cursor.fetchall() if row[0] and row[1]}
+            cursor.execute(
+                "SELECT address, scripthash FROM wallet_watch_only"
+                " WHERE coin_type = ?"
+                " AND private_key_encrypted IS NOT NULL"
+                " AND private_key_encrypted != ''",
+                (int(coin_type),),
+            )
+            result.update(
+                {row[0]: row[1] for row in cursor.fetchall() if row[0] and row[1]}
+            )
             conn.close()
             return result
         except Exception:
@@ -1480,146 +1466,6 @@ class WalletManager:
                 )
             )
             return result
-        finally:
-            self._swap_client.closeDB(cursor, commit=False)
-
-    def scanForFundedAddresses(
-        self, coin_type: Coins, backend, gap_limit: int = None
-    ) -> int:
-        if gap_limit is None:
-            gap_limit = self.getGapLimit(coin_type)
-        if not self.isInitialized(coin_type):
-            return 0
-
-        addresses_to_check = []
-        cursor = self._swap_client.openDB()
-        try:
-            bip44_coin = self.BIP84_COIN_TYPES.get(coin_type, 0)
-            now = int(time.time())
-
-            for internal in [False, True]:
-                chain_idx = 1 if internal else 0
-                for index in range(gap_limit):
-                    record = self._swap_client.queryOne(
-                        WalletAddress,
-                        cursor,
-                        {
-                            "coin_type": int(coin_type),
-                            "derivation_index": index,
-                            "is_internal": internal,
-                        },
-                    )
-                    if record is None:
-                        address, scripthash, pubkey = self._deriveAddress(
-                            coin_type, index, internal
-                        )
-                        record = WalletAddress(
-                            coin_type=int(coin_type),
-                            derivation_index=index,
-                            is_internal=internal,
-                            derivation_path=f"m/84'/{bip44_coin}'/0'/{chain_idx}/{index}",
-                            address=address,
-                            scripthash=scripthash,
-                            pubkey=pubkey,
-                            is_funded=False,
-                            ever_used=False,
-                            created_at=now,
-                        )
-                        self._swap_client.add(record, cursor)
-
-                    if not record.is_funded:
-                        addresses_to_check.append((record.address, index, internal))
-
-            self._swap_client.commitDB()
-        finally:
-            self._swap_client.closeDB(cursor, commit=False)
-
-        if not addresses_to_check:
-            return 0
-
-        funded_addresses = []
-        try:
-            addr_list = [a[0] for a in addresses_to_check]
-            balances = backend.getBalance(addr_list)
-            for addr, balance in balances.items():
-                if balance > 0:
-                    for check_addr, index, internal in addresses_to_check:
-                        if check_addr == addr:
-                            funded_addresses.append((addr, index, internal, balance))
-                            break
-        except Exception:
-            return 0
-
-        if not funded_addresses:
-            return 0
-
-        cursor = self._swap_client.openDB()
-        try:
-            found = 0
-            max_ext_index = max_int_index = None
-
-            for addr, index, internal, balance in funded_addresses:
-                record = self._swap_client.queryOne(
-                    WalletAddress,
-                    cursor,
-                    {"coin_type": int(coin_type), "address": addr},
-                )
-                if record and not record.is_funded:
-                    record.is_funded = True
-                    record.cached_balance = balance
-                    record.cached_balance_time = int(time.time())
-                    self._swap_client.updateDB(
-                        record, cursor, constraints=["coin_type", "address"]
-                    )
-                    found += 1
-
-                    if internal:
-                        max_int_index = max(max_int_index or 0, index)
-                    else:
-                        max_ext_index = max(max_ext_index or 0, index)
-
-            if max_ext_index is not None or max_int_index is not None:
-                state = self._swap_client.queryOne(
-                    WalletState, cursor, {"coin_type": int(coin_type)}
-                )
-                if state:
-                    if max_ext_index and (
-                        state.last_external_index is None
-                        or max_ext_index > state.last_external_index
-                    ):
-                        state.last_external_index = max_ext_index
-                    if max_int_index and (
-                        state.last_internal_index is None
-                        or max_int_index > state.last_internal_index
-                    ):
-                        state.last_internal_index = max_int_index
-                    state.updated_at = int(time.time())
-                    self._swap_client.updateDB(state, cursor, constraints=["coin_type"])
-
-            self._swap_client.commitDB()
-            return found
-        except Exception:
-            self._swap_client.rollbackDB()
-            return 0
-        finally:
-            self._swap_client.closeDB(cursor, commit=False)
-
-    def updateFundedStatus(
-        self, coin_type: Coins, address: str, is_funded: bool
-    ) -> bool:
-        cursor = self._swap_client.openDB()
-        try:
-            record = self._swap_client.queryOne(
-                WalletAddress, cursor, {"coin_type": int(coin_type), "address": address}
-            )
-            if record and record.is_funded != is_funded:
-                record.is_funded = is_funded
-                self._swap_client.updateDB(
-                    record, cursor, constraints=["coin_type", "address"]
-                )
-                self._swap_client.commitDB()
-                return True
-            return False
         finally:
             self._swap_client.closeDB(cursor, commit=False)
 

--- a/tests/basicswap/test_wallet_manager.py
+++ b/tests/basicswap/test_wallet_manager.py
@@ -28,6 +28,7 @@ def _make_db() -> str:
     cursor.execute("""CREATE TABLE wallet_addresses (
             coin_type INTEGER,
             address TEXT,
+            scripthash TEXT,
             is_internal INTEGER DEFAULT 0,
             is_funded INTEGER DEFAULT 0,
             cached_balance INTEGER DEFAULT 0,
@@ -36,6 +37,7 @@ def _make_db() -> str:
     cursor.execute("""CREATE TABLE wallet_watch_only (
             coin_type INTEGER,
             address TEXT,
+            scripthash TEXT,
             is_funded INTEGER DEFAULT 0,
             cached_balance INTEGER DEFAULT 0,
             private_key_encrypted BLOB
@@ -94,6 +96,58 @@ class TestWalletManagerBalance(unittest.TestCase):
         # and address subscription are unaffected.
         watched = self.wm.getAllAddresses(Coins.BTC)
         self.assertIn("swap_lock_addr", watched)
+
+
+class TestWalletManagerSignableAddresses(unittest.TestCase):
+    """Coin selection must consider every address we can sign for, regardless of
+    the is_funded flag. Change addresses are inserted unfunded and only a full
+    balance sync ever flips the flag, so selecting on it strands the change."""
+
+    def setUp(self):
+        self.db_path = _make_db()
+        coin = int(Coins.BTC)
+        conn = sqlite3.connect(self.db_path)
+        cursor = conn.cursor()
+        cursor.execute(
+            "INSERT INTO wallet_addresses (coin_type, address, scripthash, is_internal, is_funded, cached_balance, derivation_index) VALUES (?, ?, ?, 0, 1, ?, 0)",
+            (coin, "funded_addr", "sh_funded", 100_000_000),
+        )
+        # Freshly derived change address: holds the change output but is still
+        # flagged unfunded until a balance sync catches up.
+        cursor.execute(
+            "INSERT INTO wallet_addresses (coin_type, address, scripthash, is_internal, is_funded, cached_balance, derivation_index) VALUES (?, ?, ?, 1, 0, 0, 7)",
+            (coin, "fresh_change_addr", "sh_change"),
+        )
+        cursor.execute(
+            "INSERT INTO wallet_watch_only (coin_type, address, scripthash, is_funded, cached_balance, private_key_encrypted) VALUES (?, ?, ?, 0, 0, ?)",
+            (coin, "imported_with_key", "sh_imported", b"encrypted-key"),
+        )
+        cursor.execute(
+            "INSERT INTO wallet_watch_only (coin_type, address, scripthash, is_funded, cached_balance, private_key_encrypted) VALUES (?, ?, ?, 1, ?, NULL)",
+            (coin, "swap_lock_addr", "sh_lock", 500_000_000),
+        )
+        conn.commit()
+        conn.close()
+
+        self.wm = WalletManager(FakeSwapClient(self.db_path), logging.getLogger())
+
+    def tearDown(self):
+        os.remove(self.db_path)
+
+    def test_unfunded_change_address_is_signable(self):
+        signable = self.wm.getSignableAddresses(Coins.BTC)
+        self.assertIn("fresh_change_addr", signable)
+        self.assertEqual(signable["fresh_change_addr"], "sh_change")
+
+    def test_includes_imported_watch_only_holding_key(self):
+        signable = self.wm.getSignableAddresses(Coins.BTC)
+        self.assertIn("imported_with_key", signable)
+
+    def test_excludes_keyless_watch_only(self):
+        # No private key means nothing to sign the input with, so a swap lock
+        # output must never be selected as a funding source.
+        signable = self.wm.getSignableAddresses(Coins.BTC)
+        self.assertNotIn("swap_lock_addr", signable)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This *should* fix user reported issue where balance shows "1.0" but attempt to withdraw errors with insufficiend funds "0.2" due to there being a mismatch in how balances are viewed.

essentially, change addresses are handed out with `is_funded = 0` and not flipped to `1` reliably, resulting in them being skipped on the withdrawal, while still included in the balance.

draft because this is not well tested because i havent encountered the issue myself (dont uae electrum often) and the user reporting had moved the funds externally, so unable to check the fix on the affected instance.

also unsure about the full balance sync flipped it to 1, because the user had the balance stranded for a long time. Its possible that it never did a full balance sync because the connect/reconnect churn (#645) happened too often, but i dont know.