### PR TITLE
fix: password verification rejecting valid hashes when the salt contains "60"

### DIFF
--- a/basicswap/util/rfc2440.py
+++ b/basicswap/util/rfc2440.py
@@ -49,12 +49,13 @@ def verify_rfc2440_password(stored_hash, provided_password):
             return False
 
         salt_hex_plus_hash_hex = parts[1]
-        separator_index = salt_hex_plus_hash_hex.find("60")
-        if separator_index != 16:
+        if len(salt_hex_plus_hash_hex) != 58:
+            return False
+        if salt_hex_plus_hash_hex[16:18] != "60":
             return False
 
-        salt_hex = salt_hex_plus_hash_hex[:separator_index]
-        expected_hash_hex = salt_hex_plus_hash_hex[separator_index + 2 :]
+        salt_hex = salt_hex_plus_hash_hex[:16]
+        expected_hash_hex = salt_hex_plus_hash_hex[18:]
 
         salt = bytes.fromhex(salt_hex)
     except (ValueError, IndexError):

--- a/tests/basicswap/test_rfc2440_verify.py
+++ b/tests/basicswap/test_rfc2440_verify.py
@@ -1,0 +1,52 @@
+# -*- coding: utf-8 -*-
+
+# Copyright (c) 2026 The Basicswap developers
+# Distributed under the MIT software license, see the accompanying
+# file LICENSE or http://www.opensource.org/licenses/mit-license.php.
+
+import unittest
+
+from basicswap.util.rfc2440 import rfc2440_hash_password, verify_rfc2440_password
+
+
+class VerifyRfc2440PasswordTest(unittest.TestCase):
+    def test_known_vector_verifies(self):
+        stored = "16:B7A94A7E4988630E6095334BA67F06FBA509B2A7136A04C9C1B430F539"
+        self.assertTrue(verify_rfc2440_password(stored, "test"))
+        self.assertFalse(verify_rfc2440_password(stored, "wrong"))
+
+    def test_salt_starting_with_60_verifies(self):
+        salt = bytes.fromhex("60AABBCCDDEEFF11")
+        stored = rfc2440_hash_password("password1", salt=salt)
+        self.assertTrue(verify_rfc2440_password(stored, "password1"))
+        self.assertFalse(verify_rfc2440_password(stored, "password2"))
+
+    def test_salt_with_60_straddling_bytes_verifies(self):
+        salt = bytes.fromhex("F60A112233445566")
+        stored = rfc2440_hash_password("password1", salt=salt)
+        self.assertTrue(verify_rfc2440_password(stored, "password1"))
+
+    def test_all_salt_positions_verify(self):
+        for i in range(8):
+            salt = bytearray(b"\x11" * 8)
+            salt[i] = 0x60
+            stored = rfc2440_hash_password("password1", salt=bytes(salt))
+            self.assertTrue(
+                verify_rfc2440_password(stored, "password1"), f"salt offset {i}"
+            )
+
+    def test_malformed_hashes_rejected(self):
+        stored = rfc2440_hash_password("test", salt=bytes.fromhex("B7A94A7E4988630E"))
+        self.assertFalse(verify_rfc2440_password("", "test"))
+        self.assertFalse(verify_rfc2440_password("16:", "test"))
+        self.assertFalse(verify_rfc2440_password(stored.replace("16:", "17:"), "test"))
+        self.assertFalse(verify_rfc2440_password(stored[:-2], "test"))
+        self.assertFalse(verify_rfc2440_password(stored + "AA", "test"))
+        bad_specifier = stored[:19] + "61" + stored[21:]
+        self.assertFalse(verify_rfc2440_password(bad_specifier, "test"))
+        non_hex_salt = "16:" + "ZZ" * 8 + "60" + "AA" * 20
+        self.assertFalse(verify_rfc2440_password(non_hex_salt, "test"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
- verify_rfc2440_password located the hash by searching for the first "60" in the stored string, but "60" at offset 16 is the fixed iteration-count specifier, not a separator. When the random 8-byte salt itself contained "60" (~6% of generated hashes), find() returned an earlier index and verification failed for the correct password, permanently locking the user out of the web UI.
- Parse the stored hash positionally instead: 16 hex chars salt, "60" specifier, 40 hex chars SHA-1, total length 58.
- Add tests: known vector, salt starting with 0x60, "60" straddling a byte boundary, 0x60 at every salt offset, and malformed-hash rejection.