### PR TITLE
Validate legacy imported keys before AEAD migration, report decrypt failures

### DIFF
--- a/basicswap/wallet_manager.py
+++ b/basicswap/wallet_manager.py
@@ -824,8 +824,21 @@ class WalletManager:
                 conn.close()
                 return None
             encrypted_key = row[0]
-            private_key = self._decryptPrivateKey(encrypted_key, coin_type)
+            try:
+                private_key = self._decryptPrivateKey(encrypted_key, coin_type)
+            except Exception as e:
+                conn.close()
+                self._log.error(
+                    f"Failed to decrypt imported key for {address}: {e}. The record may be corrupt or tampered with."
+                )
+                return None
             if not self._isAEADImportKey(encrypted_key):
+                if not self._verifyKeyForAddress(coin_type, address, private_key):
+                    conn.close()
+                    self._log.error(
+                        f"Legacy imported key for {address} does not match the address, not migrating."
+                    )
+                    return None
                 cursor.execute(
                     "UPDATE wallet_watch_only SET private_key_encrypted = ? WHERE coin_type = ? AND address = ?",
                     (
@@ -838,7 +851,8 @@ class WalletManager:
                 self._log.info("Migrated legacy imported key to AEAD format")
             conn.close()
             return private_key
-        except Exception:
+        except Exception as e:
+            self._log.debug(f"getPrivateKey failed for {address}: {e}")
             return None
 
     def getSignableAddresses(self, coin_type: Coins) -> Dict[str, str]:
@@ -913,14 +927,7 @@ class WalletManager:
         label: str = "",
         source: str = "import",
     ) -> bool:
-        try:
-            pubkey = PublicKey.from_secret(private_key).format()
-            if (
-                segwit_addr.encode(self._getHRP(coin_type), 0, hash160(pubkey))
-                != address
-            ):
-                return False
-        except Exception:
+        if not self._verifyKeyForAddress(coin_type, address, private_key):
             return False
 
         cursor = self._swap_client.openDB()
@@ -1070,6 +1077,18 @@ class WalletManager:
             return None
         except Exception:
             return None
+
+    def _verifyKeyForAddress(
+        self, coin_type: Coins, address: str, private_key: bytes
+    ) -> bool:
+        try:
+            pubkey = PublicKey.from_secret(private_key).format()
+            return (
+                segwit_addr.encode(self._getHRP(coin_type), 0, hash160(pubkey))
+                == address
+            )
+        except Exception:
+            return False
 
     def _getXorKey(self, coin_type: Coins) -> bytes:
         # Legacy per-coin XOR keystream. Retained only to decrypt rows

--- a/tests/basicswap/test_import_key_migration.py
+++ b/tests/basicswap/test_import_key_migration.py
@@ -1,0 +1,112 @@
+# -*- coding: utf-8 -*-
+
+# Copyright (c) 2026 The Basicswap developers
+# Distributed under the MIT software license, see the accompanying
+# file LICENSE or http://www.opensource.org/licenses/mit-license.php.
+
+import os
+import sqlite3
+import tempfile
+import unittest
+from unittest.mock import MagicMock
+
+from basicswap.chainparams import Coins
+from basicswap.wallet_manager import WalletManager
+from basicswap.contrib.test_framework import segwit_addr
+from basicswap.util.crypto import hash160
+from coincurve import PublicKey
+
+SEED = bytes(range(32))
+PRIVATE_KEY = bytes(range(1, 33))
+
+
+class ImportKeyMigrationTest(unittest.TestCase):
+    def setUp(self):
+        self.tmpdir = tempfile.TemporaryDirectory()
+        sqlite_file = os.path.join(self.tmpdir.name, "db.sqlite")
+        conn = sqlite3.connect(sqlite_file)
+        conn.execute(
+            "CREATE TABLE wallet_addresses (coin_type INT, address TEXT, derivation_index INT, is_internal INT)"
+        )
+        conn.execute(
+            "CREATE TABLE wallet_watch_only (coin_type INT, address TEXT, private_key_encrypted BLOB)"
+        )
+        conn.commit()
+        conn.close()
+
+        swap_client = MagicMock()
+        swap_client.sqlite_file = sqlite_file
+        swap_client.chain = "regtest"
+        self.log = MagicMock()
+        self.wm = WalletManager(swap_client, self.log)
+        self.wm.needsMigration = lambda coin_type: False
+        self.wm.initialize(Coins.BTC, SEED)
+
+        pubkey = PublicKey.from_secret(PRIVATE_KEY).format()
+        self.address = segwit_addr.encode(
+            self.wm._getHRP(Coins.BTC), 0, hash160(pubkey)
+        )
+
+    def tearDown(self):
+        self.tmpdir.cleanup()
+
+    def _insert_watch_only(self, address, encrypted_key):
+        conn = sqlite3.connect(self.wm._swap_client.sqlite_file)
+        conn.execute(
+            "INSERT INTO wallet_watch_only (coin_type, address, private_key_encrypted) VALUES (?, ?, ?)",
+            (int(Coins.BTC), address, encrypted_key),
+        )
+        conn.commit()
+        conn.close()
+
+    def _fetch_encrypted(self, address):
+        conn = sqlite3.connect(self.wm._swap_client.sqlite_file)
+        row = conn.execute(
+            "SELECT private_key_encrypted FROM wallet_watch_only WHERE address = ?",
+            (address,),
+        ).fetchone()
+        conn.close()
+        return row[0]
+
+    def _legacy_encrypt(self, private_key):
+        keystream = self.wm._getXorKey(Coins.BTC)
+        return bytes(a ^ b for a, b in zip(private_key, keystream))
+
+    def test_valid_legacy_record_migrates(self):
+        self._insert_watch_only(self.address, self._legacy_encrypt(PRIVATE_KEY))
+        rv = self.wm.getPrivateKey(Coins.BTC, self.address)
+        self.assertEqual(rv, PRIVATE_KEY)
+        migrated = self._fetch_encrypted(self.address)
+        self.assertTrue(WalletManager._isAEADImportKey(migrated))
+
+    def test_mismatched_legacy_record_not_migrated(self):
+        other_address = segwit_addr.encode(
+            self.wm._getHRP(Coins.BTC), 0, hash160(b"\x03" * 33)
+        )
+        legacy = self._legacy_encrypt(PRIVATE_KEY)
+        self._insert_watch_only(other_address, legacy)
+        rv = self.wm.getPrivateKey(Coins.BTC, other_address)
+        self.assertIsNone(rv)
+        self.assertEqual(self._fetch_encrypted(other_address), legacy)
+        self.log.error.assert_called_once()
+        self.assertIn("does not match", self.log.error.call_args[0][0])
+
+    def test_tampered_aead_record_reports_error(self):
+        encrypted = self.wm._encryptPrivateKey(PRIVATE_KEY, Coins.BTC)
+        tampered = encrypted[:-1] + bytes([encrypted[-1] ^ 0x01])
+        self._insert_watch_only(self.address, tampered)
+        rv = self.wm.getPrivateKey(Coins.BTC, self.address)
+        self.assertIsNone(rv)
+        self.log.error.assert_called_once()
+        self.assertIn("Failed to decrypt", self.log.error.call_args[0][0])
+
+    def test_valid_aead_record_returned(self):
+        encrypted = self.wm._encryptPrivateKey(PRIVATE_KEY, Coins.BTC)
+        self._insert_watch_only(self.address, encrypted)
+        rv = self.wm.getPrivateKey(Coins.BTC, self.address)
+        self.assertEqual(rv, PRIVATE_KEY)
+        self.assertEqual(self._fetch_encrypted(self.address), encrypted)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
- New _verifyKeyForAddress() helper (derive pubkey → p2wpkh address → compare); importAddressWithKey now reuses it instead of its inline copy.. 
- getPrivateKey: decrypt failures get their own error log ("corrupt or tampered"); legacy records failing address validation are not migrated and return None with an error; the outer blanket except now logs at debug.