### PR TITLE
refactor: don't send swipe output to a wallet key when altruistic

### DIFF
--- a/basicswap/basicswap.py
+++ b/basicswap/basicswap.py
@@ -3607,6 +3607,11 @@ class BasicSwap(BaseApp, BSXNetwork, UIApp):
         if cursor is None:
             self.saveBid(bid.bid_id, bid)
 
+        # TODO: Remove with the rest of the pre KA_SWIPE compatibility.
+        reverse_bid: bool = self.is_reverse_ads_bid(offer.coin_from, offer.coin_to)
+        ci_from = self.ci(offer.coin_to if reverse_bid else offer.coin_from)
+        self._unlockMercyPrevout(ci_from, bid, cursor)
+
         # Remove any watched outputs
         self.removeWatchedOutput(Coins(offer.coin_from), bid.bid_id, None)
         self.removeWatchedOutput(Coins(offer.coin_to), bid.bid_id, None)
@@ -9160,6 +9165,38 @@ class BasicSwap(BaseApp, BSXNetwork, UIApp):
         bid.setState(BidStates.XMR_SWAP_FAILED_SWIPED)
         return True
 
+    # TODO: Remove with the rest of the pre KA_SWIPE compatibility.  Only bids
+    # whose swipe pays a pooled address still need the payout kept out of coin
+    # selection until the mercy tx has spent it.
+    def _lockMercyPrevout(self, ci_from, bid, cursor) -> None:
+        # Locks are held in memory by the daemon and expire on the electrum
+        # backend, so this is re-asserted for as long as the mercy tx is owed
+        swipe_tx = bid.txns.get(TxTypes.XMR_SWAP_A_LOCK_REFUND_SWIPE, None)
+        if swipe_tx is None:
+            return
+        try:
+            txid_hex: str = swipe_tx.txid.hex()
+            ci_from.lockOutput(
+                txid_hex,
+                ci_from.getMercyPrevout(txid_hex),
+                bid_id=bid.bid_id,
+                cursor=cursor,
+            )
+        except Exception as e:
+            self.log.debug(f"Locking mercy prevout failed: {e}")
+
+    def _unlockMercyPrevout(self, ci_from, bid, cursor) -> None:
+        swipe_tx = bid.txns.get(TxTypes.XMR_SWAP_A_LOCK_REFUND_SWIPE, None)
+        if swipe_tx is None:
+            return
+        try:
+            txid_hex: str = swipe_tx.txid.hex()
+            ci_from.unlockOutput(
+                txid_hex, ci_from.getMercyPrevout(txid_hex), cursor=cursor
+            )
+        except Exception as e:
+            self.log.debug(f"Unlocking mercy prevout failed: {e}")
+
     def _checkMercySend(self, ci_from, bid, cursor) -> bool:
         # Returns True if the bid state changed
         swipe_tx = bid.txns.get(TxTypes.XMR_SWAP_A_LOCK_REFUND_SWIPE, None)
@@ -9180,6 +9217,8 @@ class BasicSwap(BaseApp, BSXNetwork, UIApp):
             self.logBidEvent(
                 bid.bid_id, EventLogTypes.MERCY_TX_NOT_SENT, give_up_reason, cursor
             )
+            # TODO: Remove with the rest of the pre KA_SWIPE compatibility.
+            self._unlockMercyPrevout(ci_from, bid, cursor)
             bid.setState(BidStates.XMR_SWAP_FAILED_SWIPED)
             return True
 
@@ -13704,6 +13743,8 @@ class BasicSwap(BaseApp, BSXNetwork, UIApp):
             self.logBidEvent(
                 bid_id, EventLogTypes.MERCY_TX_NOT_SENT, skip_reason, cursor
             )
+            # TODO: Remove with the rest of the pre KA_SWIPE compatibility.
+            self._unlockMercyPrevout(ci_from, bid, cursor)
             bid.setState(BidStates.XMR_SWAP_FAILED_SWIPED)
             self.saveBidInSession(bid_id, bid, cursor, xmr_swap, save_in_progress=offer)
             return
@@ -13752,14 +13793,28 @@ class BasicSwap(BaseApp, BSXNetwork, UIApp):
             xmr_swap.contract_count,
             KeyTypes.KA_SWIPE,
         )
-        # A no-op where the mercy tx is signed with ka_swipe directly.
-        ci_from.prepareMercySpend(ka_swipe, swipe_out["block_height"])
 
