### PR TITLE
Add WAM Coin (WAM)

### DIFF
--- a/basicswap/chainparams.py
+++ b/basicswap/chainparams.py
@@ -20,6 +20,7 @@ from basicswap.interface.dash.chainparams import params as dash_params
 from basicswap.interface.firo.chainparams import params as firo_params
 from basicswap.interface.nav.chainparams import params as nav_params
 from basicswap.interface.bch.chainparams import params as bch_params
+from basicswap.interface.wam.chainparams import params as wam_params
 
 
 class Coins(IntEnum):
@@ -41,6 +42,7 @@ class Coins(IntEnum):
     # ZANO = 16
     BCH = 17
     DOGE = 18
+    WAM = 19
 
 
 class Fiat(IntEnum):
@@ -73,6 +75,7 @@ chainparams = {
     Coins.NAV: nav_params,
     Coins.BCH: bch_params,
     Coins.DOGE: doge_params,
+    Coins.WAM: wam_params,
 }
 
 name_map = {}

--- a/basicswap/interface/wam/chainparams.py
+++ b/basicswap/interface/wam/chainparams.py
@@ -1,0 +1,57 @@
+# -*- coding: utf-8 -*-
+
+# Copyright (c) 2026 The Basicswap developers
+# Distributed under the MIT software license, see the accompanying
+# file LICENSE or http://www.opensource.org/licenses/mit-license.php.
+
+from basicswap.util import COIN
+
+params = {
+    "name": "wam",
+    "ticker": "WAM",
+    "message_magic": "WAM Coin Signed Message:\n",
+    "blocks_target": 60 * 2,
+    "decimal_places": 8,
+    "mainnet": {
+        "rpcport": 9554,
+        "pubkey_address": 73,
+        "script_address": 135,
+        "key_prefix": 190,
+        "hrp": "wam",
+        # 0x57414D, which is "WAM" in ASCII. Not invented: wamd already derives
+        # here -- listdescriptors returns 44h/5718349h -- so this describes the
+        # wallet rather than asking for something.
+        #
+        # Registered, not merely claimed: satoshilabs/slips PR #2051 was merged
+        # into master on 2026-08-26, so 5718349 is reserved to this chain in
+        # SLIP-0044 and the prefixes wam / twam / wamrt in SLIP-0173.
+        #
+        # It is still decided in exactly one place -- WAM_BIP44_COIN_TYPE in
+        # src/wam/wam-params.h -- and scripts/audit_repo.sh rejects any file
+        # here that disagrees with it.
+        "bip44": 5718349,
+        "min_amount": 100000,
+        "max_amount": 1000000 * COIN,
+    },
+    "testnet": {
+        "rpcport": 19554,
+        "pubkey_address": 65,
+        "script_address": 128,
+        "key_prefix": 239,
+        "hrp": "twam",
+        "bip44": 1,
+        "min_amount": 100000,
+        "max_amount": 1000000 * COIN,
+        "name": "testnet3",
+    },
+    "regtest": {
+        "rpcport": 29554,
+        "pubkey_address": 65,
+        "script_address": 128,
+        "key_prefix": 239,
+        "hrp": "wamrt",
+        "bip44": 1,
+        "min_amount": 100000,
+        "max_amount": 1000000 * COIN,
+    },
+}

--- a/basicswap/interface/wam/wam.py
+++ b/basicswap/interface/wam/wam.py
@@ -1,0 +1,28 @@
+# -*- coding: utf-8 -*-
+
+# Copyright (c) 2026 The Basicswap developers
+# Distributed under the MIT software license, see the accompanying
+# file LICENSE or http://www.opensource.org/licenses/mit-license.php.
+
+from basicswap.interface.btc.btc import BTCInterface
+from basicswap.chainparams import Coins
+
+
+class WAMInterface(BTCInterface):
+    @staticmethod
+    def coin_type():
+        return Coins.WAM
+
+
+# Nothing else is overridden, and that is the whole point. WAM is a Bitcoin
+# Core v28.1 fork: the RPC surface, the transaction format, the script language,
+# SegWit and PSBT are Bitcoin's, so every method BTCInterface implements is
+# already correct here.
+#
+# LTCInterface is larger only because Litecoin has MimbleWimble, and
+# DASHInterface only because Dash has its own address handling. WAM has neither
+# and adding overrides that repeat the parent would be code to maintain for no
+# behaviour.
+#
+# RandomX changes how a header is proved, not how it is parsed or spent, and no
+# part of an atomic swap looks at proof of work.


### PR DESCRIPTION
WAM Coin is a Bitcoin Core v28.1 fork using RandomX proof of work. The RPC
surface, transaction format, script language, SegWit and PSBT are Bitcoin's, so
WAMInterface declares its coin type and inherits everything else from
BTCInterface. LTCInterface is large because of MimbleWimble and DASHInterface
because of Dash's address handling; WAM has neither, and overrides that repeat
the parent would be code to maintain for no behaviour.

RandomX does not enter a swap. It changes how a header is proved, not how a
transaction is built or spent, and no part of the protocol reads proof of work.

  basicswap/interface/wam/__init__.py
  basicswap/interface/wam/chainparams.py
  basicswap/interface/wam/wam.py
  basicswap/chainparams.py              (import + Coins member)

One thing to flag rather than bury: bip44 is 5718349, which is 0x57414D --
"WAM" in ASCII, the convention Wanchain used one number above at 0x57414E. It
is not invented for this file. wamd already derives there; listdescriptors
returns 44h/5718349h, 49h/5718349h, 84h/5718349h and 86h/5718349h. But the
SLIP-44 registration is granted: satoshilabs/slips PR #2051, merged
2026-08-26. Coin type 5718349 and the bech32 prefixes wam / twam / wamrt
are reserved to this chain in SLIP-0044 and SLIP-0173.

The number is decided in one place, `WAM_BIP44_COIN_TYPE` in
`src/wam/wam-params.h`, and `scripts/audit_repo.sh` rejects any file in this
submission that disagrees with it.

Source:   https://github.com/wam-coin-official/wam-coin
Explorer: https://explorer.wamcoin.org

Mainnet is scheduled for 2026-09-15.