### PR TITLE
fix: handle smsg errors and unlock outputs on negotiation failure

### DIFF
--- a/basicswap/basicswap.py
+++ b/basicswap/basicswap.py
@@ -6942,6 +6942,7 @@ class BasicSwap(BaseApp, BSXNetwork, UIApp):
         self.log.info(f"Accepting adaptor-sig bid {self.log.id(bid_id)}")
 
         now: int = self.getTime()
+        funded_a_lock_tx = None
         try:
             use_cursor = self.openDB(cursor)
             bid, xmr_swap = self.getXmrBidFromSession(use_cursor, bid_id)
@@ -7099,6 +7100,7 @@ class BasicSwap(BaseApp, BSXNetwork, UIApp):
                 xmr_swap.a_lock_tx = ci_from.fundSCLockTx(
                     xmr_swap.a_lock_tx, a_fee_rate, xmr_swap.vkbv, bid_id=bid.bid_id
                 )
+                funded_a_lock_tx = xmr_swap.a_lock_tx
 
             xmr_swap.a_lock_tx_id = ci_from.getTxid(xmr_swap.a_lock_tx)
             (
@@ -7275,6 +7277,14 @@ class BasicSwap(BaseApp, BSXNetwork, UIApp):
             # Add to swaps_in_progress only when waiting on txns
             self.log.info(f"Sent XMR_BID_ACCEPT_LF {self.log.id(bid_id)}")
             return bid_id
+        except Exception:
+            if funded_a_lock_tx is not None:
+                # The bid rolls back, the wallet's coin locks would not
+                try:
+                    ci_from.unlockInputs(funded_a_lock_tx, cursor=use_cursor)
+                except Exception as e:
+                    self.log.warning(f"unlockInputs failed {e}")
+            raise
         finally:
             if cursor is None:
                 self.closeDB(use_cursor)

--- a/basicswap/basicswap.py
+++ b/basicswap/basicswap.py
@@ -5378,7 +5378,13 @@ class BasicSwap(BaseApp, BSXNetwork, UIApp):
         return ci.getProofOfFunds(amount_for, extra_commit_bytes)
 
     def saveBidInSession(
-        self, bid_id: bytes, bid, cursor, xmr_swap=None, save_in_progress=None
+        self,
+        bid_id: bytes,
+        bid,
+        cursor,
+        xmr_swap=None,
+        save_in_progress=None,
+        notify: bool = True,
     ) -> None:
         self.add(bid, cursor, upsert=True)
         if bid.initiate_tx:
@@ -5401,7 +5407,8 @@ class BasicSwap(BaseApp, BSXNetwork, UIApp):
                 raise ValueError("Must specify offer for save_in_progress")
             self.swaps_in_progress[bid_id] = (bid, save_in_progress)  # (bid, offer)
 
-        self.notifyBidChanged(bid_id)
+        if notify:
+            self.notifyBidChanged(bid_id)
 
     def saveBid(self, bid_id: bytes, bid, xmr_swap=None, cursor=None) -> None:
         try:
@@ -7261,25 +7268,28 @@ class BasicSwap(BaseApp, BSXNetwork, UIApp):
                     payload_version=offer.smsg_payload_version,
                 )
 
