### PR TITLE
Don't trust offer-supplied automation_strat_id for bid decisions

### DIFF
--- a/scripts/createoffers.py
+++ b/scripts/createoffers.py
@@ -545,6 +545,36 @@ def write_state(statefile, script_state):
         json.dump(script_state, fp, indent=4)
 
 
+def get_local_identity(addr_from, debug=False):
+    try:
+        identity = read_json_api("identities/{}".format(addr_from))
+        if isinstance(identity, dict) and "address" in identity:
+            return identity
+    except Exception as e:
+        if debug:
+            print(f"Error getting identity for {addr_from}: {e}")
+    return {}
+
+
+def is_locally_trusted_offer(offer, debug=False):
+    """The offer's automation_strat_id is set by the remote peer and can't be
+    trusted.  Decide from the local identity record instead."""
+    addr_from = offer.get("addr_from")
+    if not addr_from:
+        return False
+    identity = get_local_identity(addr_from, debug)
+    automation_override = identity.get("automation_override", 0)
+    if automation_override == 2:
+        return False
+    if automation_override == 1:
+        return True
+    successful_sent_bids = identity.get("num_sent_bids_successful", 0)
+    failed_sent_bids = identity.get("num_sent_bids_failed", 0)
+    if successful_sent_bids < 1:
+        return False
+    return not (failed_sent_bids > 3 and failed_sent_bids > successful_sent_bids)
+
+
 def attempt_pre_offer_bids(
     offer_template, use_rate, amount_to_offer, coin_from_data, coin_to_data, debug=False
 ):
@@ -624,7 +654,7 @@ def filter_biddable_offers(offers, offer_template, our_rate, debug=False):
 
             if offer_rate <= max_acceptable_rate:
                 # Apply strategy-specific filtering
-                if should_bid_on_offer(offer, strategy):
+                if should_bid_on_offer(offer, strategy, debug):
                     filtered.append(offer)
 
         except (ValueError, KeyError) as e:
@@ -716,17 +746,21 @@ def place_bid_on_offer(offer, bid_amount, offer_template, debug=False):
         return False
 
 
-def should_bid_on_offer(offer, strategy):
+def should_bid_on_offer(offer, strategy, debug=False):
     """Determine if we should bid on this offer based on strategy"""
     if strategy == "aggressive":
         # Bid on all compatible offers
         return True
     elif strategy == "conservative":
-        # Only bid on offers with auto-accept enabled
-        return offer.get("automation_strat_id") in [1, 2]
+        return offer.get("automation_strat_id") in [
+            1,
+            2,
+        ] and is_locally_trusted_offer(offer, debug)
     elif strategy == "auto_accept_only":
-        # Only bid on auto-accept offers (best rates from auto-accept only)
-        return offer.get("automation_strat_id") in [1, 2]
+        return offer.get("automation_strat_id") in [
+            1,
+            2,
+        ] and is_locally_trusted_offer(offer, debug)
     elif strategy == "balanced":
         # Bid on auto-accept offers and some manual offers
         return True  # For now same as aggressive (TODO)
@@ -1211,20 +1245,21 @@ def process_offers(args, config, script_state) -> None:
                             )
                             print(f"Automation strategy ID: {offer_strat_id}")
 
-                        if template_strategy == "accept_all" and offer_strat_id == 1:
-                            auto_accept_offers.append(offer)
-                            if args.debug:
+                        if (
+                            template_strategy == "accept_all" and offer_strat_id == 1
+                        ) or (
+                            template_strategy == "accept_known"
+                            and offer_strat_id in [1, 2]
+                        ):
+                            if is_locally_trusted_offer(offer, args.debug):
+                                auto_accept_offers.append(offer)
+                                if args.debug:
+                                    print(
+                                        f"Using {template_strategy}. Offer strategy = {offer_strat_id}. Added offer: {offer_id}"
+                                    )
+                            elif args.debug:
                                 print(
-                                    f"Using {template_strategy}. Offer strategy = {offer_strat_id}. Added offer: {offer_id}"
-                                )
-                        elif template_strategy == "accept_known" and offer_strat_id in [
-                            1,
-                            2,
-                        ]:
-                            auto_accept_offers.append(offer)
-                            if args.debug:
-                                print(
-                                    f"Using {template_strategy}. Offer strategy = {offer_strat_id}. Added offer: {offer_id}"
+                                    f"Offer {offer_id} claims auto-accept but is not locally trusted. Skipping."
                                 )
                         elif template_strategy == "none" or not template_strategy:
                             auto_accept_offers.append(offer)