-        # The swipe paid a key derived for the swap, so the mercy tx is also what
-        # moves the coin into the wallet.
-        addr_to: str = self.getReceiveAddressFromPool(
-            coin_from, bid_id, TxTypes.XMR_SWAP_A_LOCK_REFUND_SWIPE, cursor
-        )
+        # TODO: Remove.  A swipe built before the payout moved to a swap derived
+        # key pays a pooled address, so the wallet signs the mercy tx and holds
+        # the prevout lock, as it did then.
+        addr_to = None
+        if not ci_from.swipePaysKey(
+            xmr_swap.a_lock_refund_swipe_tx, swipe_tx.txid.hex(), ka_swipe
+        ):
+            self.log.debug(
+                f"Bid {self.log.id(bid_id)}: swipe pays the wallet, signing the mercy tx with it."
+            )
+            self._lockMercyPrevout(ci_from, bid, cursor)
+            ka_swipe = None
+        else:
+            # A no-op where the mercy tx is signed with ka_swipe directly.
+            ci_from.prepareMercySpend(ka_swipe, swipe_out["block_height"])
+
+            # The swipe paid a key derived for the swap, so the mercy tx is also
+            # what moves the coin into the wallet.
+            addr_to = self.getReceiveAddressFromPool(
+                coin_from, bid_id, TxTypes.XMR_SWAP_A_LOCK_REFUND_SWIPE, cursor
+            )
 
         a_fee_rate: int = xmr_offer.b_fee_rate if reverse_bid else xmr_offer.a_fee_rate
         mercy_tx = ci_from.createMercyTx(

--- a/basicswap/basicswap.py
+++ b/basicswap/basicswap.py
@@ -3607,11 +3607,6 @@ class BasicSwap(BaseApp, BSXNetwork, UIApp):
         if cursor is None:
             self.saveBid(bid.bid_id, bid)
 
-        # Remove locked mercy outputs
-        reverse_bid: bool = self.is_reverse_ads_bid(offer.coin_from, offer.coin_to)
-        ci_from = self.ci(offer.coin_to if reverse_bid else offer.coin_from)
-        self._unlockMercyPrevout(ci_from, bid, cursor)
-
         # Remove any watched outputs
         self.removeWatchedOutput(Coins(offer.coin_from), bid.bid_id, None)
         self.removeWatchedOutput(Coins(offer.coin_to), bid.bid_id, None)
@@ -8540,9 +8535,8 @@ class BasicSwap(BaseApp, BSXNetwork, UIApp):
                                 chain_height=ci_from.getChainHeight(),
                             )
                             if ci_from.altruistic() and ci_from.canSendMercyTx():