-            bid.setState(BidStates.BID_ACCEPTED)  # ADS
-
-            self.saveBidInSession(bid_id, bid, use_cursor, xmr_swap=xmr_swap)
-            for k, msg_id in bid_msg_ids.items():
-                self.addMessageLink(
-                    Concepts.BID,
-                    bid_id,
-                    MessageTypes.BID_ACCEPT,
-                    msg_id,
-                    msg_sequence=k,
-                    cursor=use_cursor,
+            with self.dbSavepoint(use_cursor, "accept_xmr_bid"):
+                bid.setState(BidStates.BID_ACCEPTED)  # ADS
+                self.saveBidInSession(
+                    bid_id, bid, use_cursor, xmr_swap=xmr_swap, notify=False
                 )
+                for k, msg_id in bid_msg_ids.items():
+                    self.addMessageLink(
+                        Concepts.BID,
+                        bid_id,
+                        MessageTypes.BID_ACCEPT,
+                        msg_id,
+                        msg_sequence=k,
+                        cursor=use_cursor,
+                    )
+            self.notifyBidChanged(bid_id)
 
             # Add to swaps_in_progress only when waiting on txns
             self.log.info(f"Sent XMR_BID_ACCEPT_LF {self.log.id(bid_id)}")
             return bid_id
         except Exception:
             if funded_a_lock_tx is not None:
-                # The bid rolls back, the wallet's coin locks would not
+                # a_lock_tx was not saved, nothing else will unlock these
                 try:
                     ci_from.unlockInputs(funded_a_lock_tx, cursor=use_cursor)
                 except Exception as e:

--- a/basicswap/basicswap.py
+++ b/basicswap/basicswap.py
@@ -7105,7 +7105,11 @@ class BasicSwap(BaseApp, BSXNetwork, UIApp):
                     bid.amount, xmr_swap.a_lock_tx_script, xmr_swap.vkbv
                 )
                 xmr_swap.a_lock_tx = ci_from.fundSCLockTx(
-                    xmr_swap.a_lock_tx, a_fee_rate, xmr_swap.vkbv, bid_id=bid.bid_id
+                    xmr_swap.a_lock_tx,
+                    a_fee_rate,
+                    xmr_swap.vkbv,
+                    bid_id=bid.bid_id,
+                    cursor=use_cursor,
                 )
                 funded_a_lock_tx = xmr_swap.a_lock_tx
 

--- a/basicswap/db.py
+++ b/basicswap/db.py
@@ -9,6 +9,7 @@ import inspect
 import sqlite3
 import time
 
+from contextlib import contextmanager
 from enum import IntEnum, auto
 from typing import Optional
 
@@ -978,6 +979,21 @@ class DBMethods:
         assert self._db_lock_held()
         self._db_con.rollback()
         self._onDBRolledBack()
+
+    @contextmanager
+    def dbSavepoint(self, cursor, name: str):
+        assert self._db_lock_held()
+        # Releasing an outermost savepoint would commit
+        if not self._db_con.in_transaction:
+            cursor.execute("BEGIN")
+        cursor.execute(f"SAVEPOINT {name}")
+        try:
+            yield
+        except BaseException:
+            cursor.execute(f"ROLLBACK TO SAVEPOINT {name}")
+            cursor.execute(f"RELEASE SAVEPOINT {name}")
+            raise
+        cursor.execute(f"RELEASE SAVEPOINT {name}")
 
     def _onDBCommitted(self) -> None:
         pass

--- a/basicswap/interface/btc/btc.py
+++ b/basicswap/interface/btc/btc.py
@@ -1431,8 +1431,10 @@ class BTCInterface(FeeValidator, Secp256k1Interface):
         tx.vout.append(self.txoType()(value, self.getScriptDest(script)))
         return tx.serialize()
 
-    def fundSCLockTx(self, tx_bytes, feerate, vkbv=None, bid_id: bytes = None) -> bytes:
-        funded_tx = self.fundTx(tx_bytes, feerate, bid_id=bid_id)
+    def fundSCLockTx(
+        self, tx_bytes, feerate, vkbv=None, bid_id: bytes = None, cursor=None
+    ) -> bytes:
+        funded_tx = self.fundTx(tx_bytes, feerate, bid_id=bid_id, cursor=cursor)
 
         if self._disable_lock_tx_rbf:
             tx = self.loadTx(funded_tx)
@@ -2160,10 +2162,16 @@ class BTCInterface(FeeValidator, Secp256k1Interface):
         lock_unspents: bool = True,
         subfee: bool = False,
         bid_id: bytes = None,
+        cursor=None,
     ) -> bytes:
         if self.useBackend():
             return self._fundTxElectrum(
-                tx, feerate, lock_unspents=lock_unspents, subfee=subfee, bid_id=bid_id
+                tx,
+                feerate,
+                lock_unspents=lock_unspents,
+                subfee=subfee,
+                bid_id=bid_id,
+                cursor=cursor,
             )
 
         feerate_str = self.format_amount(feerate)
@@ -2189,6 +2197,7 @@ class BTCInterface(FeeValidator, Secp256k1Interface):
         lock_unspents: bool = True,
         subfee: bool = False,
         bid_id: bytes = None,
