### PR TITLE
Require confirmed UTXOs for Electrum swap funding

### DIFF
--- a/basicswap/interface/btc/btc.py
+++ b/basicswap/interface/btc/btc.py
@@ -2145,7 +2145,7 @@ class BTCInterface(FeeValidator, Secp256k1Interface):
         scripthashes = list(addr_to_sh.values())
         sh_to_addr = {sh: addr for addr, sh in addr_to_sh.items()}
 
-        batch_utxos = backend.getBatchUnspent(scripthashes)
+        batch_utxos = backend.getBatchUnspent(scripthashes, min_confirmations=1)
 
         utxos = []
         locked_count = 0

--- a/basicswap/interface/btc/btc.py
+++ b/basicswap/interface/btc/btc.py
@@ -2145,10 +2145,11 @@ class BTCInterface(FeeValidator, Secp256k1Interface):
         scripthashes = list(addr_to_sh.values())
         sh_to_addr = {sh: addr for addr, sh in addr_to_sh.items()}
 
-        batch_utxos = backend.getBatchUnspent(scripthashes, min_confirmations=1)
+        batch_utxos = backend.getBatchUnspent(scripthashes)
 
         utxos = []
         locked_count = 0
+        unconfirmed_count = 0
         for sh, sh_utxos in batch_utxos.items():
             addr = sh_to_addr.get(sh, "")
             if not addr:
@@ -2162,6 +2163,9 @@ class BTCInterface(FeeValidator, Secp256k1Interface):
                             f"_fundTxElectrum: scripthash mismatch for {addr}: "
                             f"stored={sh}, computed={computed_sh}"
                         )
+                if utxo.get("confirmations", 0) < 1:
+                    unconfirmed_count += 1
+                    continue
                 if wm.isUTXOLocked(
                     self.coin_type(), utxo.get("txid", ""), utxo.get("vout", 0)
                 ):
@@ -2170,9 +2174,10 @@ class BTCInterface(FeeValidator, Secp256k1Interface):
                 utxos.append(utxo)
 
         if not utxos:
-            if locked_count > 0:
+            if locked_count > 0 or unconfirmed_count > 0:
                 raise ValueError(
-                    f"No UTXOs available ({locked_count} locked for pending swaps)"
+                    f"No spendable UTXOs ({locked_count} locked for pending swaps, "
+                    f"{unconfirmed_count} awaiting confirmation)"
                 )
             raise ValueError("No UTXOs available")
 

--- a/tests/basicswap/test_electrum_funding.py
+++ b/tests/basicswap/test_electrum_funding.py
@@ -1,0 +1,92 @@
+# -*- coding: utf-8 -*-
+
+# Copyright (c) 2026 The Basicswap developers
+# Distributed under the MIT software license, see the accompanying
+# file LICENSE or http://www.opensource.org/licenses/mit-license.php.
+
+import unittest
+from unittest.mock import MagicMock
+
+from basicswap.contrib.test_framework.messages import (
+    COutPoint,
+    CTransaction,
+    CTxIn,
+    CTxOut,
+)
+from basicswap.interface.btc.btc import BTCInterface
+from basicswap.wallet_backend import ElectrumBackend
+from tests.basicswap.util.common import REQUIRED_SETTINGS
+
+UTXOS = [
+    {"tx_hash": "aa" * 32, "tx_pos": 0, "value": 5000, "height": 101},
+    {"tx_hash": "bb" * 32, "tx_pos": 1, "value": 6000, "height": 0},
+    {"tx_hash": "cc" * 32, "tx_pos": 0, "value": 7000, "height": 110},
+]
+
+
+def make_backend():
+    backend = ElectrumBackend.__new__(ElectrumBackend)
+    backend._log = MagicMock()
+    backend.getBlockHeight = lambda: 110
+    backend._call_batch = lambda calls: [UTXOS]
+    return backend
+
+
+class GetBatchUnspentTest(unittest.TestCase):
+    def test_default_includes_unconfirmed(self):
+        backend = make_backend()
+        rv = backend.getBatchUnspent(["sh1"])
+        self.assertEqual(len(rv["sh1"]), 3)
+
+    def test_min_confirmations_filters_unconfirmed(self):
+        backend = make_backend()
+        rv = backend.getBatchUnspent(["sh1"], min_confirmations=1)
+        txids = [utxo["txid"] for utxo in rv["sh1"]]
+        self.assertEqual(txids, ["aa" * 32, "cc" * 32])
+
+    def test_min_confirmations_two_excludes_tip(self):
+        backend = make_backend()
+        rv = backend.getBatchUnspent(["sh1"], min_confirmations=2)
+        txids = [utxo["txid"] for utxo in rv["sh1"]]
+        self.assertEqual(txids, ["aa" * 32])
+
+
+class SentinelError(Exception):
+    pass
+
+
+class FundTxElectrumTest(unittest.TestCase):
+    def test_funding_requires_confirmed_utxos(self):
+        settings = dict(REQUIRED_SETTINGS)
+        settings.update(
+            {
+                "rpcport": 0,
+                "rpcauth": "none",
+                "connection_type": "electrum",
+            }
+        )
+        ci = BTCInterface(settings, "regtest")
+
+        calls = []
+
+        class RecordingBackend:
+            def getBatchUnspent(self, scripthashes, min_confirmations=0):
+                calls.append(min_confirmations)
+                raise SentinelError()
+
+        wm = MagicMock()
+        wm.getFundedAddresses.return_value = {"addr1": "sh1"}
+        ci._backend = RecordingBackend()
+        ci.getWalletManager = lambda: wm
+
+        tx = CTransaction()
+        tx.vin.append(CTxIn(COutPoint(1, 0)))
+        tx.vout.append(CTxOut(10000, bytes([0x00, 0x14]) + b"\x11" * 20))
+
+        with self.assertRaises(SentinelError):
+            ci._fundTxElectrum(tx.serialize_without_witness(), 10000)
+        self.assertEqual(calls, [1])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/basicswap/test_electrum_funding.py
+++ b/tests/basicswap/test_electrum_funding.py
@@ -7,12 +7,7 @@
 import unittest
 from unittest.mock import MagicMock
 