-                                # The mercy tx spends this output, keep it out of
-                                # coin selection until it has been sent
-                                self._lockMercyPrevout(ci_from, bid, cursor)
+                                # No prevout lock: the swipe paid a key derived for
+                                # the swap, which the wallet cannot select from.
                                 delay = self.get_delay_event_seconds()
                                 self.log.info(
                                     f"Queuing mercy tx for bid {self.log.id(bid_id)} in {delay} seconds."
@@ -9166,35 +9160,6 @@ class BasicSwap(BaseApp, BSXNetwork, UIApp):
         bid.setState(BidStates.XMR_SWAP_FAILED_SWIPED)
         return True
 
-    def _lockMercyPrevout(self, ci_from, bid, cursor) -> None:
-        # Locks are held in memory by the daemon and expire on the electrum
-        # backend, so this is re-asserted for as long as the mercy tx is owed
-        swipe_tx = bid.txns.get(TxTypes.XMR_SWAP_A_LOCK_REFUND_SWIPE, None)
-        if swipe_tx is None:
-            return
-        try:
-            txid_hex: str = swipe_tx.txid.hex()
-            ci_from.lockOutput(
-                txid_hex,
-                ci_from.getMercyPrevout(txid_hex),
-                bid_id=bid.bid_id,
-                cursor=cursor,
-            )
-        except Exception as e:
-            self.log.debug(f"Locking mercy prevout failed: {e}")
-
-    def _unlockMercyPrevout(self, ci_from, bid, cursor) -> None:
-        swipe_tx = bid.txns.get(TxTypes.XMR_SWAP_A_LOCK_REFUND_SWIPE, None)
-        if swipe_tx is None:
-            return
-        try:
-            txid_hex: str = swipe_tx.txid.hex()
-            ci_from.unlockOutput(
-                txid_hex, ci_from.getMercyPrevout(txid_hex), cursor=cursor
-            )
-        except Exception as e:
-            self.log.debug(f"Unlocking mercy prevout failed: {e}")
-
     def _checkMercySend(self, ci_from, bid, cursor) -> bool:
         # Returns True if the bid state changed
         swipe_tx = bid.txns.get(TxTypes.XMR_SWAP_A_LOCK_REFUND_SWIPE, None)
@@ -9215,7 +9180,6 @@ class BasicSwap(BaseApp, BSXNetwork, UIApp):
             self.logBidEvent(
                 bid.bid_id, EventLogTypes.MERCY_TX_NOT_SENT, give_up_reason, cursor
             )
-            self._unlockMercyPrevout(ci_from, bid, cursor)
             bid.setState(BidStates.XMR_SWAP_FAILED_SWIPED)
             return True
 
@@ -13740,7 +13704,6 @@ class BasicSwap(BaseApp, BSXNetwork, UIApp):
             self.logBidEvent(
                 bid_id, EventLogTypes.MERCY_TX_NOT_SENT, skip_reason, cursor
             )
-            self._unlockMercyPrevout(ci_from, bid, cursor)
             bid.setState(BidStates.XMR_SWAP_FAILED_SWIPED)
             self.saveBidInSession(bid_id, bid, cursor, xmr_swap, save_in_progress=offer)
             return
@@ -13748,14 +13711,23 @@ class BasicSwap(BaseApp, BSXNetwork, UIApp):
         swipe_tx = bid.txns.get(TxTypes.XMR_SWAP_A_LOCK_REFUND_SWIPE)
         ensure(swipe_tx, f"Swipe tx not found for bid {self.log.id(bid_id)}.")
 
-        # Retried here until the swipe confirms, covering a wallet that hadn't
-        # picked the output up when the lock was first taken
-        self._lockMercyPrevout(ci_from, bid, cursor)
-
-        found_tx = ci_from.findConfirmedTxnByHash(swipe_tx.txid.hex())
-        if found_tx is None:
+        # The keyshare must not go out while the swipe can still be replaced: a
+        # leader whose refund spend wins that race would take both legs.  Read
+        # from the utxo set rather than the wallet, which does not hold the
+        # derived swipe payout.
+        # Any output of the swipe carries its depth.  Not getMercyPrevout: that
+        # picks the output the wallet owns, and it does not own this one yet.
+        swipe_n: int = ci_from.getMercyWatchVouts(swipe_tx.txid.hex())[0]
+        swipe_out = ci_from.getTxOutInfo(swipe_tx.txid, swipe_n)
+        swipe_depth: int = (
+            0
+            if swipe_out is None
+            else ci_from.getChainHeight() - swipe_out["block_height"] + 1
+        )
+        if swipe_depth < ci_from.blocks_confirmed:
             raise TemporaryError(
-                f"Swipe tx not yet confirmed for bid {self.log.id(bid_id)}."
+                f"Swipe tx not yet confirmed for bid {self.log.id(bid_id)}, "
+                f"depth {swipe_depth}."
             )
 
         ci_to = self.ci(coin_to)
@@ -13773,6 +13745,22 @@ class BasicSwap(BaseApp, BSXNetwork, UIApp):
             self.log.debug(f"Bid {self.log.id(bid_id)}: Sending an invalid keyshare.")
             kbsf = ci_to.getNewRandomKey()
 
+        ka_swipe = self.getPathKey(
+            coin_from,
+            coin_to,
+            bid.created_at,
+            xmr_swap.contract_count,
+            KeyTypes.KA_SWIPE,
+        )
+        # A no-op where the mercy tx is signed with ka_swipe directly.
+        ci_from.prepareMercySpend(ka_swipe, swipe_out["block_height"])
+
+        # The swipe paid a key derived for the swap, so the mercy tx is also what
+        # moves the coin into the wallet.
+        addr_to: str = self.getReceiveAddressFromPool(
+            coin_from, bid_id, TxTypes.XMR_SWAP_A_LOCK_REFUND_SWIPE, cursor
+        )
+
         a_fee_rate: int = xmr_offer.b_fee_rate if reverse_bid else xmr_offer.a_fee_rate
         mercy_tx = ci_from.createMercyTx(
             xmr_swap.a_lock_refund_swipe_tx,
@@ -13780,6 +13768,8 @@ class BasicSwap(BaseApp, BSXNetwork, UIApp):
             xmr_swap.a_lock_refund_tx_script,
             kbsf,
             a_fee_rate,
+            ka_swipe,
+            addr_to,
         )
         txid_hex: str = ci_from.publishTx(mercy_tx)
         bid.txns[TxTypes.MERCY] = SwapTx(
@@ -15794,6 +15784,9 @@ class BasicSwap(BaseApp, BSXNetwork, UIApp):
                 )
                 rv["blind_balance"] = walletinfo["blind_balance"]
                 rv["blind_unconfirmed"] = walletinfo["unconfirmed_blind"]
+                # Coinstake outputs still maturing.  Held apart from immature,
+                # which only counts coinbase credit.
+                rv["staked"] = walletinfo.get("staked_balance", 0)
             elif coin in self.xmr_based_coins:
                 rv["main_address"] = self.getCachedMainWalletAddress(ci)
             elif coin == Coins.NAV:
@@ -16722,13 +16715,29 @@ class BasicSwap(BaseApp, BSXNetwork, UIApp):
         coin_from = Coins(offer.coin_to if reverse_bid else offer.coin_from)
         coin_to = Coins(offer.coin_from if reverse_bid else offer.coin_to)
 
-        pkh_dest = ci.decodeAddress(self.getReceiveAddressForCoin(ci.coin_type()))
+        pubkey_dest = None
+        if ci.altruistic() and ci.canSendMercyTx():
+            # Derived per swap rather than taken from the address pool: the mercy
+            # tx spends this output, and a pooled address is one the coin wallet
+            # could spend first.
+            ka_swipe = self.getPathKey(
+                coin_from,
+                coin_to,
+                bid.created_at,
+                xmr_swap.contract_count,
+                KeyTypes.KA_SWIPE,
+            )
+            pubkey_dest = ci.getPubkey(ka_swipe)
+            pkh_dest = ci.pkh(pubkey_dest)
+        else:
+            pkh_dest = ci.decodeAddress(self.getReceiveAddressForCoin(ci.coin_type()))
         spend_tx = ci.createSCLockRefundSpendToFTx(
             xmr_swap.a_lock_refund_tx,
             xmr_swap.a_lock_refund_tx_script,
             pkh_dest,
             a_fee_rate,
             xmr_swap.vkbv,
+            pubkey_dest,
         )
 
         vkaf = self.getPathKey(

--- a/basicswap/basicswap_util.py
+++ b/basicswap/basicswap_util.py
@@ -39,6 +39,7 @@ class KeyTypes(IntEnum):
     KBVF = 4
     KBSF = 5
     KAF = 6
+    KA_SWIPE = 7
 
 
 class MessageNetworks(IntEnum):

--- a/basicswap/interface/base.py
+++ b/basicswap/interface/base.py
@@ -225,6 +225,14 @@ class CoinInterface:
         # swipe, that publishes it while the swipe can still be replaced.
         return False
 
+    def swipePaysKey(
+        self, swipe_tx_bytes: bytes, swipe_txid_hex: str, key: bytes
+    ) -> bool:
+        # TODO: Remove.  Bids whose swipe was built before the payout moved to a
+        # swap derived key pay a pooled address, and their mercy tx has to be
+        # signed by the wallet as it was then.
+        return True
+
     def prepareMercySpend(self, key: bytes, rescan_from: int) -> None:
         # Called before building the mercy tx, for coins that can only spend the
         # swipe payout through the wallet.  Nothing to do where the mercy tx is

--- a/basicswap/interface/base.py
+++ b/basicswap/interface/base.py
@@ -225,6 +225,12 @@ class CoinInterface:
         # swipe, that publishes it while the swipe can still be replaced.
         return False
 
+    def prepareMercySpend(self, key: bytes, rescan_from: int) -> None:
+        # Called before building the mercy tx, for coins that can only spend the
+        # swipe payout through the wallet.  Nothing to do where the mercy tx is
+        # signed with the key directly.
+        pass
+
     def getMercyWatchVouts(self, swipe_txid_hex: str, swipe_tx=None) -> List[int]:
         # Which outputs of the swipe a mercy tx could spend.  The leader has to
         # watch each one, it can't tell which the swiper will use.

--- a/basicswap/interface/bch/bch.py
+++ b/basicswap/interface/bch/bch.py
@@ -625,6 +625,7 @@ class BCHInterface(BTCInterface):
         pkh_dest,
         tx_fee_rate,
         vkbv=None,
+        pubkey_dest=None,
     ):
         # lock refund swipe tx
         # Sends the coinA locked coin to the follower
@@ -1189,6 +1190,17 @@ class BCHInterface(BTCInterface):
     def lockNonSegwitPrevouts(self) -> None:
         pass
 
+    def prepareMercySpend(self, key: bytes, rescan_from: int) -> None:
+        # The swipe paid a key derived for the swap.  Imported here rather than
+        # when the swipe was built, so the wallet cannot select the output until
+        # the mercy tx is the thing spending it.
+        addr: str = self.pkh_to_address(self.pkh(self.getPubkey(key)))
+        if self.rpc_wallet("getaddressinfo", [addr]).get("ismine", False):
+            return
+        self.rpc_wallet("importprivkey", [self.encodeKey(key), "swipe", False])
+        self._log.info(f"Rescanning {self.coin_name()} chain from {rescan_from}.")
+        self.rpc_wallet("rescanblockchain", [rescan_from])
+
     def createMercyTx(
         self,
         refund_swipe_tx_bytes: bytes,
@@ -1196,6 +1208,8 @@ class BCHInterface(BTCInterface):
         lock_refund_tx_script: bytes,
         keyshare: bytes,
         tx_fee_rate: int,
+        key: bytes | None = None,
+        addr_to: str | None = None,
     ) -> str:
         refund_swipe_tx = self.loadTx(refund_swipe_tx_bytes)
         refund_output_value = refund_swipe_tx.vout[0].nValue
@@ -1216,7 +1230,15 @@ class BCHInterface(BTCInterface):
         tx.vin.append(CTxIn(COutPoint(b2i(refund_swipe_tx_id), 0), nSequence=0))
 
         tx.vout.append(self.txoType()(0, CScript([OP_RETURN, b"XBSW", keyshare])))
-        tx.vout.append(self.txoType()(outValue, refund_output_script))
+        # Back to the same script by default, which is the wallet's own.  A swipe
+        # paid to a key derived for the swap has to name a destination instead,
+        # or the coin stays on a key the wallet knows nothing about.
+        dest_script: bytes = (
+            refund_output_script
+            if addr_to is None
+            else self.getScriptForPubkeyHash(self.decodeAddress(addr_to))
+        )
+        tx.vout.append(self.txoType()(outValue, dest_script))
 
         rate_used: int = pay_fee * 1000 // tx_size
 
@@ -1233,6 +1255,9 @@ class BCHInterface(BTCInterface):
         )
 
         txHex = tx.serialize_without_witness()