+        cursor=None,
     ) -> bytes:
         wm = self.getWalletManager()
         backend = self.getBackend()
@@ -2228,7 +2237,10 @@ class BTCInterface(FeeValidator, Secp256k1Interface):
                     unconfirmed_count += 1
                     continue
                 if wm.isUTXOLocked(
-                    self.coin_type(), utxo.get("txid", ""), utxo.get("vout", 0)
+                    self.coin_type(),
+                    utxo.get("txid", ""),
+                    utxo.get("vout", 0),
+                    cursor=cursor,
                 ):
                     locked_count += 1
                     continue
@@ -2356,7 +2368,10 @@ class BTCInterface(FeeValidator, Secp256k1Interface):
             with self._utxo_reserve_lock:
                 for utxo in selected_utxos:
                     if wm.isUTXOLocked(
-                        self.coin_type(), utxo.get("txid", ""), utxo.get("vout", 0)
+                        self.coin_type(),
+                        utxo.get("txid", ""),
+                        utxo.get("vout", 0),
+                        cursor=cursor,
                     ):
                         raise ValueError(
                             "UTXO reserved by a concurrent operation, retry funding"
@@ -2370,6 +2385,7 @@ class BTCInterface(FeeValidator, Secp256k1Interface):
                         address=utxo.get("address"),
                         bid_id=bid_id,
                         expires_in=lock_expires_in,
+                        cursor=cursor,
                     )
 
         tx_serialized = funded_tx.serialize()

--- a/basicswap/interface/dcr/dcr.py
+++ b/basicswap/interface/dcr/dcr.py
@@ -1130,6 +1130,7 @@ class DCRInterface(FeeValidator, Secp256k1Interface):
         lock_unspents: bool = True,
         subfee: bool = False,
         bid_id: bytes = None,
+        cursor=None,
     ) -> bytes:
         if subfee:
             # dcrwallet's fundrawtransaction has no subtractFeeFromOutputs option,
@@ -1213,8 +1214,10 @@ class DCRInterface(FeeValidator, Secp256k1Interface):
         tx.vout.append(self.txoType()(value, self.getScriptDest(script)))
         return tx.serialize()
 
-    def fundSCLockTx(self, tx_bytes, feerate, vkbv=None, bid_id: bytes = None):
-        return self.fundTx(tx_bytes, feerate)
+    def fundSCLockTx(
+        self, tx_bytes, feerate, vkbv=None, bid_id: bytes = None, cursor=None
+    ):
+        return self.fundTx(tx_bytes, feerate, bid_id=bid_id, cursor=cursor)
 
     def genScriptLockRefundTxScript(self, Kal, Kaf, csv_val) -> bytes:
         ensure(len(Kal) == 33, "invalid Kal length")

--- a/basicswap/interface/firo/firo.py
+++ b/basicswap/interface/firo/firo.py
@@ -338,8 +338,10 @@ class FIROInterface(BTCInterface):
 
         return tx.serialize()
 
-    def fundSCLockTx(self, tx_bytes, feerate, vkbv=None, bid_id: bytes = None):
-        return self.fundTx(tx_bytes, feerate)
+    def fundSCLockTx(
+        self, tx_bytes, feerate, vkbv=None, bid_id: bytes = None, cursor=None
+    ):
+        return self.fundTx(tx_bytes, feerate, bid_id=bid_id, cursor=cursor)
 
     def signTxWithWallet(self, tx):
         rv = self.rpc("signrawtransaction", [tx.hex()])

--- a/basicswap/interface/nav/nav.py
+++ b/basicswap/interface/nav/nav.py
@@ -793,6 +793,7 @@ class NAVInterface(BTCInterface):
         lock_unspents: bool = True,
         subfee: bool = False,
         bid_id: bytes = None,
+        cursor=None,
     ):
         feerate_str = self.format_amount(feerate)
         # TODO: unlock unspents if bid cancelled
