### PR TITLE
dcr: bump to v2.1.6 [mandatory]

### DIFF
--- a/basicswap/interface/dcr/core.py
+++ b/basicswap/interface/dcr/core.py
@@ -16,7 +16,7 @@ from basicswap.interface.prepare_util import (
     exitWithError,
 )
 
-DCR_VERSION = os.getenv("DCR_VERSION", "2.1.5")
+DCR_VERSION = os.getenv("DCR_VERSION", "2.1.6")
 DCR_VERSION_TAG = os.getenv("DCR_VERSION_TAG", "")
 decred_signers = {"decred_release": ("F516ADB7A069852C7C28A02D6D897EDF518A031D",)}
 


### PR DESCRIPTION
https://github.com/decred/dcrd/releases/tag/release-v2.1.6

> Upgrade Mandatory
> This release contains a fix for a critical consensus-related security vulnerability. Everyone is required to upgrade or risk being forked from the network.