+        # No local signing branch for key: signTx here signs the whole tx for the
+        # introspection contracts and can't produce a p2pkh input signature.
+        # prepareMercySpend has handed the key to the wallet by this point.
         return self.signTxWithWallet(txHex)
 
     def haveSignedLockRefundTx(self, xmr_swap) -> bool:

--- a/basicswap/interface/btc/btc.py
+++ b/basicswap/interface/btc/btc.py
@@ -5044,6 +5044,14 @@ class BTCInterface(FeeValidator, Secp256k1Interface):
     def canSendMercyTx(self) -> bool:
         return True
 
+    def swipePaysKey(
+        self, swipe_tx_bytes: bytes, swipe_txid_hex: str, key: bytes
+    ) -> bool:
+        # TODO: Remove with the rest of the pre KA_SWIPE compatibility.
+        swipe_tx = self.loadTx(swipe_tx_bytes)
+        dest: bytes = self.getScriptForPubkeyHash(self.pkh(self.getPubkey(key)))
+        return bytes(swipe_tx.vout[0].scriptPubKey) == bytes(dest)
+
     def createMercyTx(
         self,
         refund_swipe_tx_bytes: bytes,

--- a/basicswap/interface/btc/btc.py
+++ b/basicswap/interface/btc/btc.py
@@ -1625,6 +1625,7 @@ class BTCInterface(FeeValidator, Secp256k1Interface):
         pkh_dest,
         tx_fee_rate,
         vkbv=None,
+        pubkey_dest=None,
     ):
         # Lock refund swipe tx
         # Sends the coinA locked coin to the follower
