### PR TITLE
firo: bump to v0.14.18.0 [mandatory]

### DIFF
--- a/basicswap/interface/firo/core.py
+++ b/basicswap/interface/firo/core.py
@@ -16,7 +16,7 @@ from basicswap.interface.prepare_util import (
     generate_salt,
 )
 
-FIRO_VERSION = os.getenv("FIRO_VERSION", "0.14.17.2")
+FIRO_VERSION = os.getenv("FIRO_VERSION", "0.14.18.0")
 FIRO_VERSION_TAG = os.getenv("FIRO_VERSION_TAG", "")
 firo_signers = {"reuben": ("0186454D63E83D85EF91DE4E1290A1D0FA7EE109",)}
 


### PR DESCRIPTION
```
This is a mandatory hard fork release that restores normal multi-input Spark spending following the temporary mitigation introduced in v0.14.17.2.

Wallet users, full-node and masternode operators, miners, exchanges, and service providers should upgrade to v0.14.18.0 before block 1,371,000 (approximately 4 September 2026, 10:00 UTC).
```