### PR TITLE
network: missing cross origin port check

### DIFF
--- a/basicswap/util/network.py
+++ b/basicswap/util/network.py
@@ -124,8 +124,10 @@ def is_origin_allowed(origin, html_host, html_port, allowed_hosts) -> bool:
         if scheme == "http" and port == int(html_port) and host in default_hosts:
             return True
 
-    # 2. Configured entries. An entry with a scheme is an exact origin; a bare
-    #    host matches that host on any scheme/port (the operator vouched for it).
+    # 2. Configured entries, in the forms allowed_entry_hostname accepts. An
+    #    entry with a scheme is an exact origin; "host:port" matches that host
+    #    on that port, any scheme; a bare host matches that host on any
+    #    scheme/port (the operator vouched for it).
     for entry in allowed_hosts or []:
         if entry == "*":
             continue
@@ -134,7 +136,16 @@ def is_origin_allowed(origin, html_host, html_port, allowed_hosts) -> bool:
             t = _normalize_origin(e)
             if t is not None and (scheme, host, port) == t:
                 return True
-        elif host == e.strip("[]"):
+            continue
+        try:
+            split = urllib.parse.urlsplit("//" + e)
+            entry_host, entry_port = split.hostname, split.port
+        except ValueError:
+            entry_host, entry_port = None, None
+        if entry_host is None:
+            # Unbracketed IPv6 ("::1") has no port to split off.
+            entry_host, entry_port = e.strip("[]"), None
+        if host == entry_host and entry_port in (None, port):
             return True
     return False
 

--- a/tests/basicswap/test_other.py
+++ b/tests/basicswap/test_other.py
@@ -1044,6 +1044,49 @@ class Test(unittest.TestCase):
                 ["https://swap.example.com"],
                 False,
             ),
+            # "host:port" entry -> that host on that port, any scheme.
+            (
+                "http://abc.onion:12700",
+                "127.0.0.1",
+                12700,
+                ["abc.onion:12700"],
+                True,
+            ),
+            (
+                "https://abc.onion:12700",
+                "127.0.0.1",
+                12700,
+                ["abc.onion:12700"],
+                True,
+            ),
+            (
+                "http://abc.onion:8080",
+                "127.0.0.1",
+                12700,
+                ["abc.onion:12700"],
+                False,
+            ),
+            ("http://abc.onion", "127.0.0.1", 12700, ["abc.onion:12700"], False),
+            # A bracketed IPv6 entry keeps working, with and without a port.
+            ("http://[fd00::1]:12700", "127.0.0.1", 12700, ["[fd00::1]"], True),
+            (
+                "http://[fd00::1]:12700",
+                "127.0.0.1",
+                12700,
+                ["[fd00::1]:12700"],
+                True,
+            ),
+            (
+                "http://[fd00::1]:8080",
+                "127.0.0.1",
+                12700,
+                ["[fd00::1]:12700"],
+                False,
+            ),
+            # Unbracketed IPv6 has no port to split off.
+            ("http://[fd00::1]:8080", "127.0.0.1", 12700, ["fd00::1"], True),
+            # A malformed port matches nothing.
+            ("http://abc.onion", "127.0.0.1", 12700, ["abc.onion:nope"], False),
             # "*" is ignored by the origin check.
             ("http://evil.com", "127.0.0.1", 12700, ["*"], False),
             (


### PR DESCRIPTION
When adding `my.onion:12700` to allowed hosts, it was rejecting my entry. Only bare hosts matched.