### PR TITLE
wallet: balance reporting fixes

### DIFF
--- a/basicswap/interface/xmr/xmr.py
+++ b/basicswap/interface/xmr/xmr.py
@@ -386,6 +386,8 @@ class XMRInterface(CoinInterface):
             except Exception as e:
                 if "Failed to open wallet" in str(e):
                     rv = {
+                        "no_data": True,
+                        "name": self.coin_name(),
                         "encrypted": True,
                         "locked": True,
                         "balance": 0,

--- a/basicswap/js_server.py
+++ b/basicswap/js_server.py
@@ -147,10 +147,13 @@ def js_walletbalances(self, url_split, post_string, is_json) -> bytes:
 
                 have_data = False
                 updating = False
+                # only some coins withhold their balance while locked.
+                locked = False
                 if k in wallets:
                     w = wallets[k]
                     have_data = "error" not in w and "no_data" not in w
                     updating = bool(w.get("updating", False))
+                    locked = bool(w.get("locked", False))
 
                 balance = "0.0"
                 if k in wallets:
@@ -186,6 +189,7 @@ def js_walletbalances(self, url_split, post_string, is_json) -> bytes:
                     "connection_type": v["connection_type"],
                     "have_data": have_data,
                     "updating": updating,
+                    "locked": locked,
                 }
 
                 ci = swap_client.ci(k)

--- a/basicswap/js_server.py
+++ b/basicswap/js_server.py
@@ -145,6 +145,13 @@ def js_walletbalances(self, url_split, post_string, is_json) -> bytes:
                 continue
             if v["connection_type"] in ("rpc", "electrum"):
 
+                have_data = False
+                updating = False
+                if k in wallets:
+                    w = wallets[k]
+                    have_data = "error" not in w and "no_data" not in w
+                    updating = bool(w.get("updating", False))
+
                 balance = "0.0"
                 if k in wallets:
                     w = wallets[k]
@@ -177,6 +184,8 @@ def js_walletbalances(self, url_split, post_string, is_json) -> bytes:
                     "pending": pending,
                     "ticker": chainparams[k]["ticker"],
                     "connection_type": v["connection_type"],
+                    "have_data": have_data,
+                    "updating": updating,
                 }
 
                 ci = swap_client.ci(k)

--- a/basicswap/static/js/pages/wallet-page.js
+++ b/basicswap/static/js/pages/wallet-page.js
@@ -351,6 +351,10 @@
       );
 
       matchingCoins.forEach(coinData => {
+        if (coinData.have_data === false || coinData.updating === true) {
+          return;
+        }
+
         const balanceElements = document.querySelectorAll('.coinname-value[data-coinname][data-balance-type]');
         balanceElements.forEach(element => {
           const elementCoinName = element.getAttribute('data-coinname');
@@ -377,21 +381,17 @@
     updatePendingForCoin: function(coinData) {
       const pendingAmount = parseFloat(coinData.pending || '0');
 
+      const badge = document.querySelector(
+        `[data-badge-type="pending"][data-coinname="${coinData.name}"]`
+      );
+      if (!badge) return;
 
-      const pendingElements = document.querySelectorAll('.inline-block.py-1.px-2.rounded-full.bg-green-100');
-
-      pendingElements.forEach(el => {
-        const text = el.textContent || '';
-
-        if (text.includes('Pending:') && text.includes(coinData.ticker)) {
-          if (pendingAmount > 0) {
-            el.textContent = `Pending: +${coinData.pending} ${coinData.ticker}`;
-            el.style.display = '';
-          } else {
-            el.style.display = 'none';
-          }
-        }
-      });
+      if (pendingAmount > 0) {
+        badge.textContent = `Pending: +${coinData.pending} ${coinData.ticker}`;
+        badge.style.display = '';
+      } else {
+        badge.style.display = 'none';
+      }
     },
 
     refreshTransactions: function() {

--- a/basicswap/templates/wallet.html
+++ b/basicswap/templates/wallet.html
@@ -141,7 +141,7 @@
                             <span class="coinname-value" data-coinname="{{ w.name }}" data-balance-type="balance">{{ w.balance }} {{ w.ticker }}</span>
                             (<span class="usd-value"></span>)
                             {% if w.pending %}
-                              <span class="inline-block py-1 px-2 rounded-full bg-green-100 text-green-500 dark:bg-gray-500 dark:text-green-500">Pending: +{{ w.pending }} {{ w.ticker }} </span>
+                              <span class="inline-block py-1 px-2 rounded-full bg-green-100 text-green-500 dark:bg-gray-500 dark:text-green-500" data-coinname="{{ w.name }}" data-badge-type="pending">Pending: +{{ w.pending }} {{ w.ticker }} </span>
                             {% endif %}
                             {% if w.pending_out %}
                               <span class="inline-block py-1 px-2 rounded-full bg-yellow-100 text-yellow-600 dark:bg-gray-500 dark:text-yellow-400">Unconfirmed: -{{ w.pending_out }} {{ w.ticker }} </span>


### PR DESCRIPTION
2 semi-related fixes here, both included because 2 builds on top of 1

1.  As reported in #686 it can appear that the pending/unconfirmed balances are not being reported (they are, but are overwritten by 0 by the websocket). This doesnt fix the issue entirely (slow to display), but it does fix them from disappearing or being clobbered by multiple coin types having pending balances (mweb + plain)
2. At startup on a locked wallet, the api checks coin balances. non-xmr-like coins are still readable, but xmr is not. Basicswap reports a 0 balance, which, for api consumers, appears as the entire balance being drained. when unlocked, it will then report and incoming balance change for the full amount. This commit fixes it so that an xmr wallet doesnt report balance changes on a wallet it cant read.