@@ -5050,6 +5051,8 @@ class BTCInterface(FeeValidator, Secp256k1Interface):
         lock_refund_tx_script: bytes,
         keyshare: bytes,
         tx_fee_rate: int,
+        key: bytes | None = None,
+        addr_to: str | None = None,
     ) -> bytes:
         # Hands the keyshare to the leader in a tx of its own, spending the
         # swipe's payout output.
@@ -5061,7 +5064,15 @@ class BTCInterface(FeeValidator, Secp256k1Interface):
         tx.nVersion = self.txVersion()
         tx.vin.append(CTxIn(COutPoint(b2i(refund_swipe_tx_id), 0)))
         tx.vout.append(self.txoType()(0, CScript([OP_RETURN, b"XBSW", keyshare])))
-        tx.vout.append(self.txoType()(0, prevout_script))
+        # Back to the same script by default, which is the wallet's own.  A swipe
+        # paid to a key derived for the swap has to name a destination instead,
+        # or the coin stays on a key the wallet knows nothing about.
+        dest_script: bytes = (
+            prevout_script
+            if addr_to is None
+            else self.getScriptForPubkeyHash(self.decodeAddress(addr_to))
+        )
+        tx.vout.append(self.txoType()(0, dest_script))
 
         witness_bytes: int = self.getWitnessStackSerialisedLength(
             self.getP2WPKHDummyWitness()
@@ -5086,7 +5097,24 @@ class BTCInterface(FeeValidator, Secp256k1Interface):
                 ),
             )
         )
