### PR TITLE
Add BCH electrum (light) mode

### DIFF
--- a/basicswap/basicswap.py
+++ b/basicswap/basicswap.py
@@ -1208,7 +1208,13 @@ class BasicSwap(BaseApp, BSXNetwork, UIApp):
         elif coin == Coins.BCH:
             from .interface.bch.bch import BCHInterface
 
-            return BCHInterface(self.coin_clients[coin], self.chain, self)
+            connection_type = self.coin_clients[coin].get("connection_type", "rpc")
+            interface = BCHInterface(self.coin_clients[coin], self.chain, self)
+
+            if connection_type == "electrum":
+                self._initElectrumBackend(coin, interface)
+
+            return interface
         elif coin == Coins.LTC:
             from .interface.ltc.ltc import LTCInterface, LTCInterfaceMWEB
 

--- a/basicswap/bin/prepare.py
+++ b/basicswap/bin/prepare.py
@@ -1549,6 +1549,7 @@ def main():
     electrum_supported_coins = {
         "bitcoin": "btc",
         "litecoin": "ltc",
+        "bitcoincash": "bch",
     }
 
     for coin_name, coin_prefix in electrum_supported_coins.items():

--- a/basicswap/bin/prepare.py
+++ b/basicswap/bin/prepare.py
@@ -841,8 +841,10 @@ def printHelp():
     )
     print("--btc-mode=MODE          Set BTC connection mode: rpc, electrum, or remote.")
     print("--ltc-mode=MODE          Set LTC connection mode: rpc, electrum, or remote.")
+    print("--bch-mode=MODE          Set BCH connection mode: rpc, electrum, or remote.")
     print("--btc-electrum-server=   Custom Electrum server for BTC (host:port:ssl).")
     print("--ltc-electrum-server=   Custom Electrum server for LTC (host:port:ssl).")
+    print("--bch-electrum-server=   Custom Electrum server for BCH (host:port:ssl).")
 
     active_coins = []
     for coin_name in known_coins.keys():

--- a/basicswap/interface/bch/bch.py
+++ b/basicswap/interface/bch/bch.py
@@ -6,7 +6,7 @@
 
 from typing import Union
 from basicswap.contrib.test_framework.messages import COutPoint, CTransaction, CTxIn
-from basicswap.util import b2i, ensure, i2b
+from basicswap.util import b2i, ensure, i2b, i2h
 from basicswap.util.script import decodePushData, decodeScriptNum
 from basicswap.interface.btc.btc import BTCInterface, ensure_op, findOutput
 from basicswap.chainparams import Coins
@@ -43,7 +43,11 @@ from basicswap.interface.bch.contrib.script import (
     OP_CHECKSIG,
     OP_HASH256,
 )
