### PR TITLE
coinhistory: adjust backoff, use the backoff, prune old data, remove dead code

### DIFF
--- a/basicswap/basicswap.py
+++ b/basicswap/basicswap.py
@@ -16886,7 +16886,15 @@ class BasicSwap(BaseApp, BSXNetwork, UIApp):
 
             for coin_id, price_data in new_values.items():
                 cursor.execute(
-                    "INSERT OR REPLACE INTO coinhistory (coin_id, days, price_data, source, last_updated) VALUES (:coin_id, :days, :price_data, :rate_source, :last_updated)",
+                    "DELETE FROM coinhistory WHERE coin_id = :coin_id AND days = :days AND source = :rate_source",
+                    {
+                        "coin_id": coin_id,
+                        "days": days,
+                        "rate_source": rate_source,
+                    },
+                )
+                cursor.execute(
+                    "INSERT INTO coinhistory (coin_id, days, price_data, source, last_updated) VALUES (:coin_id, :days, :price_data, :rate_source, :last_updated)",
                     {
                         "coin_id": coin_id,
                         "days": days,

--- a/basicswap/basicswap.py
+++ b/basicswap/basicswap.py
@@ -540,7 +540,6 @@ class BasicSwap(BaseApp, BSXNetwork, UIApp):
         self._tx_cache = {}
         self._price_cache = {}
         self._volume_cache = {}
-        self._historical_cache = {}
         self._pending_bid_notifications = set()
         self._price_cache_lock = threading.Lock()
         self._rate_limit_backoff_until = 0
@@ -548,12 +547,8 @@ class BasicSwap(BaseApp, BSXNetwork, UIApp):
         self._price_fetch_thread = None
         self._price_fetch_running = False
         self._last_price_fetch = 0
-        self._last_volume_fetch = 0
         self.price_fetch_interval = self.get_int_setting(
             "price_fetch_interval", 5 * 60, 60, 60 * 60
-        )
-        self.volume_fetch_interval = self.get_int_setting(
-            "volume_fetch_interval", 5 * 60, 60, 60 * 60
         )
 
         self._max_transient_errors = self.settings.get(
@@ -16522,7 +16517,6 @@ class BasicSwap(BaseApp, BSXNetwork, UIApp):
                     try:
                         self._fetchPricesAndVolumeBackground()
                         self._last_price_fetch = now
-                        self._last_volume_fetch = now
                         self.clearRateSourceBackoff()
                     except Exception as e:
                         if self.isRateLimitError(e):
@@ -16549,177 +16543,6 @@ class BasicSwap(BaseApp, BSXNetwork, UIApp):
 
         for rate_source in ["coingecko.com"]:
             self._fetchPricesAndVolumeForSource(all_coins, rate_source, Fiat.USD)
-
-    def _fetchPricesBackground(self):
-        all_coins = [c for c in Coins if c in chainparams]
-        if not all_coins:
-            return
-
-        for rate_source in ["coingecko.com"]:
-            try:
-                self._fetchPricesForSource(all_coins, rate_source, Fiat.USD)
-            except Exception as e:
-                self.log.warning(
-                    f"Background price fetch from {rate_source} failed: {e}"
-                )
-
-    def _fetchVolumeBackground(self):
-        all_coins = [c for c in Coins if c in chainparams]
-        if not all_coins:
-            return
-
-        for rate_source in ["coingecko.com"]:
-            try:
-                self._fetchVolumeForSource(all_coins, rate_source)
-            except Exception as e:
-                self.log.warning(
-                    f"Background volume fetch from {rate_source} failed: {e}"
-                )
-
-    def _fetchPricesForSource(self, coins_list, rate_source, currency_to):
-        now = int(time.time())
-        headers = {"User-Agent": "Mozilla/5.0", "Connection": "close"}
-
-        exchange_name_map = {}
-        coin_ids = ""
-        for coin_id in coins_list:
-            if len(coin_ids) > 0:
-                coin_ids += ","
-            exchange_name = self.getExchangeName(coin_id, rate_source)
-            coin_ids += exchange_name
-            exchange_name_map[exchange_name] = coin_id
-
-        if rate_source == "coingecko.com":
-            ticker_to = fiatTicker(currency_to).lower()
-            api_key = get_api_key_setting(
-                self.settings,
-                "coingecko_api_key",
-                default_coingecko_api_key,
-                escape=True,
-            )
-            url = f"https://api.coingecko.com/api/v3/simple/price?ids={coin_ids}&vs_currencies={ticker_to}"
-            if api_key != "":
-                url += f"&api_key={api_key}"
-
-            js = json.loads(self.readURL(url, timeout=3, headers=headers))
-
-            with self._price_cache_lock:
-                for k, v in js.items():
-                    coin_id = exchange_name_map[k]
-                    cache_key = (coin_id, currency_to, rate_source)
-                    self._price_cache[cache_key] = {
-                        "rate": v[ticker_to],
-                        "timestamp": now,
-                    }
-
-            cursor = self.openDB()
-            try:
-                update_query = """
-                    UPDATE coinrates SET
-                        rate=:rate,
-                        last_updated=:last_updated
-                    WHERE currency_from = :currency_from AND currency_to = :currency_to AND source = :rate_source
-                    """
-
-                insert_query = """INSERT INTO coinrates(currency_from, currency_to, rate, source, last_updated)
-                        VALUES(:currency_from, :currency_to, :rate, :rate_source, :last_updated)"""
-
-                for k, v in js.items():
-                    coin_id = exchange_name_map[k]
-                    cursor.execute(
-                        update_query,
-                        {
-                            "currency_from": coin_id,
-                            "currency_to": currency_to,
-                            "rate": v[ticker_to],
-                            "rate_source": rate_source,
-                            "last_updated": now,
-                        },
-                    )
-                    if cursor.rowcount < 1:
-                        cursor.execute(
-                            insert_query,
-                            {
-                                "currency_from": coin_id,
-                                "currency_to": currency_to,
-                                "rate": v[ticker_to],
-                                "rate_source": rate_source,
-                                "last_updated": now,
-                            },
-                        )
-                self.commitDB()
-            finally:
-                self.closeDB(cursor, commit=False)
-
-    def _fetchVolumeForSource(self, coins_list, rate_source):
-        now = int(time.time())
-        headers = {"User-Agent": "Mozilla/5.0", "Connection": "close"}
-
-        exchange_name_map = {}
-        coin_ids = ""
-        for coin_id in coins_list:
-            if len(coin_ids) > 0:
-                coin_ids += ","
-            exchange_name = self.getExchangeName(coin_id, rate_source)
-            coin_ids += exchange_name
-            exchange_name_map[exchange_name] = coin_id
-
-        if rate_source == "coingecko.com":
-            api_key = get_api_key_setting(
-                self.settings,
-                "coingecko_api_key",
-                default_coingecko_api_key,
-                escape=True,
-            )
-            url = f"https://api.coingecko.com/api/v3/simple/price?ids={coin_ids}&vs_currencies=usd&include_24hr_vol=true&include_24hr_change=true"
-            if api_key != "":
-                url += f"&api_key={api_key}"
-
-            js = json.loads(self.readURL(url, timeout=3, headers=headers))
-
-            with self._price_cache_lock:
-                for k, v in js.items():
-                    coin_id = exchange_name_map[k]
-                    cache_key = (coin_id, rate_source)
-                    volume_24h = v.get("usd_24h_vol")
-                    price_change_24h = v.get("usd_24h_change")
-                    self._volume_cache[cache_key] = {
-                        "volume_24h": (
-                            float(volume_24h) if volume_24h is not None else None
-                        ),
-                        "price_change_24h": (
-                            float(price_change_24h)
-                            if price_change_24h is not None
-                            else 0.0
-                        ),
-                        "timestamp": now,
-                    }
-
-            cursor = self.openDB()
-            try:
-                for k, v in js.items():
-                    coin_id = exchange_name_map[k]
-                    volume_24h = v.get("usd_24h_vol")
-                    price_change_24h = v.get("usd_24h_change")
-                    cursor.execute(
-                        "INSERT OR REPLACE INTO coinvolume (coin_id, volume_24h, price_change_24h, source, last_updated) VALUES (:coin_id, :volume_24h, :price_change_24h, :rate_source, :last_updated)",
-                        {
-                            "coin_id": coin_id,
-                            "volume_24h": (
-                                str(volume_24h) if volume_24h is not None else "None"
-                            ),
-                            "price_change_24h": (
-                                str(price_change_24h)
-                                if price_change_24h is not None
-                                else "0.0"
-                            ),
-                            "rate_source": rate_source,
-                            "last_updated": now,
-                        },
-                    )
-                self.commitDB()
-            finally:
-                self.closeDB(cursor, commit=False)
 
     def _fetchPricesAndVolumeForSource(self, coins_list, rate_source, currency_to):
         now = int(time.time())

--- a/basicswap/basicswap.py
+++ b/basicswap/basicswap.py
@@ -543,6 +543,8 @@ class BasicSwap(BaseApp, BSXNetwork, UIApp):
         self._historical_cache = {}
         self._pending_bid_notifications = set()
         self._price_cache_lock = threading.Lock()
+        self._rate_limit_backoff_until = 0
+        self._rate_limit_backoff_step = 1
         self._price_fetch_thread = None
         self._price_fetch_running = False
         self._last_price_fetch = 0
@@ -16483,16 +16485,34 @@ class BasicSwap(BaseApp, BSXNetwork, UIApp):
 
         return chainparams[use_coinid]["name"]
 
-    def _backgroundPriceFetchLoop(self):
-        backoff_until = 0
-        backoff_multiplier = 1
+    def isRateLimitError(self, e) -> bool:
+        error_str = str(e)
+        return "429" in error_str or "Too Many Requests" in error_str
 
+    def rateSourceBackoffRemaining(self) -> int:
+        with self._price_cache_lock:
+            return max(0, self._rate_limit_backoff_until - int(time.time()))
+
+    def noteRateSourceLimited(self) -> int:
+        with self._price_cache_lock:
+            backoff_seconds: int = min(20 * self._rate_limit_backoff_step, 120)
+            self._rate_limit_backoff_until = int(time.time()) + backoff_seconds
+            self._rate_limit_backoff_step = min(self._rate_limit_backoff_step + 1, 6)
+        return backoff_seconds
+
+    def clearRateSourceBackoff(self) -> None:
+        with self._price_cache_lock:
+            self._rate_limit_backoff_until = 0
+            self._rate_limit_backoff_step = 1
+
+    def _backgroundPriceFetchLoop(self):
         while self._price_fetch_running:
             try:
                 now = int(time.time())
 
-                if now < backoff_until:
-                    for _ in range(60):
+                backoff_remaining: int = self.rateSourceBackoffRemaining()
+                if backoff_remaining > 0:
+                    for _ in range(backoff_remaining):
                         if not self._price_fetch_running:
                             break
                         time.sleep(1)
@@ -16503,13 +16523,10 @@ class BasicSwap(BaseApp, BSXNetwork, UIApp):
                         self._fetchPricesAndVolumeBackground()
                         self._last_price_fetch = now
                         self._last_volume_fetch = now
-                        backoff_multiplier = 1
+                        self.clearRateSourceBackoff()
                     except Exception as e:
-                        error_str = str(e)
-                        if "429" in error_str or "Too Many Requests" in error_str:
-                            backoff_seconds = min(120 * backoff_multiplier, 960)
-                            backoff_until = now + backoff_seconds
-                            backoff_multiplier = min(backoff_multiplier * 2, 8)
+                        if self.isRateLimitError(e):
+                            backoff_seconds: int = self.noteRateSourceLimited()
                             self.log.warning(
                                 f"CoinGecko rate limited, backing off for {backoff_seconds}s"
                             )
@@ -16992,6 +17009,15 @@ class BasicSwap(BaseApp, BSXNetwork, UIApp):
             if len(need_coins) < 1:
                 return return_data
 
+            backoff_remaining: int = self.rateSourceBackoffRemaining()
+            if backoff_remaining > 0:
+                self.log.debug(
+                    f"Skipping historical data fetch, rate limited for {backoff_remaining}s"
+                )
+                for coin_id in need_coins:
+                    return_data[coin_id] = []
+                return return_data
+
             if rate_source == "coingecko.com":
                 api_key: str = get_api_key_setting(
                     self.settings,
@@ -17014,11 +17040,21 @@ class BasicSwap(BaseApp, BSXNetwork, UIApp):
                         if "prices" in js:
                             return_data[coin_id] = js["prices"]
                             new_values[coin_id] = js["prices"]
+                        self.clearRateSourceBackoff()
                     except Exception as e:
                         self.log.warning(
                             f"Could not fetch historical data for {Coins(coin_id).name}: {e}"
                         )
                         return_data[coin_id] = []
+                        if self.isRateLimitError(e):
+                            backoff_seconds: int = self.noteRateSourceLimited()
+                            self.log.warning(
+                                f"CoinGecko rate limited, backing off for {backoff_seconds}s"
+                            )
+                            for remaining_id in need_coins:
+                                if remaining_id not in return_data:
+                                    return_data[remaining_id] = []
+                            break
             else:
                 raise ValueError(f"Unknown rate source {rate_source}")
 

--- a/basicswap/basicswap.py
+++ b/basicswap/basicswap.py
@@ -16636,7 +16636,14 @@ class BasicSwap(BaseApp, BSXNetwork, UIApp):
                     volume_24h = v.get(f"{ticker_to}_24h_vol")
                     price_change_24h = v.get(f"{ticker_to}_24h_change")
                     cursor.execute(
-                        "INSERT OR REPLACE INTO coinvolume (coin_id, volume_24h, price_change_24h, source, last_updated) VALUES (:coin_id, :volume_24h, :price_change_24h, :rate_source, :last_updated)",
+                        "DELETE FROM coinvolume WHERE coin_id = :coin_id AND source = :rate_source",
+                        {
+                            "coin_id": coin_id,
+                            "rate_source": rate_source,
+                        },
+                    )
+                    cursor.execute(
+                        "INSERT INTO coinvolume (coin_id, volume_24h, price_change_24h, source, last_updated) VALUES (:coin_id, :volume_24h, :price_change_24h, :rate_source, :last_updated)",
                         {
                             "coin_id": coin_id,
                             "volume_24h": (


### PR DESCRIPTION
- Changed backoff from 120s * tries to 960s ceiling -> 20s * tries to 120s ceiling
-  fixed bugs where lookupHistoricalData ignoted the backoff and walked through the coins anyway
-  historical data appended rows indefinitely, but we only ever consult the most recent one. The third commit here trims the older rows
- fourth commit does the same trim, but fir coinvolume (my db had 847k rows of old coinvolume data)