-        return self.signTxWithWallet(tx.serialize())
+        if key is None:
+            # The swipe paid a pooled address the wallet holds
+            return self.signTxWithWallet(tx.serialize())
+
+        # A key derived for this swap instead, which the wallet does not hold, so
+        # nothing else can spend the output and it is signed here.
+        script_code = CScript(
+            [
+                OP_DUP,
+                OP_HASH160,
+                prevout_script[2:22],
+                OP_EQUALVERIFY,
+                OP_CHECKSIG,
+            ]
+        )
+        sig = self.signTx(key, tx.serialize(), 0, script_code, prevout_value)
+        pubkey: bytes = self.getPubkey(key)
+        return self.setTxSignature(tx.serialize(), [sig, pubkey])
 
     def extractMercyKeyshare(self, tx: dict) -> Optional[bytes]:
         # OP_RETURN, a 4 byte push of XBSW, then a 32 byte push of the keyshare

--- a/basicswap/interface/dcr/dcr.py
+++ b/basicswap/interface/dcr/dcr.py
@@ -1696,6 +1696,7 @@ class DCRInterface(FeeValidator, Secp256k1Interface):
         pkh_dest,
         tx_fee_rate,
         vkbv=None,
+        pubkey_dest=None,
     ):
         # lock refund swipe tx
         # Sends the coinA locked coin to the follower
@@ -1782,6 +1783,8 @@ class DCRInterface(FeeValidator, Secp256k1Interface):
         lock_refund_tx_script: bytes,
         keyshare: bytes,
         tx_fee_rate: int,
+        key: bytes | None = None,
+        addr_to: str | None = None,
     ) -> bytes:
         # Hands the keyshare to the leader in a tx of its own, spending the
         # swipe's payout output, so it can be held back until the swipe has
@@ -1798,7 +1801,15 @@ class DCRInterface(FeeValidator, Secp256k1Interface):
         push_script_data(mercy_script, b"XBSW")
         push_script_data(mercy_script, keyshare)
         tx.vout.append(self.txoType()(0, bytes(mercy_script)))
-        tx.vout.append(self.txoType()(0, prevout_script))
+        # Back to the same script by default, which is the wallet's own.  A swipe
+        # paid to a key derived for the swap has to name a destination instead,
+        # or the coin stays on a key the wallet knows nothing about.
+        dest_script: bytes = (
+            prevout_script
+            if addr_to is None
+            else self.getPubkeyHashDest(self.decodeAddress(addr_to))
+        )
+        tx.vout.append(self.txoType()(0, dest_script))
 
         # A p2pkh signature script: OP_DATA_73 <sig> OP_DATA_33 <pubkey>
         size: int = len(tx.serialize()) + 108
@@ -1818,9 +1829,16 @@ class DCRInterface(FeeValidator, Secp256k1Interface):
                 ),
             )
         )