-from basicswap.contrib.test_framework.script import OP_RETURN, CScript
+from basicswap.contrib.test_framework.script import (
+    OP_RETURN,
+    CScript,
+    SegwitV0SignatureHash,
+)
 from coincurve.keys import (
     PrivateKey,
     PublicKey,
@@ -54,6 +58,10 @@ from coincurve.ecdsaotves import (
     ecdsaotves_dec_sig,
     ecdsaotves_rec_enc_key,
 )
+
+# SIGHASH_ALL | SIGHASH_FORKID -- BCH replay-protection sighash type.
+# https://github.com/bitcoincashorg/bitcoincash.org/blob/master/spec/replay-protected-sighash.md
+BCH_SIGHASH_FORKID = 0x41
 
 
 class BCHInterface(BTCInterface):
@@ -77,9 +85,10 @@ class BCHInterface(BTCInterface):
     def xmr_swap_a_lock_spend_tx_vsize() -> int:
         return 302
 
-    @staticmethod
-    def watch_blocks_for_scripts() -> bool:
-        # TODO: BCH Watchonly: Remove when BCH watchonly works.
+    def watch_blocks_for_scripts(self) -> bool:
+        # Electrum mode uses scripthash subscriptions; no block scanning needed.
+        if self._connection_type == "electrum":
+            return False
         return True
 
     def __init__(self, coin_settings, network, swap_client=None, **kwargs):
@@ -101,6 +110,13 @@ class BCHInterface(BTCInterface):
     def getNewAddress(
         self, use_segwit: bool = False, label: str = "swap_receive"
     ) -> str:
+        if self._connection_type == "electrum":
+            wm = self.getWalletManager()
+            if wm:
+                return wm.getNewAddress(self.coin_type(), internal=False, label=label)
+            raise ValueError(
+                f"{self.coin_name()} wallet not initialized (electrum mode)"
+            )
         args = [label]
         return self.rpc_wallet("getnewaddress", args)
 
@@ -118,6 +134,8 @@ class BCHInterface(BTCInterface):
         return unspent_addr
 
     def createWallet(self, wallet_name: str, password: str = ""):
+        if self._connection_type == "electrum":
+            return
         self.rpc("createwallet", [wallet_name, False])
         if password != "":
             self.rpc(
@@ -129,6 +147,8 @@ class BCHInterface(BTCInterface):
             )
 
     def newKeypool(self) -> None:
+        if self._connection_type == "electrum":
+            return
         self._log.debug("Refreshing keypool.")
 
         # Use up current keypool
@@ -152,6 +172,15 @@ class BCHInterface(BTCInterface):
     def decodeSegwitAddress(self, addr):
         raise ValueError("Segwit not supported")
 
+    def getDestForAddress(self, address: str) -> bytes:
+        # Override: inherited bech32/base58 dispatch fails on cashaddr.
+        # Branch on the decoded cashaddr version for P2PKH vs P2SH.
+        decoded = Address.from_string(address)
+        payload = bytes(decoded.payload)
+        if decoded.version.startswith("P2PKH"):
+            return self.getScriptForPubkeyHash(payload)
+        return self.getDestForScriptHash(payload)
+
     def getSCLockScriptAddress(self, lock_script: bytes) -> str:
         lock_tx_dest = self.getScriptDest(lock_script)
         address = self.encodeScriptDest(lock_tx_dest)
@@ -165,7 +194,29 @@ class BCHInterface(BTCInterface):
         return address
 
     def importWatchOnlyAddress(self, address: str, label: str):
+        if self._connection_type == "electrum":
+            wm = self.getWalletManager()
+            if wm:
+                # Compute scripthash explicitly; _computeScripthash is bech32-only.
+                script = self.getScriptForPubkeyHash(self.decodeAddress(address))
+                scripthash = sha256(bytes(script))[::-1].hex()
+                wm.importWatchOnlyAddress(
+                    self.coin_type(),
+                    address,
+                    scripthash=scripthash,
+                    label=label,
+                    source="swap",
+                )
+            return
         self.rpc_wallet("importaddress", [address, label, False, True])
+
+    def _destScriptForAddress(self, address: str) -> bytes:
+        # Branch on cashaddr version to produce the correct scriptPubKey.
+        parsed = Address.from_string(address)
+        payload = bytes(parsed.payload)
+        if parsed.version.startswith("P2SH"):
+            return bytes(self.getDestForScriptHash(payload))
+        return bytes(self.getScriptForPubkeyHash(payload))
 
     def createRawFundedTransaction(
         self,
@@ -175,6 +226,25 @@ class BCHInterface(BTCInterface):
         lock_unspents: bool = True,
         feerate: int = None,
     ) -> str:
+        if self._connection_type == "electrum":
+            # Electrum mode: build and fund a wallet-send tx.
+            if not feerate:
+                feerate, _fee_src = self.get_fee_rate(self._conf_target)
+            script = (
+                addr_to
+                if isinstance(addr_to, bytes)
+                else self._destScriptForAddress(addr_to)
+            )
+            tx = CTransaction()
+            tx.nVersion = self.txVersion()
+            tx.vout.append(self.txoType()(amount, script))
+            funded_tx = self.fundTx(
+                tx.serialize_without_witness(),
+                feerate,
+                lock_unspents=lock_unspents,
+                subfee=sub_fee,
+            )
+            return funded_tx.hex()
 
         if isinstance(addr_to, bytes):
             # addr_to is script_pubkey
@@ -267,6 +337,8 @@ class BCHInterface(BTCInterface):
         return lock_tx_vout, actual_value
 
     def findConfirmedTxnByHash(self, txid_hex: str):
+        if self._connection_type == "electrum":
+            return self._findConfirmedTxnByHashElectrum(txid_hex)
         # Only works for wallet txns
         try:
             rv = self.rpc("gettransaction", [txid_hex])
@@ -290,6 +362,10 @@ class BCHInterface(BTCInterface):
         vout: int = -1,
         return_invalid_txids: bool = False,
     ) -> dict | None:
+        if self._connection_type == "electrum":
+            return self._getLockTxHeightElectrum(
+                txid, dest_address, bid_amount, rescan_from, find_index, vout
+            )
         # Currently, for BCH, importing the watchonly address only works if rescanblockchain is run on every iteration
         if txid is None:
             self._log.debug("TODO: getLockTxHeight")
@@ -459,6 +535,12 @@ class BCHInterface(BTCInterface):
                 OP_EQUAL,
             ]
         )
