### PR TITLE
ws: close non-websocket connections instead of raising

### DIFF
--- a/basicswap/contrib/websocket_server/websocket_server.py
+++ b/basicswap/contrib/websocket_server/websocket_server.py
@@ -465,23 +465,27 @@ class WebSocketHandler(StreamRequestHandler):
     def read_http_headers(self):
         headers = {}
         # first line should be HTTP GET
-        http_get = self.rfile.readline().decode().strip()
-        assert http_get.upper().startswith('GET')
+        http_get = self.rfile.readline().decode(errors="replace").strip()
+        if not http_get.upper().startswith('GET'):
+            return None
         # remaining should be headers
         while True:
-            header = self.rfile.readline().decode().strip()
+            header = self.rfile.readline().decode(errors="replace").strip()
             if not header:
                 break
-            head, value = header.split(':', 1)
+            head, sep, value = header.partition(':')
+            if not sep:
+                continue
             headers[head.lower().strip()] = value.strip()
         return headers
 
     def handshake(self):
         headers = self.read_http_headers()
+        if headers is None:
+            self.keep_alive = False
+            return
 
-        try:
-            assert headers['upgrade'].lower() == 'websocket'
-        except AssertionError:
+        if headers.get('upgrade', '').lower() != 'websocket':
             self.keep_alive = False
             return
 

--- a/tests/basicswap/test_other.py
+++ b/tests/basicswap/test_other.py
@@ -1171,6 +1171,41 @@ class Test(unittest.TestCase):
         for headers, settings, expected in cases:
             assert check(Stub(settings), headers) is expected, (headers, settings)
 
+    def test_ws_handshake_bad_request(self):
+        # Anything that is not a websocket handshake (port scans, a client that
+        # closes before sending, a TLS hello) must close the connection instead
+        # of raising out of the request handler.
+        import io
+        from basicswap.contrib.websocket_server.websocket_server import (
+            WebSocketHandler,
+        )
+
+        def make_handler(data: bytes):
+            handler = WebSocketHandler.__new__(WebSocketHandler)
+            handler.rfile = io.BytesIO(data)
+            handler.keep_alive = True
+            handler.handshake_done = False
+            handler.valid_client = False
+            return handler
+
+        for data in (
+            b"",
+            b"\r\n",
+            b"\x16\x03\x01\x00\xa5\x01\x00\x00\xa1\x03\x03",
+            b"POST / HTTP/1.1\r\nUpgrade: websocket\r\n\r\n",
+        ):
+            handler = make_handler(data)
+            assert handler.read_http_headers() is None
+            handler.handshake()
+            assert handler.keep_alive is False
+
+        # A plain GET without the upgrade header is parsed, then rejected.
+        handler = make_handler(b"GET / HTTP/1.1\r\nHost: 127.0.0.1\r\nbroken\r\n\r\n")
+        assert handler.read_http_headers() == {"host": "127.0.0.1"}
+        handler = make_handler(b"GET / HTTP/1.1\r\nHost: 127.0.0.1\r\n\r\n")
+        handler.handshake()
+        assert handler.keep_alive is False
+
     def test_is_allowed_host(self):
         from basicswap.http_server import HttpHandler
 


### PR DESCRIPTION
fixes:
```
----------------------------------------                                                                                                                                                
Exception occurred during processing of request from ('127.0.0.1', 40032)                                                                                                               
Traceback (most recent call last):                                                                                                                                                      
  File "/usr/lib/python3.14/socketserver.py", line 697, in process_request_thread                                                                                                       
    self.finish_request(request, client_address)                                                                                                                                        
    ~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^                                                                                                                                        
  File "/usr/lib/python3.14/socketserver.py", line 362, in finish_request                                                                                                               
    self.RequestHandlerClass(request, client_address, self)                                                                                                                             
    ~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                                                                                                             
  File "/home/nahuhh/bsx-set_daemon/basicswap/contrib/websocket_server/websocket_server.py", line 288, in __init__                                                                      
    StreamRequestHandler.__init__(self, socket, addr, server)                                                                                                                           
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                                                                                                           
  File "/usr/lib/python3.14/socketserver.py", line 766, in __init__                                                                                                                     
    self.handle()                                                                                                                                                                       
    ~~~~~~~~~~~^^                                                                                                                                                                       
  File "/home/nahuhh/bsx-set_daemon/basicswap/contrib/websocket_server/websocket_server.py", line 299, in handle                                                                        
    self.handshake()                                                                                                                                                                    
    ~~~~~~~~~~~~~~^^                                                                                                                                                                    
  File "/home/nahuhh/bsx-set_daemon/basicswap/contrib/websocket_server/websocket_server.py", line 480, in handshake                                                                     
    headers = self.read_http_headers()                                                                                                                                                  
  File "/home/nahuhh/bsx-set_daemon/basicswap/contrib/websocket_server/websocket_server.py", line 469, in read_http_headers                                                             
    assert http_get.upper().startswith('GET')                                                                                                                                           
           ~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^                                                                                                                                           
AssertionError                                                                                                                                                                          
---------------------------------------- 
```