-        # Full serialisation, NoWitness leaves signrawtransaction nowhere to
-        # write the signature script
-        return self.signTxWithWallet(tx.serialize())
+        if key is None:
+            # The swipe paid a pooled address the wallet holds.
+            # Full serialisation, NoWitness leaves signrawtransaction nowhere to
+            # write the signature script
+            return self.signTxWithWallet(tx.serialize())
+
+        # A key derived for this swap instead, which the wallet does not hold, so
+        # nothing else can spend the output and it is signed here.
+        sig = self.signTx(key, tx.serialize(), 0, prevout_script, prevout_value)
+        return self.setTxSignature(tx.serialize(), [sig, self.getPubkey(key)])
 
     def signTxOtVES(
         self,

--- a/basicswap/interface/dcr/dcr.py
+++ b/basicswap/interface/dcr/dcr.py
@@ -1776,6 +1776,14 @@ class DCRInterface(FeeValidator, Secp256k1Interface):
             if "expected unspent output" not in str(e):
                 raise
 
+    def swipePaysKey(
+        self, swipe_tx_bytes: bytes, swipe_txid_hex: str, key: bytes
+    ) -> bool:
+        # TODO: Remove with the rest of the pre KA_SWIPE compatibility.
+        swipe_tx = self.loadTx(swipe_tx_bytes)
+        dest: bytes = self.getPubkeyHashDest(self.pkh(self.getPubkey(key)))
+        return bytes(swipe_tx.vout[0].script_pubkey) == bytes(dest)
+
     def createMercyTx(
         self,
         refund_swipe_tx_bytes: bytes,

--- a/basicswap/interface/nav/nav.py
+++ b/basicswap/interface/nav/nav.py
@@ -939,6 +939,7 @@ class NAVInterface(BTCInterface):
         pkh_dest,
         tx_fee_rate,
         vkbv=None,
+        pubkey_dest=None,
     ):
         # lock refund swipe tx
         # Sends the coinA locked coin to the follower

--- a/basicswap/interface/part/part.py
+++ b/basicswap/interface/part/part.py
@@ -1050,6 +1050,18 @@ class PARTInterfaceBlind(PARTInterface):
                     self._log.debug(f"getaddressinfo {addr} failed: {e}")
         raise ValueError("Swipe payout output not found")
 
+    def prepareMercySpend(self, key: bytes, rescan_from: int) -> None:
+        # Spending a blind output needs its blinding factor, which the wallet
+        # derives once it holds the key.  Imported here rather than when the
+        # swipe was built, so the wallet cannot select the output until the
+        # mercy tx is the thing spending it.
+        addr: str = self.pkh_to_address(self.pkh(self.getPubkey(key)))
+        if self.rpc_wallet("getaddressinfo", [addr]).get("ismine", False):
+            return
+        self.rpc_wallet("importprivkey", [self.encodeKey(key), "swipe", False])
+        self._log.info(f"Rescanning {self.coin_name()} chain from {rescan_from}.")
+        self.rpc_wallet("rescanblockchain", [rescan_from])
+
     def createMercyTx(
         self,
         refund_swipe_tx_bytes: bytes,
@@ -1057,9 +1069,12 @@ class PARTInterfaceBlind(PARTInterface):
         lock_refund_tx_script: bytes,
         keyshare: bytes,
         tx_fee_rate: int,
+        key: bytes | None = None,
+        addr_to: str | None = None,
     ) -> bytes:
         # Hands the keyshare to the leader in a tx of its own, spending the
-        # swipe's payout output.
+        # swipe's payout output.  No local signing branch for key: a blind output
+        # is spent through the wallet, which prepareMercySpend has given the key.
         swipe_txid_hex: str = refund_swipe_tx_id.hex()
         swipe_tx = self.rpc("decoderawtransaction", [refund_swipe_tx_bytes.hex()])
 
@@ -1085,6 +1100,7 @@ class PARTInterfaceBlind(PARTInterface):
         pkh_dest,
         tx_fee_rate,
         vkbv,
+        pubkey_dest=None,
     ):
         # lock refund swipe tx
         # Sends the coinA locked coin to the follower
@@ -1099,8 +1115,12 @@ class PARTInterfaceBlind(PARTInterface):
 
         tx_lock_refund_id = lock_refund_tx_obj["txid"]
         addr_out = self.pkh_to_address(pkh_dest)
-        addr_info = self.rpc_wallet("getaddressinfo", [addr_out])
-        output_pubkey_hex = addr_info["pubkey"]
+        if pubkey_dest is None:
+            addr_info = self.rpc_wallet("getaddressinfo", [addr_out])
+            output_pubkey_hex = addr_info["pubkey"]
+        else:
+            # A key derived for the swap, which the wallet cannot look up
+            output_pubkey_hex = pubkey_dest.hex()
 
         A, B, lock2_value, C = extractScriptLockRefundScriptValues(script_lock_refund)
 