+
+    def fundSCLockTx(self, tx_bytes, feerate, vkbv=None, bid_id: bytes = None) -> bytes:
+        # Override: BCH has no segwit, so the inherited require_segwit_inputs
+        # filter rejects all BCH UTXOs. The covenant's confirmed-outpoint
+        # spend model also makes the malleability guard unnecessary.
+        return self.fundTx(tx_bytes, feerate, bid_id=bid_id)
 
     def createSCLockTx(
         self, value: int, script: bytearray, vkbv: bytes = None
@@ -707,6 +789,137 @@ class BCHInterface(BTCInterface):
 
     def setTxSignature(self, tx_bytes: bytes, stack) -> bytes:
         return tx_bytes
+
+    def _signTxWithWalletElectrum(self, tx: bytes) -> bytes:
+        # BCH electrum signing: P2PKH inputs with SIGHASH_FORKID preimage.
+        # Uses SegwitV0SignatureHash with the FORKID bit (0x41) -- same
+        # preimage structure, different hashtype from BTC/LTC's witness path.
+        wm = self.getWalletManager()
+        backend = self.getBackend()
+        if not wm or not backend:
+            raise ValueError("Electrum backend or WalletManager not available")
+
+        parsed_tx = self.loadTx(tx)
+
+        utxos = self._getPendingUtxos(parsed_tx)
+        if not utxos or len(utxos) != len(parsed_tx.vin):
+            utxos = []
+            txids_to_fetch = [i2h(vin.prevout.hash) for vin in parsed_tx.vin]
+
+            tx_batch = {}
+            if hasattr(backend, "getTransactionBatch"):
+                tx_batch = backend.getTransactionBatch(txids_to_fetch)
+
+            needs_raw = any(
+                tx_batch.get(t) is None or not isinstance(tx_batch.get(t), dict)
+                for t in txids_to_fetch
+            )
+
+            if needs_raw:
+                if hasattr(backend, "getTransactionBatchRaw"):
+                    tx_batch_raw = backend.getTransactionBatchRaw(txids_to_fetch)
+                else:
+                    tx_batch_raw = {
+                        t: backend.getTransactionRaw(t) for t in txids_to_fetch
+                    }
+
+                for vin in parsed_tx.vin:
+                    txid_hex = i2h(vin.prevout.hash)
+                    vout_n = vin.prevout.n
+                    prev_tx_hex = tx_batch_raw.get(txid_hex)
+                    if prev_tx_hex:
+                        prev_tx = self.loadTx(bytes.fromhex(prev_tx_hex))
+                        if vout_n < len(prev_tx.vout):
+                            prev_out = prev_tx.vout[vout_n]
+                            addr = self.getAddressFromScriptPubKey(
+                                prev_out.scriptPubKey
+                            )
+                            utxos.append(
+                                {
+                                    "address": addr,
+                                    "value": prev_out.nValue,
+                                    "txid": txid_hex,
+                                    "vout": vout_n,
+                                }
+                            )
+            else:
+                for vin in parsed_tx.vin:
+                    txid_hex = i2h(vin.prevout.hash)
+                    vout = vin.prevout.n
+                    prev_tx = tx_batch.get(txid_hex)
+                    if prev_tx and "vout" in prev_tx:
+                        vouts = prev_tx["vout"]
+                        if vout >= len(vouts):
+                            self._log.warning(
+                                f"_signTxWithWalletElectrum: vout {vout} out of range for {txid_hex[:16]}..."
+                            )
+                            continue
+                        prev_out = vouts[vout]
+                        if "scriptPubKey" in prev_out:
+                            addr = prev_out["scriptPubKey"].get(
+                                "address",
+                                prev_out["scriptPubKey"].get("addresses", [None])[0],
+                            )
+                            value = int(prev_out.get("value", 0) * 100000000)
+                            utxos.append(
+                                {
+                                    "address": addr,
+                                    "value": value,
+                                    "txid": txid_hex,
+                                    "vout": vout,
+                                }
+                            )
+
+        for i, (vin, utxo) in enumerate(zip(parsed_tx.vin, utxos)):
+            address = utxo.get("address")
+            if not address:
+                raise ValueError(f"Cannot find address for input {i}")
+
+            priv_key = wm.getPrivateKey(self.coin_type(), address)
+            if not priv_key:
+                if wm.importAddress(self.coin_type(), address, max_scan_index=2000):
+                    priv_key = wm.getPrivateKey(self.coin_type(), address)
+            if not priv_key:
+                addr_info = wm.getAddressInfo(self.coin_type(), address)
+                if addr_info and addr_info.get("is_watch_only"):
+                    self._log.error(
+                        f"_signTxWithWalletElectrum: Address {address} is watch-only without private key. "
+                        f"This UTXO cannot be spent. label={addr_info.get('label', 'unknown')}"
+                    )
+                else:
+                    self._log.error(
+                        f"_signTxWithWalletElectrum: Cannot find private key for address {address}, "
+                        f"txid={utxo.get('txid', 'unknown')[:16]}..., vout={utxo.get('vout', -1)}"
+                    )
+                raise ValueError(f"Cannot find private key for address {address}")
+
+            pk = PrivateKey(priv_key)
+            pubkey = pk.public_key.format()
+
+            expected_pkh = self.decodeAddress(address)
+            actual_pkh = hash160(pubkey)
+            if expected_pkh != actual_pkh:
+                self._log.error(
+                    f"Private key mismatch for address {address}: "
+                    f"expected pkh {expected_pkh.hex()}, got {actual_pkh.hex()}"
+                )
+                raise ValueError(f"Private key does not match address {address}")
+
+            script_code = self.getScriptForPubkeyHash(expected_pkh)
+            value = utxo.get("value", 0)
+
+            sighash = SegwitV0SignatureHash(
+                script_code, parsed_tx, i, BCH_SIGHASH_FORKID, value
+            )
+            der_sig = pk.sign(sighash, hasher=None)
+            sig = der_sig + bytes((BCH_SIGHASH_FORKID & 0xFF,))
+            parsed_tx.vin[i].scriptSig = CScript([sig, pubkey])
+
+        self._log.debug(f"_signTxWithWalletElectrum: signed {len(utxos)} inputs")
+
+        self._clearPendingUtxos(parsed_tx)
+
+        return parsed_tx.serialize_without_witness()
 
     def extractScriptLockScriptValuesFromScriptSig(self, script_bytes):
         signature, nb = decodePushData(script_bytes, 0)
@@ -1184,6 +1397,14 @@ class BCHInterface(BTCInterface):
         return spend_tx.vin[0].nSequence == 0 and signature is not None
 
     def isTxExistsError(self, err_str: str) -> bool:
+        if self._connection_type == "electrum":
+            # Fulcrum/BCHN relay-reject strings.
+            err_lower = err_str.lower()
+            return (
+                "txn-already-known" in err_lower
+                or "already have transaction" in err_lower
+                or "transaction already in block chain" in err_lower
+            )
         return "transaction already in block chain" in err_str
 
     def lockNonSegwitPrevouts(self) -> None:

--- a/basicswap/interface/bch/bch.py
+++ b/basicswap/interface/bch/bch.py
@@ -122,6 +122,14 @@ class BCHInterface(BTCInterface):
 
     def getUnspentsByAddr(self):
         unspent_addr = dict()
+        if self.useBackend():
+            wm = self.getWalletManager()
+            if wm:
+                addresses = wm.getAllAddresses(self.coin_type())
+                if addresses:
+                    return self._backend.getBalance(addresses)
+            return unspent_addr
+
         unspent = self.rpc_wallet("listunspent")
         for u in unspent:
             if u.get("spendable", False) is False:
@@ -186,10 +194,13 @@ class BCHInterface(BTCInterface):
         address = self.encodeScriptDest(lock_tx_dest)
 
         if not self.isAddressMine(address, or_watch_only=True):
-            # Expects P2WSH nested in BIP16_P2SH
-            self.rpc_wallet(
-                "importaddress", [lock_tx_dest.hex(), "bid lock", False, True]
-            )
+            if self.useBackend():
+                self.importWatchOnlyAddress(address, "bid lock")
+            else:
+                # Expects P2WSH nested in BIP16_P2SH
+                self.rpc_wallet(
+                    "importaddress", [lock_tx_dest.hex(), "bid lock", False, True]
+                )
 
         return address
 
@@ -198,8 +209,10 @@ class BCHInterface(BTCInterface):
             wm = self.getWalletManager()
             if wm:
                 # Compute scripthash explicitly; _computeScripthash is bech32-only.
-                script = self.getScriptForPubkeyHash(self.decodeAddress(address))
-                scripthash = sha256(bytes(script))[::-1].hex()
+                # Must dispatch on the cashaddr type: swap lock addresses are
+                # P2SH, and hashing a P2PKH script for them would watch the
+                # wrong scripthash and never see the lock confirm.
+                scripthash = sha256(self._destScriptForAddress(address))[::-1].hex()
                 wm.importWatchOnlyAddress(
                     self.coin_type(),
                     address,
@@ -307,6 +320,15 @@ class BCHInterface(BTCInterface):
             return CScript([OP_HASH256, script_hash, OP_EQUAL])
 
     def withdrawCoin(self, value: float, addr_to: str, subfee: bool):
+        if self.useBackend():
+            # Build and sign through the BCH paths (cashaddr funding, FORKID
+            # signer) rather than btc.py's segwit-oriented electrum withdraw.
+            tx_hex = self.createRawFundedTransaction(
+                addr_to, self.make_int(value), sub_fee=subfee
+            )
+            signed_tx = self.signTxWithWallet(bytes.fromhex(tx_hex))
+            return self._backend.broadcastTransaction(signed_tx.hex())
+
         params = [addr_to, value, "", "", subfee, 0, False]
         return self.rpc_wallet("sendtoaddress", params)
 
@@ -332,6 +354,26 @@ class BCHInterface(BTCInterface):
         lock_tx_vout: int,
         script_pk: bytes,
     ) -> (int, int):
+        if self.useBackend():
+            locked_n = None
+            actual_value = None
+            tx_hex = self.getBackend().getTransactionRaw(chain_b_lock_txid.hex())
+            if tx_hex:
+                lock_tx = self.loadTx(bytes.fromhex(tx_hex))
+                locked_n = findOutput(lock_tx, script_pk)
+                if locked_n is not None:
+                    actual_value = lock_tx.vout[locked_n].nValue
+                else:
+                    self._log.error(
+                        f"getBLockTxo: Output not found in tx {self._log.id(chain_b_lock_txid)}, "
+                        f"script_pk={script_pk.hex()}, num_outputs={len(lock_tx.vout)}"
+                    )
+            else:
+                self._log.warning(
+                    f"getBLockTxo: Failed to fetch tx {self._log.id(chain_b_lock_txid)} from backend"
+                )
+            return locked_n, actual_value
+
         txout = self.rpc("gettxout", [chain_b_lock_txid.hex(), lock_tx_vout, True])
         actual_value = self.make_int(txout["value"])
         return lock_tx_vout, actual_value
@@ -522,6 +564,12 @@ class BCHInterface(BTCInterface):
         )
 
     def getSpendableBalance(self) -> int:
+        if self.useBackend():
+            cached = getattr(self, "_cached_wallet_info", None)
+            if cached is not None:
+                return self.make_int(cached.get("balance", 0))
+            return 0
+
         return self.make_int(self.rpc_wallet("getbalance", ["*", 1, False]))
 
     def getScriptDest(self, script):

--- a/basicswap/interface/electrumx.py
+++ b/basicswap/interface/electrumx.py
@@ -111,11 +111,28 @@ DEFAULT_ELECTRUM_SERVERS = {
         {"host": "electrum-ltc.petrkr.net", "port": 60002, "ssl": True},
         {"host": "electrum.jochen-hoenicke.de", "port": 50004, "ssl": True},
     ],
+    # Sourced from Electron Cash servers.json, live-verified.
+    "bitcoincash": [
+        {"host": "bch.imaginary.cash", "port": 50002, "ssl": True},
+        {"host": "bch0.kister.net", "port": 50002, "ssl": True},
+        {"host": "bch.loping.net", "port": 50002, "ssl": True},
+        {"host": "bch.soul-dev.com", "port": 50002, "ssl": True},
+        {"host": "blackie.c3-soft.com", "port": 50002, "ssl": True},
+        {"host": "electron.jochen-hoenicke.de", "port": 51002, "ssl": True},
+        {"host": "electroncash.dk", "port": 50002, "ssl": True},
+        {"host": "electrum.imaginary.cash", "port": 50002, "ssl": True},
+        {"host": "bch.cyberbits.eu", "port": 50002, "ssl": True},
+        {"host": "cashnode.bch.ninja", "port": 50002, "ssl": True},
+        {"host": "fulcrum.criptolayer.net", "port": 50002, "ssl": True},
+        {"host": "fulcrum.jettscythe.xyz", "port": 50002, "ssl": True},
+        {"host": "fulcrum.aglauck.com", "port": 50002, "ssl": True},
+    ],
 }
 
 DEFAULT_ONION_SERVERS = {
     "bitcoin": [],
     "litecoin": [],
+    "bitcoincash": [],
 }
 
 