-from basicswap.contrib.test_framework.messages import (
-    COutPoint,
-    CTransaction,
-    CTxIn,
-    CTxOut,
-)
+from basicswap.contrib.test_framework.messages import CTransaction, CTxOut
 from basicswap.interface.btc.btc import BTCInterface
 from basicswap.wallet_backend import ElectrumBackend
 from tests.basicswap.util.common import REQUIRED_SETTINGS
@@ -34,58 +29,58 @@ def make_backend():
 
 class GetBatchUnspentTest(unittest.TestCase):
     def test_default_includes_unconfirmed(self):
-        backend = make_backend()
-        rv = backend.getBatchUnspent(["sh1"])
+        rv = make_backend().getBatchUnspent(["sh1"])
         self.assertEqual(len(rv["sh1"]), 3)
 
     def test_min_confirmations_filters_unconfirmed(self):
-        backend = make_backend()
-        rv = backend.getBatchUnspent(["sh1"], min_confirmations=1)
-        txids = [utxo["txid"] for utxo in rv["sh1"]]
-        self.assertEqual(txids, ["aa" * 32, "cc" * 32])
-
-    def test_min_confirmations_two_excludes_tip(self):
-        backend = make_backend()
-        rv = backend.getBatchUnspent(["sh1"], min_confirmations=2)
-        txids = [utxo["txid"] for utxo in rv["sh1"]]
-        self.assertEqual(txids, ["aa" * 32])
-
-
-class SentinelError(Exception):
-    pass
+        rv = make_backend().getBatchUnspent(["sh1"], min_confirmations=1)
+        self.assertEqual([u["txid"] for u in rv["sh1"]], ["aa" * 32, "cc" * 32])
 
 
 class FundTxElectrumTest(unittest.TestCase):
-    def test_funding_requires_confirmed_utxos(self):
+    def setUp(self):
         settings = dict(REQUIRED_SETTINGS)
         settings.update(
-            {
-                "rpcport": 0,
-                "rpcauth": "none",
-                "connection_type": "electrum",
-            }
+            {"rpcport": 0, "rpcauth": "none", "connection_type": "electrum"}
         )
-        ci = BTCInterface(settings, "regtest")
+        self.ci = BTCInterface(settings, "regtest")
+        self.ci._log = MagicMock()
+        self.addr = self.ci.encodeSegwitAddress(b"\x11" * 20)
 
-        calls = []
+    def _fund(self, utxos):
+        sh = self.ci.addressToScripthash(self.addr)
 
-        class RecordingBackend:
+        class FakeBackend:
             def getBatchUnspent(self, scripthashes, min_confirmations=0):
-                calls.append(min_confirmations)
-                raise SentinelError()
+                return {
+                    sh: [u for u in utxos if u["confirmations"] >= min_confirmations]
+                }
 
         wm = MagicMock()
-        wm.getFundedAddresses.return_value = {"addr1": "sh1"}
-        ci._backend = RecordingBackend()
-        ci.getWalletManager = lambda: wm
+        wm.getFundedAddresses.return_value = {self.addr: sh}
+        wm.isUTXOLocked.return_value = False
+        self.ci._backend = FakeBackend()
+        self.ci.getWalletManager = lambda: wm
 
         tx = CTransaction()
-        tx.vin.append(CTxIn(COutPoint(1, 0)))
         tx.vout.append(CTxOut(10000, bytes([0x00, 0x14]) + b"\x11" * 20))
+        funded = self.ci.loadTx(
+            self.ci._fundTxElectrum(tx.serialize_without_witness(), 1000)
+        )
+        return {
+            txin.prevout.hash.to_bytes(32, "little")[::-1].hex() for txin in funded.vin
+        }
 
-        with self.assertRaises(SentinelError):
-            ci._fundTxElectrum(tx.serialize_without_witness(), 10000)
-        self.assertEqual(calls, [1])
+    def test_unconfirmed_utxos_are_not_spent(self):
+        confirmed = {"txid": "aa" * 32, "vout": 0, "value": 10750, "confirmations": 3}
+        unconfirmed = {"txid": "bb" * 32, "vout": 0, "value": 99000, "confirmations": 0}
+        self.assertEqual(self._fund([unconfirmed, confirmed]), {"aa" * 32})
+
+    def test_only_unconfirmed_reports_why(self):
+        unconfirmed = {"txid": "bb" * 32, "vout": 0, "value": 99000, "confirmations": 0}
+        with self.assertRaises(ValueError) as e:
+            self._fund([unconfirmed])
+        self.assertIn("awaiting confirmation", str(e.exception))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
- `_fundTxElectrum` no longer spends unconfirmed UTXOs: 0-conf outputs are filtered during coin selection and counted separately
- When funding fails, the error now says why: "No spendable UTXOs (N locked for pending swaps, M awaiting confirmation)" instead of a bare "No UTXOs available"
- `getBatchUnspent` keeps its default behavior (includes unconfirmed); the `min_confirmations` parameter remains available for callers that want backend-side filtering
- Tests run the actual funding path with a fake backend: verify a tx funds only from confirmed UTXOs, and that an unconfirmed-only wallet reports "awaiting confirmation"