@@ -815,9 +816,9 @@ class NAVInterface(BTCInterface):
         return tx_signed.serialize_without_witness()
 
     def fundSCLockTx(
-        self, tx_bytes: bytes, feerate, vkbv=None, bid_id: bytes = None
+        self, tx_bytes: bytes, feerate, vkbv=None, bid_id: bytes = None, cursor=None
     ) -> bytes:
-        tx_funded = self.fundTx(tx_bytes.hex(), feerate)
+        tx_funded = self.fundTx(tx_bytes.hex(), feerate, bid_id=bid_id, cursor=cursor)
         return tx_funded
 
     def createSCLockRefundTx(

--- a/basicswap/interface/part/part.py
+++ b/basicswap/interface/part/part.py
@@ -359,7 +359,12 @@ class PARTInterfaceBlind(PARTInterface):
         return bytes.fromhex(rv["hex"])
 
     def fundSCLockTx(
-        self, tx_bytes: bytes, feerate: int, vkbv: bytes, bid_id: bytes = None
+        self,
+        tx_bytes: bytes,
+        feerate: int,
+        vkbv: bytes,
+        bid_id: bytes = None,
+        cursor=None,
     ) -> bytes:
         feerate_str = self.format_amount(feerate)
         # TODO: unlock unspents if bid cancelled

--- a/basicswap/network/bsx_network.py
+++ b/basicswap/network/bsx_network.py
@@ -742,6 +742,7 @@ class BSXNetwork:
         if return_msg:
             options["returnmsg"] = True
 
+        ro = None
         try:
             ro = self.callrpc(
                 "smsgsend",
@@ -751,9 +752,14 @@ class BSXNetwork:
             if return_msg:
                 return bytes.fromhex(ro["msgid"]), bytes.fromhex(ro["msg"])
             return bytes.fromhex(ro["msgid"])
-        except Exception as e:  # noqa: F841
+        except Exception as e:
             if self.debug:
-                self.log.error("smsgsend failed {}".format(json.dumps(ro, indent=4)))
+                if ro is None:
+                    self.log.error(f"smsgsend failed {e}")
+                else:
+                    self.log.error(
+                        f"smsgsend failed {e}, response {json.dumps(ro, indent=4)}"
+                    )
             raise
 
     def forwardSmsg(self, smsg_msg: bytes) -> None:

--- a/tests/basicswap/test_other.py
+++ b/tests/basicswap/test_other.py
@@ -1535,6 +1535,35 @@ class Test(unittest.TestCase):
         finally:
             db_test.closeDB(cursor)
 
+    def test_db_savepoint(self):
+        db_test = DBMethods()
+        db_test.sqlite_file = ":memory:"
+        db_test.mxDB = threading.RLock()
+        cursor = db_test.openDB()
+        try:
+            cursor.execute("CREATE TABLE sp_test (v INTEGER)")
+            cursor.execute("INSERT INTO sp_test VALUES (1)")
+            try:
+                with db_test.dbSavepoint(cursor, "sp"):
+                    cursor.execute("INSERT INTO sp_test VALUES (2)")
+                    raise ValueError("Roll back")
+            except ValueError:
+                pass
+            assert db_test._db_con.in_transaction
+            cursor.execute("INSERT INTO sp_test VALUES (3)")
+            db_test.commitDB()
+
+            # Release must not commit
+            with db_test.dbSavepoint(cursor, "sp"):
+                cursor.execute("INSERT INTO sp_test VALUES (4)")
+            assert db_test._db_con.in_transaction
+            db_test.rollbackDB()
+
+            rows = [r[0] for r in cursor.execute("SELECT v FROM sp_test ORDER BY v")]
+            assert rows == [1, 3]
+        finally:
+            db_test.closeDB(cursor)
+
     def test_tx_hashes(self):
         tx = CTransaction()
         tx.nVersion = 2


### PR DESCRIPTION
the first commit fixes an issue that only affects debug builds. The log is intended to capture the smsg details, but if it error (such as a timeouto the empty variable is raised, causing the swap to go into error. What we do here, is recognize and raise the actual error, so something such as a timeout isnt fatal.

the second commit is related. If there is a fatal error, the swap aborts, but the coins arent unlocked. with the change to raising error, a transient error would cause the funds to be re-locked (a regression). This commit ensures that the funds are unlocked 