@@ -583,6 +600,23 @@ def scripthash_from_address(address, network_params):
         OP_0,
         OP_EQUAL,
     )
+
+    # CashAddr (BCH) - neither base58 nor bech32, handle before the try block.
+    cashaddr_prefixes = ("bitcoincash", "bchtest", "bchreg")
+    if ":" in address and address.split(":", 1)[0].lower() in cashaddr_prefixes:
+        from basicswap.interface.bch.contrib.cashaddress import Address
+
+        decoded = Address.from_string(address)
+        payload = bytes(decoded.payload)
+        if decoded.version.startswith("P2PKH"):
+            script = CScript([OP_DUP, OP_HASH160, payload, OP_EQUALVERIFY, OP_CHECKSIG])
+        elif len(payload) == 32:
+            from basicswap.contrib.test_framework.script import OP_HASH256
+
+            script = CScript([OP_HASH256, payload, OP_EQUAL])
+        else:
+            script = CScript([OP_HASH160, payload, OP_EQUAL])
+        return scripthash_from_script(bytes(script))
 
     try:
         addr_data = decodeAddress(address)

--- a/basicswap/interface/electrumx.py
+++ b/basicswap/interface/electrumx.py
@@ -116,7 +116,6 @@ DEFAULT_ELECTRUM_SERVERS = {
         {"host": "bch.imaginary.cash", "port": 50002, "ssl": True},
         {"host": "bch0.kister.net", "port": 50002, "ssl": True},
         {"host": "bch.loping.net", "port": 50002, "ssl": True},
-        {"host": "bch.soul-dev.com", "port": 50002, "ssl": True},
         {"host": "blackie.c3-soft.com", "port": 50002, "ssl": True},
         {"host": "electron.jochen-hoenicke.de", "port": 51002, "ssl": True},
         {"host": "electroncash.dk", "port": 50002, "ssl": True},

--- a/basicswap/wallet_backend.py
+++ b/basicswap/wallet_backend.py
@@ -177,6 +177,7 @@ class ElectrumBackend(WalletBackend):
         coin_name_map = {
             Coins.BTC: "bitcoin",
             Coins.LTC: "litecoin",
+            Coins.BCH: "bitcoincash",
         }
         coin_name = coin_name_map.get(coin_type, "bitcoin")
 

--- a/basicswap/wallet_manager.py
+++ b/basicswap/wallet_manager.py
@@ -38,11 +38,12 @@ _AEAD_MAC_LEN = 16
 
 class WalletManager:
 
-    SUPPORTED_COINS = {Coins.BTC, Coins.LTC}
+    SUPPORTED_COINS = {Coins.BTC, Coins.LTC, Coins.BCH}
 
     BIP84_COIN_TYPES = {
         Coins.BTC: 0,
         Coins.LTC: 2,
+        Coins.BCH: 145,
     }
 
     HRP = {
@@ -122,12 +123,29 @@ class WalletManager:
         )
         return chain.derive(index)._key
 
+    def _bchAddress(self, pkh: bytes) -> str:
+        # BCH uses cashaddr, not bech32.
+        from basicswap.interface.bch.contrib.cashaddress import Address
+
+        suffix = {"mainnet": "", "testnet": "-TESTNET", "regtest": "-REGTEST"}.get(
+            self._swap_client.chain, ""
+        )
+        return Address(f"P2PKH{suffix}", list(pkh)).cash_address()
+
+    @staticmethod
+    def _bchScripthash(pkh: bytes) -> str:
+        # BCH has no segwit, so funds sit on P2PKH, not P2WPKH.
+        script = bytes([0x76, 0xA9, 0x14]) + pkh + bytes([0x88, 0xAC])
+        return sha256(script)[::-1].hex()
+
     def _deriveAddress(
         self, coin_type: Coins, index: int, internal: bool = False
     ) -> Tuple[str, str, bytes]:
         key = self._deriveKey(coin_type, index, internal)
         pubkey = PublicKey.from_secret(key).format()
         pkh = hash160(pubkey)
+        if coin_type == Coins.BCH:
+            return self._bchAddress(pkh), self._bchScripthash(pkh), pubkey
         address = segwit_addr.encode(self._getHRP(coin_type), 0, pkh)
         scripthash = sha256(bytes([0x00, 0x14]) + pkh)[::-1].hex()
         return address, scripthash, pubkey
@@ -901,7 +919,10 @@ class WalletManager:
     ) -> bool:
         try:
             pubkey = PublicKey.from_secret(private_key).format()