--- a/tests/basicswap/test_amm_trust.py
+++ b/tests/basicswap/test_amm_trust.py
@@ -1,0 +1,144 @@
+# -*- coding: utf-8 -*-
+
+# Copyright (c) 2026 The Basicswap developers
+# Distributed under the MIT software license, see the accompanying
+# file LICENSE or http://www.opensource.org/licenses/mit-license.php.
+
+import importlib.util
+import os
+import unittest
+
+_SCRIPT_PATH = os.path.join(
+    os.path.dirname(__file__), "..", "..", "scripts", "createoffers.py"
+)
+_spec = importlib.util.spec_from_file_location("createoffers", _SCRIPT_PATH)
+createoffers = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(createoffers)
+
+
+def make_offer(strat_id=1, addr_from="addr_peer"):
+    return {
+        "offer_id": "abcd",
+        "addr_from": addr_from,
+        "rate": 1.0,
+        "automation_strat_id": strat_id,
+    }
+
+
+class FakeIdentityApi:
+    def __init__(self, identities):
+        self._identities = identities
+
+    def __call__(self, path, json_data=None):
+        addr = path.split("/")[-1]
+        if addr in self._identities:
+            return dict(self._identities[addr], address=addr)
+        return {}
+
+
+def set_identities(identities):
+    createoffers.read_json_api = FakeIdentityApi(identities)
+
+
+class IsLocallyTrustedOfferTest(unittest.TestCase):
+    def test_unknown_identity_not_trusted(self):
+        set_identities({})
+        self.assertFalse(createoffers.is_locally_trusted_offer(make_offer()))
+
+    def test_automation_override_always_trusted(self):
+        set_identities({"addr_peer": {"automation_override": 1}})
+        self.assertTrue(createoffers.is_locally_trusted_offer(make_offer()))
+
+    def test_automation_override_never_not_trusted(self):
+        set_identities(
+            {
+                "addr_peer": {
+                    "automation_override": 2,
+                    "num_sent_bids_successful": 10,
+                    "num_sent_bids_failed": 0,
+                }
+            }
+        )
+        self.assertFalse(createoffers.is_locally_trusted_offer(make_offer()))
+
+    def test_successful_history_trusted(self):
+        set_identities(
+            {
+                "addr_peer": {
+                    "automation_override": 0,
+                    "num_sent_bids_successful": 2,
+                    "num_sent_bids_failed": 1,
+                }
+            }
+        )
+        self.assertTrue(createoffers.is_locally_trusted_offer(make_offer()))
+
+    def test_no_successful_history_not_trusted(self):
+        set_identities(
+            {
+                "addr_peer": {
+                    "automation_override": 0,
+                    "num_sent_bids_successful": 0,
+                    "num_sent_bids_failed": 0,
+                }
+            }
+        )
+        self.assertFalse(createoffers.is_locally_trusted_offer(make_offer()))
+
+    def test_too_many_failed_bids_not_trusted(self):
+        set_identities(
+            {
+                "addr_peer": {
+                    "automation_override": 0,
+                    "num_sent_bids_successful": 1,
+                    "num_sent_bids_failed": 5,
+                }
+            }
+        )
+        self.assertFalse(createoffers.is_locally_trusted_offer(make_offer()))
+
+    def test_missing_addr_from_not_trusted(self):
+        set_identities({"addr_peer": {"automation_override": 1}})
+        offer = make_offer()
+        del offer["addr_from"]
+        self.assertFalse(createoffers.is_locally_trusted_offer(offer))
+
+
+class ShouldBidOnOfferTest(unittest.TestCase):
+    def test_claimed_auto_accept_alone_is_not_enough(self):
+        set_identities({})
+        offer = make_offer(strat_id=1)
+        self.assertFalse(createoffers.should_bid_on_offer(offer, "conservative"))
+        self.assertFalse(createoffers.should_bid_on_offer(offer, "auto_accept_only"))
+
+    def test_claimed_and_locally_trusted(self):
+        set_identities({"addr_peer": {"automation_override": 1}})
+        offer = make_offer(strat_id=1)
+        self.assertTrue(createoffers.should_bid_on_offer(offer, "conservative"))
+        self.assertTrue(createoffers.should_bid_on_offer(offer, "auto_accept_only"))
+
+    def test_trusted_without_auto_accept_claim(self):
+        set_identities({"addr_peer": {"automation_override": 1}})
+        offer = make_offer(strat_id=0)
+        self.assertFalse(createoffers.should_bid_on_offer(offer, "conservative"))
+
+    def test_aggressive_unchanged(self):
+        set_identities({})
+        self.assertTrue(createoffers.should_bid_on_offer(make_offer(), "aggressive"))
+
+
+class FilterBiddableOffersTest(unittest.TestCase):
+    def test_untrusted_claimed_offer_filtered_out(self):
+        set_identities({"addr_known": {"automation_override": 1}})
+        offers = [
+            make_offer(strat_id=1, addr_from="addr_unknown"),
+            make_offer(strat_id=1, addr_from="addr_known"),
+        ]
+        template = {"bid_strategy": "conservative", "bid_rate_tolerance": 2.0}
+        filtered = createoffers.filter_biddable_offers(offers, template, 1.0)
+        self.assertEqual(len(filtered), 1)
+        self.assertEqual(filtered[0]["addr_from"], "addr_known")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
- automation_strat_id on received offers is a wire field written by the counterparty; the AMM used it as the sole gate for auto-bidding and for including offers in market-rate statistics.
- New is_locally_trusted_offer helper decides from the local identity record instead: your automation_override setting for that address, or successful swap history (same criteria the main bid path already uses)
- conservative/auto_accept_only bid strategies and the market-rate filter now require local trust in addition to the peer's claim.
- Fresh installs with no history fall back to CoinGecko rates for accept_all/accept_known templates; automation_strategy: none keeps the old inclusive behavior.