--- a/basicswap/interface/part/part.py
+++ b/basicswap/interface/part/part.py
@@ -1050,6 +1050,24 @@ class PARTInterfaceBlind(PARTInterface):
                     self._log.debug(f"getaddressinfo {addr} failed: {e}")
         raise ValueError("Swipe payout output not found")
 
+    def swipePaysKey(
+        self, swipe_tx_bytes: bytes, swipe_txid_hex: str, key: bytes
+    ) -> bool:
+        # TODO: Remove with the rest of the pre KA_SWIPE compatibility.
+        # A blind output hides its value, not its address.
+        addr_key: str = self.pkh_to_address(self.pkh(self.getPubkey(key)))
+        swipe_tx = self.rpc("decoderawtransaction", [swipe_tx_bytes.hex()])
+        for txo in swipe_tx["vout"]:
+            if txo["type"] != "blind":
+                continue
+            script_pubkey = txo.get("scriptPubKey", {})
+            addrs = list(script_pubkey.get("addresses", []))
+            if "address" in script_pubkey:
+                addrs.append(script_pubkey["address"])
+            if addr_key in addrs:
+                return True
+        return False
+
     def prepareMercySpend(self, key: bytes, rescan_from: int) -> None:
         # Spending a blind output needs its blinding factor, which the wallet
         # derives once it holds the key.  Imported here rather than when the

--- a/tests/basicswap/test_bch_xmr.py
+++ b/tests/basicswap/test_bch_xmr.py
@@ -210,6 +210,7 @@ class TestBCH(BasicSwapTest):
             "datadir": os.path.join(datadir, "bch_" + str(node_id)),
             "bindir": BITCOINCASH_BINDIR,
             "use_segwit": False,
+            "blocks_confirmed": 3,
             "wallet_name": "bsx_wallet",
         }
 

--- a/tests/basicswap/test_btc_xmr.py
+++ b/tests/basicswap/test_btc_xmr.py
@@ -98,12 +98,15 @@ class TestFunctions(BaseTest):
             coin_ticker: str = "PART"
             balance_type: str = "anon_balance"
             unconfirmed_name: str = "anon_pending"
-        elif coin == Coins.NAV:
+        elif coin in (Coins.NAV, Coins.PART):
+            # PART stakes during the tests, moving the staked output's whole
+            # value out of the spendable balance until the coinstake matures.
             coin_wallet = js_wallets[coin.name]
             return (
                 float(coin_wallet["balance"])
                 + float(coin_wallet["unconfirmed"])
-                + float(coin_wallet["immature"])
+                + float(coin_wallet.get("immature", 0.0))
+                + float(coin_wallet.get("staked", 0.0))
             )
         else:
             coin_ticker: str = coin.name

--- a/tests/basicswap/test_partblind_xmr.py
+++ b/tests/basicswap/test_partblind_xmr.py
@@ -388,7 +388,13 @@ class Test(BaseTest):
             test_delay_event,
             swap_clients[0],
             bid_id,
-            (BidStates.BID_STALLED_FOR_TEST, BidStates.XMR_SWAP_FAILED_SWIPED),
+            (
+                BidStates.BID_STALLED_FOR_TEST,
+                BidStates.XMR_SWAP_FAILED_SWIPED,
+                # The lock b tx above is invalid, so the mercy keyshare arrives
+                # with nothing to spend.
+                BidStates.XMR_SWAP_FAILED_SWIPED_MERCY_UNUSED,
+            ),
             wait_for=180,
         )
         wait_for_bid(

--- a/tests/basicswap/test_xmr.py
+++ b/tests/basicswap/test_xmr.py
@@ -168,6 +168,7 @@ def prepare_swapclient_dir(
                 "use_segwit": True,
                 "use_descriptors": BTC_USE_DESCRIPTORS,
                 "use_legacy_key_paths": BTC_USE_LEGACY_KEY_PATHS,
+                "blocks_confirmed": 3,
                 "wallet_name": "bsx_wallet",
             },
         },
@@ -213,6 +214,7 @@ def prepare_swapclient_dir(
             "datadir": os.path.join(datadir, "ltc_" + str(node_id)),
             "bindir": cfg.LITECOIN_BINDIR,
             "use_segwit": True,
+            "blocks_confirmed": 3,
             "wallet_name": "bsx_wallet",
         }
 


### PR DESCRIPTION
Avoid the swipe utxos needing to be locked by sending the swipe output to a non-wallet address then sending to a wallet address with the mercytx.
