### PR TITLE
bids: fix subfee PART blind bids

### DIFF
--- a/basicswap/basicswap.py
+++ b/basicswap/basicswap.py
@@ -4180,7 +4180,10 @@ class BasicSwap(BaseApp, BSXNetwork, UIApp):
         )
         self.log.debug(f"Ensuring wallet can send {balance_msg}.")
         try:
-            if ci.interface_type() in self.scriptless_coins:
+            if (
+                ci.interface_type() in self.scriptless_coins
+                or ci.interface_type() == Coins.PART_BLIND
+            ):
                 ci.ensureFunds(ensure_balance + estimated_fee)
             elif ci.useBackend():
                 self.log.debug(
@@ -5685,14 +5688,18 @@ class BasicSwap(BaseApp, BSXNetwork, UIApp):
             offer.amount_negotiable,
             f"Offer amounts are final: {self.log.id(offer_id)}.",
         )
-        if offer.coin_to in self.xmr_based_coins:
-            raise ValueError("TODO")
         if offer.swap_type != SwapTypes.XMR_SWAP:
             raise ValueError("TODO")
         ci_to = self.ci(offer.coin_to)
         ci_from = self.ci(offer.coin_from)
         pi = self.pi(SwapTypes.XMR_SWAP)
         reverse_bid: bool = self.is_reverse_ads_bid(offer.coin_from, offer.coin_to)
+
+        if not reverse_bid and offer.coin_to in self.xmr_based_coins + (
+            Coins.PART_ANON,
+            Coins.PART_BLIND,
+        ):
+            raise ValueError("TODO")
 
         feerate: int = xmr_offer.b_fee_rate
         if reverse_bid:

--- a/basicswap/interface/part/part.py
+++ b/basicswap/interface/part/part.py
@@ -298,6 +298,9 @@ class PARTInterfaceBlind(PARTInterface):
     def coin_name(self) -> str:
         return super().coin_name() + " Blind"
 
+    def ticker(self) -> str:
+        return super().ticker() + " Blind"
+
     def getScriptLockTxNonce(self, data):
         return hashlib.sha256(data + bytes("locktx", "utf-8")).digest()
 
@@ -1413,6 +1416,9 @@ class PARTInterfaceAnon(PARTInterface):
 
     def coin_name(self) -> str:
         return super().coin_name() + " Anon"
+
+    def ticker(self) -> str:
+        return super().ticker() + " Anon"
 
     def publishBLockTx(
         self,

--- a/basicswap/ui/page_offers.py
+++ b/basicswap/ui/page_offers.py
@@ -1113,18 +1113,16 @@ def page_offer(self, url_split: List[str], post_string: str) -> bytes:
         data["tracking_ticker"] = ci_from.ticker()
 
     if show_bid_form:
-        coin_to_id = int(ci_to.coin_type())
-        wallet_coin_to_id = coin_to_id
-        if coin_to_id in (Coins.PART_ANON, Coins.PART_BLIND):
-            wallet_coin_to_id = Coins.PART
+        coin_to_variant = Coins(offer.coin_to)
+        wallet_coin_to_id = int(ci_to.coin_type())
 
         swap_client.updateWalletsInfo(only_coin=wallet_coin_to_id)
         coin_to_wallet = swap_client.getCachedWalletsInfo(
             {"coin_id": wallet_coin_to_id}
         )[wallet_coin_to_id]
-        if coin_to_id == Coins.PART_ANON:
+        if coin_to_variant == Coins.PART_ANON:
             balance_key = "anon_balance"
-        elif coin_to_id == Coins.PART_BLIND:
+        elif coin_to_variant == Coins.PART_BLIND:
             balance_key = "blind_balance"
         else:
             balance_key = "balance"
@@ -1133,7 +1131,9 @@ def page_offer(self, url_split: List[str], post_string: str) -> bytes:
         bid_can_subfee: bool = True
         if offer.swap_type != SwapTypes.XMR_SWAP:
             bid_can_subfee = False
-        if coin_to_id in swap_client.xmr_based_coins:
+        if coin_to_variant in swap_client.xmr_based_coins:
+            bid_can_subfee = False
+        if not reverse_bid and coin_to_variant in (Coins.PART_ANON, Coins.PART_BLIND):
             bid_can_subfee = False
         if offer.amount_negotiable is False:
             bid_can_subfee = False


### PR DESCRIPTION
using subfee when bidding with part blind against a script coin (example blind <-> ltc) caused the blind checks to be skipped, and plain balance to be used to fund the swap.

new bid form incorrectly displayed "Sending/Receiving (PART)" instead of the variant.

new bid form's "max" button did not use the blind balance