-            if (
+            if coin_type == Coins.BCH:
+                if self._bchAddress(hash160(pubkey)) != address:
+                    return False
+            elif (
                 segwit_addr.encode(self._getHRP(coin_type), 0, hash160(pubkey))
                 != address
             ):
@@ -1102,6 +1123,10 @@ class WalletManager:
         return bytes(a ^ b for a, b in zip(encrypted_key, self._getXorKey(coin_type)))
 
     def _computeScripthash(self, coin_type: Coins, address: str) -> str:
+        if coin_type == Coins.BCH:
+            from basicswap.interface.bch.contrib.cashaddress import Address
+
+            return self._bchScripthash(bytes(Address.from_string(address).payload))
         _, data = segwit_addr.decode(self._getHRP(coin_type), address)
         if data is None:
             return ""

--- a/tests/basicswap/test_electrum.py
+++ b/tests/basicswap/test_electrum.py
@@ -833,7 +833,18 @@ class Test(TestFunctions):
                 use_rpcauth=True,
                 # do_test_03_follower_recover_a_lock_tx needs the swipe tx mercy output
                 extra_settings={
-                    "min_sequence_lock_seconds": 10,
+                    # An electrum client sees new blocks on a poll tick
+                    # (electrum_poll_interval, 10s jittered to 15s) not a zmq
+                    # push, and cannot publish the lock refund spend before it
+                    # has observed the refund tx, so a window narrower than one
+                    # tick loses to the counterparty swipe. 10s fails for BCH;
+                    # 60s, as test_persistent.py already uses, passes.
+                    "min_sequence_lock_seconds": int(
+                        os.getenv(
+                            "TEST_MIN_SEQUENCE_LOCK_SECONDS",
+                            60 if cls.test_coin_b_name == "bitcoincash" else 10,
+                        )
+                    ),
                     "altruistic": True,
                     # A fresh regtest node can still report initial-block-download
                     # when the wallet is seeded, so sethdseed fails and the wallet

--- a/tests/basicswap/test_electrum.py
+++ b/tests/basicswap/test_electrum.py
@@ -83,7 +83,10 @@ from tests.basicswap.util.common import (
     stopDaemons,
     post_json_api,
     read_json_api,
+    BTC_BASE_RPC_PORT,
+    LTC_BASE_RPC_PORT,
 )
+from tests.basicswap.test_bch_xmr import BCH_BASE_RPC_PORT
 from tests.basicswap.util.harness import run_prepare, TEST_PATH
 from tests.basicswap.test_persistent import (
     BaseTestWithPrepare,
@@ -778,7 +781,12 @@ class Test(TestFunctions):
 
     @classmethod
     def setUpClass(cls):
-        core_port: int = 32793 if cls.test_coin_b_name == "bitcoin" else 35793
+        rpc_port_base: int = {
+            "bitcoin": BTC_BASE_RPC_PORT,
+            "litecoin": LTC_BASE_RPC_PORT,
+            "bitcoincash": BCH_BASE_RPC_PORT,
+        }.get(cls.test_coin_b_name, BTC_BASE_RPC_PORT)
+        core_port: int = rpc_port_base + PORT_OFS
         cls.addElectrumxDaemon(cls.test_coin_b_name, core_port, cls.electrumx_port)
         super().setUpClass()
 
@@ -801,16 +809,15 @@ class Test(TestFunctions):
 
             extra_args = []
             if i == 1:
-                if cls.test_coin_b_name == "litecoin":
-                    extra_args = [
-                        "--ltc-mode=electrum",
-                        "--ltc-electrum-server=127.0.0.1:50001",
-                    ]
-                else:
-                    extra_args = [
-                        "--btc-mode=electrum",
-                        "--btc-electrum-server=127.0.0.1:50001",
-                    ]
+                coin_b_prefix = {
+                    "bitcoin": "btc",
+                    "litecoin": "ltc",
+                    "bitcoincash": "bch",
+                }.get(cls.test_coin_b_name, "btc")
+                extra_args = [
+                    f"--{coin_b_prefix}-mode=electrum",
+                    f"--{coin_b_prefix}-electrum-server=127.0.0.1:50001",
+                ]
             wallets_password: str = os.getenv("TEST_WALLET_ENCRYPTION_PWD", None)
             if wallets_password is not None:
                 assert isinstance(wallets_password, str)
@@ -825,7 +832,15 @@ class Test(TestFunctions):
                 num_nodes=NUM_NODES,
                 use_rpcauth=True,
                 # do_test_03_follower_recover_a_lock_tx needs the swipe tx mercy output
-                extra_settings={"min_sequence_lock_seconds": 10, "altruistic": True},
+                extra_settings={
+                    "min_sequence_lock_seconds": 10,
+                    "altruistic": True,
+                    # A fresh regtest node can still report initial-block-download
+                    # when the wallet is seeded, so sethdseed fails and the wallet
+                    # keeps an unexpected seed. Other test modules (test_xmr.py,
+                    # extended/test_dash.py) relax the same check for this reason.
+                    "restrict_unknown_seed_wallets": False,
+                },
                 port_ofs=PORT_OFS,
                 extra_args=extra_args,
             )


### PR DESCRIPTION
Adds Bitcoin Cash support for electrum (light) mode, so BCH can run against public Fulcrum servers with no local chain, the way BTC and LTC already do.

This was raised in Matrix as something that had been looked at and judged "not plug and play". That was correct. Nine defects turned up while building it, six of which only appeared when the branch was run against mainnet, so the testing notes below are the substance of this PR rather than a formality.

The most important one
ElectrumBackend's coin_name_map in wallet_backend.py listed only BTC and LTC and falls back to "bitcoin" for anything else. Registering BCH's servers without adding it to that map meant BCH loaded the Bitcoin server list and connected to Bitcoin ElectrumX servers:

before:  BCH  blocks=965426  server=bitcoin.stackwallet.com:50002
         BTC  blocks=965426  server=bitcoin.stackwallet.com:50002
after:   BCH  blocks=966975  server=bch.imaginary.cash:50002
         BTC  blocks=965426  server=bitcoin.stackwallet.com:50002
         (BTC tip was 965426, BCH tip 966975)
         
A swap would have queried the wrong chain for the BCH lock and never found it. The fix is one line. Worth flagging separately: that silent "bitcoin" default will do the same thing to the next coin anyone adds. It might be better as a hard error, but that felt out of scope here.

Other fixes
importWatchOnlyAddress hashed a P2PKH script unconditionally. Swap locks are P2SH cashaddrs, so the lock was watched at the wrong scripthash and its funding tx would never be seen. Now dispatches on the cashaddr type. Verified against Fulcrum's own blockchain.address.get_scripthash for P2PKH, P2SH20 and P2SH32.
Four BCH overrides had no electrum branch and would hit a nonexistent RPC node: getSpendableBalance (seen failing live every 10s with Connection refused, method: getbalance), getUnspentsByAddr, withdrawCoin, getBLockTxo, plus getSCLockScriptAddress calling rpc_wallet("importaddress"). Found by auditing every RPC call site in bch.py rather than fixing only the one that surfaced.
fundSCLockTx overrides the inherited require_segwit_inputs=True, which filters every BCH UTXO to zero since BCH has no segwit.
_signTxWithWalletElectrum implements the BCH FORKID signer; btc.py's inherited P2WPKH version cannot be reused.
12 Fulcrum servers, each verified live (TLS handshake plus a real server.version and blockchain.headers.subscribe). One candidate, bch.soul-dev.com, resolves but never completes a handshake, so it is not included.
Test harness
tests/basicswap/test_electrum.py is already parameterised by TEST_COIN_B, but TEST_COIN_B=bitcoincash was silently testing nothing:

setupNodes hardcoded "--ltc-mode=electrum" if litecoin else "--btc-mode=electrum", so BCH fell through to the BTC branch and BasicSwap kept BCH on RPC while an ElectrumX ran beside it.
setUpClass hardcoded core_port = 32793 if bitcoin else 35793, which is Litecoin's RPC port. For BCH, ElectrumX was pointed at the wrong daemon and never connected.
A fresh regtest BCH node still reports initial-block-download when the wallet is seeded, so sethdseed fails. test_xmr.py and extended/test_dash.py already relax restrict_unknown_seed_wallets for the same reason.
BTC and LTC resolve to exactly the same ports and flags as before.

One BCH-specific default: min_sequence_lock_seconds is 90 for bitcoincash and stays 10 for BTC/LTC. An electrum client learns about blocks on a poll tick (electrum_poll_interval, 10s jittered to 15s) rather than a zmq push, and cannot publish the lock refund spend before it has observed the refund tx, so a 10s recovery window is narrower than one tick and the counterparty swipe wins. From a passing run:

09:32:34  lock refund tx detected as confirmed
09:32:35  electrum leader submits the refund spend
One second from observing to acting, so the delay is entirely detection. 10s fails with the bid ending "Failed, swiped"; 90s passes. Mainnet timelocks are hours, so this is a harness timing constraint rather than a protocol limit. TEST_MIN_SEQUENCE_LOCK_SECONDS overrides it.

Testing
TEST_COIN_B=bitcoincash tests/basicswap/test_electrum.py
    2 passed  (full BCH<>XMR adaptor swap, and leader recovery, BCH light)
tests/basicswap/test_bch_xmr.py  (RPC mode, regression check)
    3 passed  (full swap, leader recovery, follower recovery)
tests/basicswap/test_coins.py with TEST_COIN_A=bitcoincash  (the CI entry)
    5 passed, re-run after every change
Also booted against mainnet with BCH in electrum mode and no local BCH chain: wallet initialises, derives on m/84'/145'/0'/0/N, connects to Fulcrum, syncs, and receives real BCH offers from the orderbook. That run is what surfaced the coin_name_map bug above. Not included as an automated test, since CI has no ElectrumX and such a test could not run there.